### PR TITLE
[#27] feat: 기사님 리스트 조회(필터, 정렬, 검색)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,8 @@ import dotenv from "dotenv";
 import { errorHandler, notFoundHandler } from "./middlewares/errorMiddleware";
 import { setupAutoSwagger } from "./utils/swagger-auto";
 import authRouter from "./routes/auth.route";
+import moverRouter from "./routes/mover.routes";
+
 
 // 환경변수 로드
 dotenv.config();
@@ -37,6 +39,7 @@ setupAutoSwagger(app);
 
 // API 라우트 연결
 // app.use('/api/users', userRoutes);
+app.use("/movers", moverRouter); // TODO: 추후 authMiddleware 추가
 app.use("/auth", authRouter);
 
 // 404 에러 핸들링

--- a/src/controllers/mover.controller.ts
+++ b/src/controllers/mover.controller.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from "express";
+import {
+  fetchMoverList,
+  fetchBookmarkedMovers,
+} from "../services/mover.service";
+import { IMoverListFilter } from "../types/mover.types";
+
+/**
+ * 기사님 리스트 조회 (필터, 정렬, 키워드)
+ */
+export const getMoverListController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const { region, serviceTypeId, search, sort, cursor, take } = req.query;
+
+    const filter: IMoverListFilter = {
+      region: region as any,
+      serviceTypeId: serviceTypeId ? Number(serviceTypeId) : undefined,
+      search: search as string,
+      sort: sort as any,
+      cursor: cursor ? Number(cursor) : undefined,
+      take: take ? Number(take) : undefined,
+    };
+
+    const movers = await fetchMoverList(filter);
+    res.json({ success: true, data: movers });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 찜한 기사님 조회
+ */
+export const getBookmarkedMoversController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    // TODO: 실제 인증된 사용자 ID를 가져오는 로직으로 변경 필요
+    const userId = 1;
+
+    const bookmarkedMovers = await fetchBookmarkedMovers(userId);
+    res.json({ success: true, data: bookmarkedMovers });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/repositories/mover.repository.ts
+++ b/src/repositories/mover.repository.ts
@@ -1,0 +1,112 @@
+import { PrismaClient } from "@prisma/client";
+import { IMoverListFilter, TOrderByType } from "../types/mover.types";
+const prisma = new PrismaClient();
+
+/**
+ * 정렬 조건 생성 함수
+ */
+const getOrderBy = (sort: string): TOrderByType => {
+  switch (sort) {
+    case "rating":
+      return { avgRating: "desc" };
+    case "career":
+      return { experience: "desc" };
+    case "confirmed":
+      return { completedCount: "desc" };
+    default:
+      return { reviewCount: "desc" };
+  }
+};
+
+/**
+ * 기사님 리스트 조회 (필터, 정렬, 키워드)
+ */
+export const getMoverList = async (filter: IMoverListFilter) => {
+  const {
+    region,
+    serviceTypeId,
+    search,
+    sort = "review",
+    cursor,
+    take = 20,
+  } = filter;
+
+  // 필터, 검색
+  const where: any = {
+    deletedAt: null,
+    user: {
+      currentRole: "MOVER",
+      hasProfile: true,
+      deletedAt: null,
+    },
+    ...(search && { nickname: { contains: search } }),
+    ...(region && {
+      serviceRegions: {
+        some: { region },
+      },
+    }),
+    ...(serviceTypeId && {
+      serviceTypes: {
+        some: { serviceId: serviceTypeId },
+      },
+    }),
+  };
+
+  // 정렬
+  const orderBy = getOrderBy(sort);
+
+  return prisma.profile.findMany({
+    where,
+    orderBy,
+    skip: cursor ? 1 : 0,
+    ...(cursor && { cursor: { id: cursor } }),
+    take,
+    include: {
+      user: {
+        select: { id: true, name: true, email: true },
+      },
+      serviceRegions: true,
+      serviceTypes: { include: { service: true } },
+    },
+  });
+};
+
+/**
+ * 찜한 기사님 조회
+ */
+export const getBookmarkedMovers = async (userId: number) => {
+  const favorites = await prisma.favorite.findMany({
+    where: {
+      userId: userId,
+      mover: {
+        currentRole: "MOVER",
+        hasProfile: true,
+        deletedAt: null,
+        profile: {
+          deletedAt: null,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc", // 유저가 찜한 시간을 기준으로 최신순 조회
+    },
+    take: 3,
+    include: {
+      mover: {
+        include: {
+          profile: {
+            include: {
+              user: {
+                select: { id: true, name: true, email: true },
+              },
+              serviceRegions: true,
+              serviceTypes: { include: { service: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return favorites.map((favorite) => favorite.mover.profile);
+};

--- a/src/routes/mover.routes.ts
+++ b/src/routes/mover.routes.ts
@@ -1,0 +1,194 @@
+import { Router } from "express";
+import {
+  getMoverListController,
+  getBookmarkedMoversController,
+} from "../controllers/mover.controller";
+
+const moverRouter = Router();
+
+/**
+ * 기사님 정보
+ * @typedef {object} MoverInfo
+ * @property {number} id - 기사님 프로필 ID
+ * @property {number} userId - 사용자 ID
+ * @property {string} nickname - 기사님 닉네임
+ * @property {string} profileImage - 프로필 이미지 URL
+ * @property {number} experience - 경력 (년)
+ * @property {string} introduction - 소개글
+ * @property {string} description - 상세 설명
+ * @property {number} completedCount - 완료된 이사 건수
+ * @property {number} avgRating - 평균 평점
+ * @property {number} reviewCount - 리뷰 개수
+ * @property {number} favoriteCount - 찜한 사용자 수
+ * @property {string} lastActivityAt - 마지막 활동 시간
+ * @property {object} user - 사용자 정보
+ * @property {number} user.id - 사용자 ID
+ * @property {string} user.name - 사용자 이름
+ * @property {string} user.email - 사용자 이메일
+ * @property {array} serviceRegions - 서비스 지역 목록
+ * @property {array} serviceTypes - 서비스 종류 목록
+ */
+
+/**
+ * 기사님 리스트 응답
+ * @typedef {object} MoverListResponse
+ * @property {boolean} success - 성공 여부
+ * @property {array<MoverInfo>} data - 기사님 목록
+ */
+
+/**
+ * 기사님 리스트 필터
+ * @typedef {object} MoverListFilter
+ * @property {string} region - 지역 필터 (SEOUL, BUSAN, DAEGU, INCHEON, GWANGJU, DAEJEON, ULSAN, SEJONG, GYEONGGI, CHUNGBUK, CHUNGNAM, JEONBUK, JEONNAM, GYEONGBUK, GYEONGNAM, GANGWON, JEJU)
+ * @property {number} serviceTypeId - 서비스 종류 ID (1: 소형이사, 2: 가정이사, 3: 사무실이사)
+ * @property {string} search - 닉네임 검색 키워드
+ * @property {string} sort - 정렬 기준 (review: 리뷰순, rating: 평점순, career: 경력순, confirmed: 확정순)
+ * @property {number} cursor - 무한스크롤 커서 (마지막 기사님 ID)
+ * @property {number} take - 조회할 개수 (기본값: 20, 최대: 50)
+ */
+
+/**
+ * 에러 응답
+ * @typedef {object} ErrorResponse
+ * @property {boolean} success - 성공 여부 (false)
+ * @property {object} error - 에러 정보
+ * @property {string} error.message - 에러 메시지
+ * @property {number} error.status - HTTP 상태 코드
+ */
+
+// 기사님 리스트 조회 엔드포인트
+/**
+ * GET /movers
+ * @summary 기사님 리스트 조회
+ * @description 필터링, 정렬, 검색 기능을 지원하는 기사님 목록을 조회합니다. 무한스크롤을 지원하며 최대 20개씩 반환합니다.
+ * @tags Movers
+ * @param {string} region.query - 지역 필터 (예: SEOUL, BUSAN, GYEONGGI)
+ * @param {number} serviceTypeId.query - 서비스 종류 ID (1: 소형이사, 2: 가정이사, 3: 사무실이사)
+ * @param {string} search.query - 닉네임 검색 키워드
+ * @param {string} sort.query - 정렬 기준 (review: 리뷰순, rating: 평점순, career: 경력순, confirmed: 확정순)
+ * @param {number} cursor.query - 무한스크롤 커서 (마지막 기사님 ID)
+ * @param {number} take.query - 조회할 개수 (기본값: 20, 최대: 50)
+ * @return {MoverListResponse} 200 - 기사님 목록 조회 성공
+ * @return {ErrorResponse} 400 - 잘못된 쿼리 파라미터
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ * @example request - 기본 조회
+ * GET /movers
+ * @example request - 지역 필터 조회
+ * GET /movers?region=SEOUL
+ * @example request - 서비스 필터 조회
+ * GET /movers?serviceTypeId=1
+ * @example request - 닉네임 검색
+ * GET /movers?search=김
+ * @example request - 정렬 (경력순)
+ * GET /movers?sort=career
+ * @example request - 무한스크롤
+ * GET /movers?take=2&cursor=4
+ * @example response - 200 - 성공 응답 예시
+ * {
+ *   "success": true,
+ *   "data": [
+ *     {
+ *       "id": 1,
+ *       "userId": 4,
+ *       "nickname": "믿을만한김기사",
+ *       "profileImage": "https://s3.amazonaws.com/profiles/profile1.jpg",
+ *       "experience": 5,
+ *       "introduction": "5년 경력의 꼼꼼한 이사 전문가입니다",
+ *       "description": "안전하고 신속한 이사를 약속드립니다.",
+ *       "completedCount": 136,
+ *       "avgRating": 5.0,
+ *       "reviewCount": 128,
+ *       "favoriteCount": 45,
+ *       "lastActivityAt": "2025-07-10T00:33:16.456Z",
+ *       "user": {
+ *         "id": 4,
+ *         "name": "김민수",
+ *         "email": "mover1@example.com"
+ *       },
+ *       "serviceRegions": [
+ *         {
+ *           "id": 1,
+ *           "profileId": 1,
+ *           "region": "SEOUL"
+ *         }
+ *       ],
+ *       "serviceTypes": [
+ *         {
+ *           "id": 1,
+ *           "profileId": 1,
+ *           "serviceId": 1,
+ *           "service": {
+ *             "id": 1,
+ *             "name": "소형이사",
+ *             "description": "원룸, 투룸 등 소규모 이사",
+ *             "isActive": true,
+ *             "iconUrl": "https://s3.amazonaws.com/moving-icons/small-moving.svg"
+ *           }
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
+moverRouter.get("/", getMoverListController);
+
+// 찜한 기사님 조회 엔드포인트
+/**
+ * GET /movers/bookmarked
+ * @summary 찜한 기사님 조회
+ * @description 현재 사용자가 찜한 기사님 목록을 조회합니다. 최근 활동 순으로 정렬됩니다.
+ * @tags Movers
+ * @return {MoverListResponse} 200 - 찜한 기사님 목록 조회 성공
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ * @example request - 찜한 기사님 조회
+ * GET /movers/bookmarked
+ * @example response - 200 - 성공 응답 예시
+ * {
+ *   "success": true,
+ *   "data": [
+ *     {
+ *       "id": 1,
+ *       "userId": 4,
+ *       "nickname": "믿을만한김기사",
+ *       "profileImage": "https://s3.amazonaws.com/profiles/profile1.jpg",
+ *       "experience": 5,
+ *       "introduction": "5년 경력의 꼼꼼한 이사 전문가입니다",
+ *       "description": "안전하고 신속한 이사를 약속드립니다.",
+ *       "completedCount": 136,
+ *       "avgRating": 5.0,
+ *       "reviewCount": 128,
+ *       "favoriteCount": 45,
+ *       "lastActivityAt": "2025-07-10T00:33:16.456Z",
+ *       "user": {
+ *         "id": 4,
+ *         "name": "김민수",
+ *         "email": "mover1@example.com"
+ *       },
+ *       "serviceRegions": [
+ *         {
+ *           "id": 1,
+ *           "profileId": 1,
+ *           "region": "SEOUL"
+ *         }
+ *       ],
+ *       "serviceTypes": [
+ *         {
+ *           "id": 1,
+ *           "profileId": 1,
+ *           "serviceId": 1,
+ *           "service": {
+ *             "id": 1,
+ *             "name": "소형이사",
+ *             "description": "원룸, 투룸 등 소규모 이사",
+ *             "isActive": true,
+ *             "iconUrl": "https://s3.amazonaws.com/moving-icons/small-moving.svg"
+ *           }
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
+moverRouter.get("/bookmarked", getBookmarkedMoversController);
+
+export default moverRouter;

--- a/src/services/mover.service.ts
+++ b/src/services/mover.service.ts
@@ -1,0 +1,19 @@
+import {
+  getMoverList,
+  getBookmarkedMovers,
+} from "../repositories/mover.repository";
+import { IMoverListFilter } from "../types/mover.types";
+
+/**
+ * 기사님 리스트 조회 (필터, 정렬, 키워드)
+ */
+export const fetchMoverList = async (filter: IMoverListFilter) => {
+  return getMoverList(filter);
+};
+
+/**
+ * 찜한 기사님 조회
+ */
+export const fetchBookmarkedMovers = async (userId: number) => {
+  return getBookmarkedMovers(userId);
+};

--- a/src/types/mover.types.d.ts
+++ b/src/types/mover.types.d.ts
@@ -1,0 +1,12 @@
+import { Region } from "@prisma/client";
+
+export interface IMoverListFilter {
+  region?: Region;
+  serviceTypeId?: number;
+  search?: string;
+  sort?: "review" | "rating" | "career" | "confirmed";
+  cursor?: number;
+  take?: number;
+}
+
+export type TOrderByType = Record<string, "asc" | "desc">;


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 찾기 API 구현 및 Swagger 문서화
- 필터링, 정렬, 검색, 무한스크롤 기능
- 찜한 기사님 조회 API

## ✅ 주요 작업 내용
- 기사님 리스트 조회 API (GET /movers)
- 찜한 기사님 조회 API (GET /movers/bookmarked)
- TypeScript 타입 정의 및 Swagger 문서화

## 🔄 관련 이슈

Closes #27 
Closes #28 
Closes #29  

## 📎 참고 자료 (선택)
- API 명세서: https://admitted-turkey-c17.notion.site/API-2155da6dc98c813891ead8eb7218d631?pvs=74
- Swagger UI: http://localhost:5050/api-docs
- API JSON: http://localhost:5050/api-docs.json

## 📝 비고
- 현재는 유저를 하드코딩한 상태
- authMiddleware 추후 적용
