### PR TITLE
#4 feat: 소프트 삭제 구현

### DIFF
--- a/src/db/prisma/migrations/20250704101610_add_soft_delete/migration.sql
+++ b/src/db/prisma/migrations/20250704101610_add_soft_delete/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "actions" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "designated_quote_requests" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "moving_requests" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "notifications" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "profiles" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "quotes" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "reviews" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   accessToken                String?
   refreshToken               String?
   tokenExpiresAt             DateTime?
+  deletedAt                  DateTime?
   createdAt                  DateTime                 @default(now())
   updatedAt                  DateTime                 @updatedAt
   actions                    Action[]
@@ -60,6 +61,7 @@ model Profile {
   experience     Int
   introduction   String
   description    String
+  deletedAt      DateTime?
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
   serviceRegions ProfileRegion[]
@@ -137,6 +139,7 @@ model MovingRequest {
   estimatedDistance       Float?
   floor                   Int?
   hasElevator             Boolean?
+  deletedAt               DateTime?
   createdAt               DateTime                 @default(now())
   updatedAt               DateTime                 @updatedAt
   designatedQuoteRequests DesignatedQuoteRequest[]
@@ -163,6 +166,7 @@ model DesignatedQuoteRequest {
   message    String?
   status     DesignatedQuoteRequestStatus @default(PENDING)
   expiresAt  DateTime
+  deletedAt  DateTime?
   createdAt  DateTime                     @default(now())
   updatedAt  DateTime                     @updatedAt
   customer   User                         @relation("CustomerDesignatedRequests", fields: [customerId], references: [id], onDelete: Cascade)
@@ -187,6 +191,7 @@ model Quote {
   isDesignated             Boolean                 @default(false)
   designatedQuoteRequestId Int?                    @unique
   validUntil               DateTime?
+  deletedAt                DateTime?
   createdAt                DateTime                @default(now())
   updatedAt                DateTime                @updatedAt
   confirmedRequest         MovingRequest?          @relation("ConfirmedQuote")
@@ -210,6 +215,7 @@ model Action {
   entityType    String
   description   String?
   metadata      Json?
+  deletedAt     DateTime?
   createdAt     DateTime       @default(now())
   user          User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   notifications Notification[]
@@ -230,6 +236,7 @@ model Notification {
   content   String
   isRead    Boolean          @default(false)
   actionUrl String?
+  deletedAt DateTime?
   createdAt DateTime         @default(now())
   action    Action           @relation(fields: [actionId], references: [id], onDelete: Cascade)
   user      User             @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -250,6 +257,7 @@ model Review {
   content   String
   status    ReviewStatus  @default(PENDING)
   isPublic  Boolean       @default(true)
+  deletedAt DateTime?
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
   mover     User          @relation("MoverReviews", fields: [moverId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## ✨ 작업 개요

무빙 서비스의 핵심 비즈니스 데이터 보호를 위한 소프트 삭제(Soft Delete) 기능을 구현했습니다. 사용자 탈퇴, 견적 요청 취소, 리뷰 숨김 등의 상황에서 데이터를 물리적으로 삭제하지 않고 `deletedAt` 타임스탬프로 논리적 삭제 처리하여 데이터 복구와 감사 추적이 가능하도록 개선했습니다.

## ✅ 주요 작업 내용

### 📊 데이터베이스 스키마 개선
- **8개 핵심 모델에 `deletedAt` 필드 추가**
  - `User` - 사용자 탈퇴 시 과거 견적/리뷰 기록 보존
  - `Profile` - 기사님 프로필 복구 가능성 제공
  - `MovingRequest` - 취소된 견적 요청의 이력 관리
  - `Quote` - 기사님 견적 히스토리 보존
  - `Review` - 부적절한 리뷰 숨김 처리
  - `DesignatedQuoteRequest` - 지정 견적 요청 이력
  - `Action` - 이벤트 로그 관리
  - `Notification` - 알림 데이터 정리

### 🛡️ 비즈니스 로직 보호
- **참조 무결성 유지**: 탈퇴한 기사님의 과거 견적 기록 보존
- **데이터 복구 지원**: 실수로 삭제된 데이터 복구 가능성
- **감사 추적**: 삭제된 데이터의 이력 관리 및 추적

### 🔧 기술적 구현
- **Prisma 스키마 업데이트**: `deletedAt DateTime?` 필드 추가
- **마이그레이션 생성**: `20250704101610_add_soft_delete.sql`
- **NULL 허용**: 활성 데이터는 `deletedAt = null`, 삭제된 데이터는 타임스탬프

## 🔄 관련 이슈

Closes #4

## 📎 참고 자료 (선택)

- **Prisma 공식 문서**: [Soft Delete Pattern](https://www.prisma.io/docs/concepts/components/prisma-client/middleware/soft-delete-middleware)
- **ERD 설계**: https://www.notion.so/ERD-2245da6dc98c801eaa3ac4db04fb42fd

## 🧪 테스트 방법 (선택)

### 🔍 마이그레이션 확인
- [x] `npx prisma migrate status` - 마이그레이션 상태 확인
- [x] DBeaver로 데이터 필드 변경 이력 확인
- [x] 모든 핵심 모델에 `deletedAt` 필드 추가 확인

## 📊 구현된 스키마 구조

```prisma
// 예시: User 모델
model User {
  id                    Int       @id @default(autoincrement())
  email                 String    @unique
  encryptedPassword     String?
  encryptedPhoneNumber  String?
  userType              UserType
  isActive              Boolean   @default(false)
  
  deletedAt             DateTime? // 🆕 소프트 삭제 필드
  
  createdAt             DateTime  @default(now())
  updatedAt             DateTime  @updatedAt
  
  // ... 관계 필드들
  @@map("users")
}
```
## 📝 비고

- **마이그레이션 안전성**: 기존 데이터에 영향 없이 새 필드만 추가
- **하위 호환성**: 기존 코드는 그대로 동작하며, 점진적으로 소프트 삭제 로직 적용 예정
- **성능 고려**: 조회 성능을 위해 `deletedAt` 필드에 인덱스 추가 검토 필요
- **커밋 메시지 수정**: 이슈 번호 연결을 위해 커밋 메시지를 `#4 feat: 소프트 삭제 구현`으로 수정