### PR TITLE
[#6]feat:사용자 다중 역할 시스템 구현

### DIFF
--- a/src/db/prisma/migrations/20250707014616_update_user_schema/migration.sql
+++ b/src/db/prisma/migrations/20250707014616_update_user_schema/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isActive` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `userType` on the `users` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "users_isActive_idx";
+
+-- DropIndex
+DROP INDEX "users_userType_idx";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "isActive",
+DROP COLUMN "userType",
+ADD COLUMN     "currentRole" "UserType" NOT NULL DEFAULT 'CUSTOMER',
+ADD COLUMN     "hasProfile" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "user_roles" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "role" "UserType" NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_roles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_roles_userId_idx" ON "user_roles"("userId");
+
+-- CreateIndex
+CREATE INDEX "user_roles_role_idx" ON "user_roles"("role");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_roles_userId_role_key" ON "user_roles"("userId", "role");
+
+-- CreateIndex
+CREATE INDEX "users_currentRole_idx" ON "users"("currentRole");
+
+-- CreateIndex
+CREATE INDEX "users_hasProfile_idx" ON "users"("hasProfile");
+
+-- AddForeignKey
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -12,8 +12,8 @@ model User {
   email                      String                   @unique
   encryptedPassword          String?
   encryptedPhoneNumber       String?
-  userType                   UserType
-  isActive                   Boolean                  @default(false)
+  currentRole                UserType                 @default(CUSTOMER)
+  hasProfile                 Boolean                  @default(false)
   lastLoginAt                DateTime?
   accessToken                String?
   refreshToken               String?
@@ -33,10 +33,11 @@ model User {
   receivedReviews            Review[]                 @relation("MoverReviews")
   reviews                    Review[]
   socialAccounts             SocialAccount[]
+  userRoles                  UserRole[]
 
   @@index([email])
-  @@index([userType])
-  @@index([isActive])
+  @@index([currentRole])
+  @@index([hasProfile])
   @@map("users")
 }
 
@@ -284,6 +285,20 @@ model Favorite {
   @@index([userId])
   @@index([moverId])
   @@map("favorites")
+}
+
+model UserRole {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  role      UserType
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, role])
+  @@index([userId])
+  @@index([role])
+  @@map("user_roles")
 }
 
 enum UserType {

--- a/src/db/prisma/seed.ts
+++ b/src/db/prisma/seed.ts
@@ -94,9 +94,15 @@ async function main() {
         email: "customer1@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-1234-5678"),
-        userType: UserType.CUSTOMER,
-        isActive: true,
+        currentRole: UserType.CUSTOMER,
+        hasProfile: false,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.CUSTOMER,
+            isActive: true,
+          },
+        },
       },
     }),
     prisma.user.create({
@@ -104,9 +110,15 @@ async function main() {
         email: "customer2@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-2345-6789"),
-        userType: UserType.CUSTOMER,
-        isActive: true,
+        currentRole: UserType.CUSTOMER,
+        hasProfile: false,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.CUSTOMER,
+            isActive: true,
+          },
+        },
       },
     }),
     prisma.user.create({
@@ -114,9 +126,15 @@ async function main() {
         email: "customer3@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-3456-7890"),
-        userType: UserType.CUSTOMER,
-        isActive: true,
+        currentRole: UserType.CUSTOMER,
+        hasProfile: false,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.CUSTOMER,
+            isActive: true,
+          },
+        },
       },
     }),
   ]);
@@ -129,9 +147,15 @@ async function main() {
         email: "mover1@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-4567-8901"),
-        userType: UserType.MOVER,
-        isActive: true,
+        currentRole: UserType.MOVER,
+        hasProfile: true,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.MOVER,
+            isActive: true,
+          },
+        },
       },
     }),
     prisma.user.create({
@@ -139,9 +163,15 @@ async function main() {
         email: "mover2@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-5678-9012"),
-        userType: UserType.MOVER,
-        isActive: true,
+        currentRole: UserType.MOVER,
+        hasProfile: true,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.MOVER,
+            isActive: true,
+          },
+        },
       },
     }),
     prisma.user.create({
@@ -149,9 +179,15 @@ async function main() {
         email: "mover3@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-6789-0123"),
-        userType: UserType.MOVER,
-        isActive: true,
+        currentRole: UserType.MOVER,
+        hasProfile: true,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.MOVER,
+            isActive: true,
+          },
+        },
       },
     }),
     prisma.user.create({
@@ -159,9 +195,15 @@ async function main() {
         email: "mover4@example.com",
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-7890-1234"),
-        userType: UserType.MOVER,
-        isActive: true,
+        currentRole: UserType.MOVER,
+        hasProfile: true,
         lastLoginAt: new Date(),
+        userRoles: {
+          create: {
+            role: UserType.MOVER,
+            isActive: true,
+          },
+        },
       },
     }),
   ]);


### PR DESCRIPTION
## ✨ 작업 개요

사용자 다중 역할 시스템을 구현하여 한 사용자가 고객과 기사님 역할을 모두 가질 수 있도록 Prisma 스키마를 개선했습니다. 이메일 유니크 제약을 유지하면서도 역할별 분리 로그인을 지원하는 구조로 설계했습니다.

## ✅ 주요 작업 내용

- UserRole 테이블 추가: 다중 역할 지원을 위한 별도 테이블 생성
- User 스키마 리팩토링:
   - userType → currentRole (현재 활성 역할)
   - isActive → hasProfile (프로필 보유 여부 명확화)
- 소프트 삭제 기능 유지: 주요 엔티티에 deletedAt 필드 보존
- 시드 데이터 업데이트: 새로운 스키마 구조에 맞춰 시드 코드 수정
- 데이터베이스 인덱스 최적화: 성능을 위한 적절한 인덱스 설정

## 🔄 관련 이슈

Closes #6

## 📎 참고 자료 (선택)

- 스키마 변경 내용
```  // 새로 추가된 UserRole 테이블
  model UserRole {
    userId Int
    role UserType
    isActive Boolean @default(true)
    @@unique([userId, role])
  }
  
  // 수정된 User 모델
  model User {
    currentRole UserType @default(CUSTOMER)
    hasProfile Boolean @default(false)
    userRoles UserRole[]
  }
```

## 🧪 테스트 방법 (선택)

- [ ] 이전 DB 시드 데이터 삭제 후 시드 넣기 
- ![image](https://github.com/user-attachments/assets/e5506a8d-c739-43ba-b99a-76ec7d7c8976)

- `DBeaver` 에서 데이터 들어간 것은 확인했지만 EC2 접속 불가로 `prisma studio`로 데이터가 들어가 있는 상태는 확인 불가능한 상태임

## 📝 비고
