### PR TITLE
[#15]feat:기사님 회원가입 플로우 개선

### DIFF
--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 model User {
   id                   Int      @id @default(autoincrement())
   email                String   @unique
-  name                 String? // 일반 유저 실명 (기사님은 Profile의 nickname 사용)
+  name                 String? // 실명 (일반 유저 및 기사님 모두 사용)
   encryptedPassword    String?
   encryptedPhoneNumber String?
   currentRole          UserType @default(CUSTOMER)
@@ -81,7 +81,7 @@ model SocialAccount {
 model Profile {
   id           Int     @id @default(autoincrement())
   userId       Int     @unique
-  nickname     String  @unique
+  nickname     String  @unique // 기사님 별명 (프로필에서 표시되는 이름)
   profileImage String?
   experience   Int
   introduction String

--- a/src/db/prisma/seed.ts
+++ b/src/db/prisma/seed.ts
@@ -109,6 +109,7 @@ async function main() {
     prisma.user.create({
       data: {
         email: "mover1@example.com",
+        name: "김민수", // 기사님 실명
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-4567-8901"),
         currentRole: UserType.MOVER,
@@ -125,6 +126,7 @@ async function main() {
     prisma.user.create({
       data: {
         email: "mover2@example.com",
+        name: "박성호", // 기사님 실명
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-5678-9012"),
         currentRole: UserType.MOVER,
@@ -141,6 +143,7 @@ async function main() {
     prisma.user.create({
       data: {
         email: "mover3@example.com",
+        name: "이준혁", // 기사님 실명
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-6789-0123"),
         currentRole: UserType.MOVER,
@@ -157,6 +160,7 @@ async function main() {
     prisma.user.create({
       data: {
         email: "mover4@example.com",
+        name: "최동철", // 기사님 실명
         encryptedPassword: await bcrypt.hash("password123", 10),
         encryptedPhoneNumber: encryptPhoneNumber("010-7890-1234"),
         currentRole: UserType.MOVER,


### PR DESCRIPTION
## ✨ 작업 개요

- 기획 변경에 따른 기사님 회원가입/프로필 시스템 개선
- 실명과 별명을 분리하여 관리하는 구조로 스키마 및 시드 데이터 수정

## ✅ 주요 작업 내용

- 스키마 수정: User.name을 실명(일반유저+기사님), Profile.nickname을 별명으로 명확화
- 시드 데이터 개선: 기사님 4명에게 실명 필드 추가 (김민수, 박성호, 이준혁, 최동철)
- 주석 개선: 각 필드의 용도를 명확히 하여 개발자 이해도 향상
- 데이터베이스 초기화: 새로운 구조에 맞게 전체 시드 데이터 재적용

## 변경된 파일
`src/db/prisma/schema.prisma`
```
-- User 모델
- name String? // 일반 유저 실명 (기사님은 Profile의 nickname 사용)  
+ name String? // 실명 (일반 유저 및 기사님 모두 사용)

-- Profile 모델
- nickname String @unique
+ nickname String @unique // 기사님 별명 (프로필에서 표시되는 이름)
```


## 🔄 관련 이슈

Closes #15

## 📎 참고 자료 (선택)

- 기획 요구사항: 기사님 회원가입 시 실명 수집, 프로필에서 별명 표시

## 🧪 테스트 방법 (선택)


## 📝 비고

- 
