### PR TITLE
[#40] feat: 프리즈마 미들웨어로 리뷰생성 미들웨어 생성 및 등록.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,8 @@ import { errorHandler, notFoundHandler } from "./middlewares/errorMiddleware";
 import { setupAutoSwagger } from "./utils/swagger-auto";
 import authRouter from "./routes/auth.route";
 import moverRouter from "./routes/mover.routes";
+import prisma from "./db/prisma/prisma";
+import { reviewPrismaMiddleware } from "./middlewares/reviewMiddleware";
 
 // 환경변수 로드
 dotenv.config();
@@ -58,6 +60,9 @@ setupAutoSwagger(app);
 // app.use('/api/users', userRoutes);
 app.use("/movers", moverRouter); // TODO: 추후 authMiddleware 추가
 app.use("/auth", authRouter);
+
+// 리뷰생성 Prisma 미들웨어 등록
+prisma.$use(reviewPrismaMiddleware);
 
 // 404 에러 핸들링
 app.use(notFoundHandler);

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,8 +5,6 @@ import { errorHandler, notFoundHandler } from "./middlewares/errorMiddleware";
 import { setupAutoSwagger } from "./utils/swagger-auto";
 import authRouter from "./routes/auth.route";
 import moverRouter from "./routes/mover.routes";
-import prisma from "./db/prisma/prisma";
-import { reviewPrismaMiddleware } from "./middlewares/reviewMiddleware";
 
 // 환경변수 로드
 dotenv.config();
@@ -60,9 +58,6 @@ setupAutoSwagger(app);
 // app.use('/api/users', userRoutes);
 app.use("/movers", moverRouter); // TODO: 추후 authMiddleware 추가
 app.use("/auth", authRouter);
-
-// 리뷰생성 Prisma 미들웨어 등록
-prisma.$use(reviewPrismaMiddleware);
 
 // 404 에러 핸들링
 app.use(notFoundHandler);

--- a/src/db/prisma/prisma.ts
+++ b/src/db/prisma/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default prisma; 

--- a/src/db/prisma/prisma.ts
+++ b/src/db/prisma/prisma.ts
@@ -1,5 +1,9 @@
 import { PrismaClient } from "@prisma/client";
+import { reviewPrismaMiddleware } from "../../middlewares/reviewMiddleware";
 
 const prisma = new PrismaClient();
 
-export default prisma; 
+// 리뷰생성 Prisma 미들웨어 등록
+prisma.$use(reviewPrismaMiddleware);
+
+export default prisma;

--- a/src/middlewares/reviewMiddleware.ts
+++ b/src/middlewares/reviewMiddleware.ts
@@ -1,0 +1,47 @@
+import { Prisma } from '@prisma/client';
+import prisma from "../db/prisma/prisma";
+
+// Prisma 미들웨어: Quote.update에서 confirmedEstimateId가 새로 설정될 때 Review 자동 생성
+export const reviewPrismaMiddleware: Prisma.Middleware = async (params, next) => {
+  if (
+    params.model === "Quote" &&
+    params.action === "update" &&
+    params.args?.data?.confirmedEstimateId !== undefined
+  ) {
+    // 기존 Quote를 먼저 조회
+    const quote = await prisma.quote.findUnique({
+      where: params.args.where,
+      select: { confirmedEstimateId: true, id: true, userId: true },
+    });
+    const afterId = params.args.data.confirmedEstimateId;
+    if (quote && !quote.confirmedEstimateId && afterId) {
+      // 이미 해당 quoteId, userId로 리뷰가 있는지 확인
+      const reviewExists = await prisma.review.findFirst({
+        where: {
+          quoteId: quote.id,
+          userId: quote.userId,
+        },
+      });
+      if (!reviewExists) {
+        // estimateId, moverId를 찾아야 할 수 있음
+        const estimate = await prisma.estimate.findUnique({
+          where: { id: afterId },
+          select: { id: true, moverId: true },
+        });
+        if (estimate) {
+          await prisma.review.create({
+            data: {
+              quoteId: quote.id,
+              estimateId: estimate.id,
+              userId: quote.userId,
+              moverId: estimate.moverId,
+              rating: 0,
+              content: "",
+            },
+          });
+        }
+      }
+    }
+  }
+  return next(params);
+};


### PR DESCRIPTION
## ✨ 작업 개요

- 기본 리뷰 생성 미들웨어 생성 및 등록.

## ✅ 주요 작업 내용

- 견적 확정시 상태가 펜딩이고 레이팅이 0, 콘텐트가 ""인 상태의 기본 리뷰 생성.
- 이후 리뷰 작성시 PATCH 메서드로 레이팅과 콘텐트를 바꾸는 방식. -> 확정 견적 하나당 리뷰는 하나만 필요하다는 특성.
- HTTPS 통신이 아닌 데이터 변화 감지를 통해 작동해야 하기에 일반 미들웨어가 아닌 프리즈마 미들웨어로 구현.

## 🔄 관련 이슈

Closes #40 - 기본리뷰 생성 이슈
#42 - 리뷰 작성 이슈

## 📎 참고 자료 (선택)

- API 명세서: [노션 링크](https://admitted-turkey-c17.notion.site/API-2155da6dc98c813891ead8eb7218d631?source=copy_link)

## 🧪 테스트 방법 (선택)

- [ ] 

## 📝 비고

- 기본 리뷰가 생성되자마자 따로 알림을 보내거나 하지 않기에 메시지 큐는 불필요하다 판단해 고려하지 않았습니다.
