### PR TITLE
[#41] feat: 리뷰 작성 가능 견적 리스트 가져오기 API 구현.

### DIFF
--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -20,6 +20,25 @@ const reviewController = {
       next(error);
     }
   },
+
+  // 2. 리뷰 작성 가능한 Quote 리스트 조회
+  getWritableQuotes: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    try {
+      const userId = Number(req.user?.userId || req.query.userId);
+      if (!userId) {
+        res.status(400).json({ message: "유저를 찾을수 없습니다." });
+        return;
+      }
+      const quotes = await reviewService.getWritableQuotes(userId);
+      res.json(quotes);
+    } catch (error) {
+      next(error);
+    }
+  },
 };
 
 export default reviewController;

--- a/src/repositories/review.repository.ts
+++ b/src/repositories/review.repository.ts
@@ -9,6 +9,25 @@ const reviewRepository = {
       data: { rating, content, status: ReviewStatus.COMPLETED },
     });
   },
+
+  // 2. 리뷰 작성 가능한 Quote 리스트 조회
+  getWritableQuotes: async (userId: number) => {
+    return prisma.quote.findMany({
+      where: {
+        userId,
+        confirmedEstimateId: { not: null },
+        reviews: {
+          some: { status: ReviewStatus.PENDING },
+        },
+      },
+      include: {
+        confirmedEstimate: true,
+        reviews: {
+          where: { status: ReviewStatus.PENDING },
+        },
+      },
+    });
+  },
 };
 
 export default reviewRepository;

--- a/src/routes/review.route.ts
+++ b/src/routes/review.route.ts
@@ -6,4 +6,7 @@ const reviewRouter = Router();
 // 리뷰 작성 (완료 처리)
 reviewRouter.patch("/:id", reviewController.postReview);
 
+// 리뷰 작성 가능한 Quote 리스트
+reviewRouter.get("/writable-quotes", reviewController.getWritableQuotes);
+
 export default reviewRouter;

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -4,6 +4,10 @@ const reviewService = {
   postReview: async (reviewId: number, rating: number, content: string) => {
     return reviewRepository.postReview(reviewId, rating, content);
   },
+
+  getWritableQuotes: async (userId: number) => {
+    return reviewRepository.getWritableQuotes(userId);
+  },
 };
 
 export default reviewService;


### PR DESCRIPTION
## ✨ 작업 개요

- 작성 가능한 리뷰 페이지에서 사용 될 리뷰 작성 가능 견적 리스트 가져오기 API 구현.

## ✅ 주요 작업 내용

- 리뷰 작성 가능 견적 리스트 가져오기 API 구현 및 라우팅

## 🔄 관련 이슈

- Closes #41 - 리뷰 가능 견적 리스트 가져오기 API 구현 이슈
- #42 - 리뷰 작성 API 구현 이슈
- #40 - 기본 리뷰 생성 이슈
- #39 - 프로젝트 분석 이슈

## 📎 참고 자료 (선택)

- API 명세서: [노션 링크](https://admitted-turkey-c17.notion.site/API-2155da6dc98c813891ead8eb7218d631?source=copy_link)

## 🧪 테스트 방법 (선택)

- [ ] 작성 가능한 리뷰 페이지 방문시 쿠키에서 userId 받아서 내가 리뷰 쓸수 있는 견적 리스트만 받아오는지 확인.

## 📝 비고

- 
