### PR TITLE
[#19]fix: name 및 nickname 제약 조건 위반 수정

### DIFF
--- a/src/db/prisma/migrations/20250709004253_user_name/migration.sql
+++ b/src/db/prisma/migrations/20250709004253_user_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `name` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "name" SET NOT NULL;

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 model User {
   id                   Int      @id @default(autoincrement())
   email                String   @unique
-  name                 String? // 일반 유저 실명 (기사님은 Profile의 nickname 사용)
+  name                 String // 유저의 실명 (모든 사용자 필수)
   encryptedPassword    String?
   encryptedPhoneNumber String?
   currentRole          UserType @default(CUSTOMER)
@@ -81,7 +81,7 @@ model SocialAccount {
 model Profile {
   id           Int     @id @default(autoincrement())
   userId       Int     @unique
-  nickname     String  @unique
+  nickname     String  @unique // 기사님 닉네임 (필수, 자동 생성)
   profileImage String?
   experience   Int
   introduction String


### PR DESCRIPTION
## ✨ 작업 개요

- 스키마 시나리오 상 기사님 프로필 생성 시 닉네임 자동 생성할 수 있게 변경

## ✅ 주요 작업 내용

- `User.name`: 유니크 삭제, 옵셔널 삭제 모든 사용자 필수 필드
- `Profile.nickname`: 기사님 닉네임 필수 필드

## 🔄 관련 이슈

Closes #19

## 📎 참고 자료 (선택)
- 

## 🧪 테스트 방법 (선택)

- 마이그레이션 완료

## 📝 비고

- nickname에 옵셔널을 안넣은 이유는 기획상 필수 필드
- 스크럼 때 정한 시나리오처럼 닉네임을 적지 않고 싶을 때는 백엔드 로직으로 자동으로 닉네임이 생성되는 로직이 필요함
