### PR TITLE
[#88]feat: 찜한 기사님을 추적할 수 있는 공통 유틸 함수 제작

### DIFF
--- a/src/utils/favoriteUtils.ts
+++ b/src/utils/favoriteUtils.ts
@@ -1,0 +1,57 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+/**
+ * 기사님 목록에 찜하기 상태를 추가하는 유틸리티 함수
+ * @param movers 기사님 목록 (userId 필드 필요)
+ * @param userId 현재 로그인한 사용자 ID (선택적)
+ * @returns isFavorited 필드가 추가된 기사님 목록
+ */
+export const addFavoriteStatusToMovers = async (
+  movers: any[],
+  userId?: number
+): Promise<any[]> => {
+  if (!userId) {
+    return movers.map(mover => ({ ...mover, isFavorited: false }));
+  }
+  const moverIds = movers.map(mover => mover.userId);
+  const favorites = await prisma.favorite.findMany({
+    where: {
+      userId,
+      moverId: { in: moverIds }
+    },
+    select: { moverId: true }
+  });
+  const favoritedMoverIds = new Set(favorites.map(fav => fav.moverId));
+  return movers.map(mover => ({
+    ...mover,
+    isFavorited: favoritedMoverIds.has(mover.userId)
+  }));
+};
+
+/**
+ * 단일 기사님에 찜하기 상태를 추가하는 유틸리티 함수
+ * @param mover 기사님 정보 (userId 필드 필요)
+ * @param userId 현재 로그인한 사용자 ID (선택적)
+ * @returns isFavorited 필드가 추가된 기사님 정보
+ */
+export const addFavoriteStatusToMover = async (
+  mover: any,
+  userId?: number
+): Promise<any> => {
+  if (!userId) {
+    return { ...mover, isFavorited: false };
+  }
+  const favorite = await prisma.favorite.findUnique({
+    where: {
+      userId_moverId: {
+        userId,
+        moverId: mover.userId
+      }
+    }
+  });
+  return {
+    ...mover,
+    isFavorited: !!favorite
+  };
+}; 


### PR DESCRIPTION
## ✨ 작업 개요

- 찜한 기사님을 추적할 수 있는 `isFavorited`필드가 모든 `get`메소드에 빠져있는 것을 확인하고 이를 공통 유틸로 제작하여 get 메소드에서 불러 사용할 수 있도록 제작

## ✅ 주요 작업 내용
- 로그인 한 유저일 경우 처리
- 로그인 하지 않은 유저일 경우 처리

## 🔄 관련 이슈

Closes #88

## 📎 참고 자료 (선택)

- API 명세서: https://www.notion.so/2335da6dc98c80fab638c304acd06702


## 🧪 테스트 방법 (선택)
<img width="459" height="694" alt="스크린샷 2025-07-17 100747" src="https://github.com/user-attachments/assets/2e371d55-66ac-41d6-8baf-d93e9b9fd3da" />


## 📝 비고
- 필요 기능이 빠졌을 경우 말씀해주세요


- (추가 예정 기능, 보완 필요 등)
