### PR TITLE
Feat/notification 알림을 위한 액션 생성 및 알림 생성, 알림 관련 API 구현.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import userQuoteRouter from "./routes/userQuote.route";
 import quoteRouter from "./routes/quote.routes";
 import moverEstimateRouter from "./routes/moverEstimate.routes";
 import favoriteRouter from "./routes/favorite.routes";
+import sseRouter from "./routes/sse.route";
 
 // 환경변수 로드
 dotenv.config();
@@ -39,6 +40,8 @@ app.use(
       }
     },
     credentials: true,
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
   })
 );
 
@@ -75,6 +78,9 @@ app.use("/customer-quotes", userQuoteRouter);
 app.use("/quotes", quoteRouter);
 app.use("/mover-estimates", moverEstimateRouter);
 app.use("/favorites", favoriteRouter);
+
+// SSE 라우팅
+app.use("/sse/notification", sseRouter);
 
 // 404 에러 핸들링
 app.use(notFoundHandler);

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import quoteRouter from "./routes/quote.routes";
 import moverEstimateRouter from "./routes/moverEstimate.routes";
 import favoriteRouter from "./routes/favorite.routes";
 import sseRouter from "./routes/sse.route";
+import notificationRouter from "./routes/notification.route";
 
 // 환경변수 로드
 dotenv.config();
@@ -78,6 +79,7 @@ app.use("/customer-quotes", userQuoteRouter);
 app.use("/quotes", quoteRouter);
 app.use("/mover-estimates", moverEstimateRouter);
 app.use("/favorites", favoriteRouter);
+app.use("/notifications", notificationRouter);
 
 // SSE 라우팅
 app.use("/sse/notification", sseRouter);

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import moverEstimateRouter from "./routes/moverEstimate.routes";
 import favoriteRouter from "./routes/favorite.routes";
 import sseRouter from "./routes/sse.route";
 import notificationRouter from "./routes/notification.route";
+import actionTestRouter from "./routes/actionTest.route";
 
 // 환경변수 로드
 dotenv.config();
@@ -80,6 +81,7 @@ app.use("/quotes", quoteRouter);
 app.use("/mover-estimates", moverEstimateRouter);
 app.use("/favorites", favoriteRouter);
 app.use("/notifications", notificationRouter);
+app.use("/actions", actionTestRouter);
 
 // SSE 라우팅
 app.use("/sse/notification", sseRouter);

--- a/src/controllers/actionTest.controller.ts
+++ b/src/controllers/actionTest.controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from "express";
+import actionService from "../services/action.service";
+import { ActionType } from "@prisma/client";
+
+const actionTestController = {
+  // POST /actions/test
+  createTestAction: async (req: Request, res: Response) => {
+    try {
+      // 테스트용 임의 값 (userId, entityId 등은 실제 존재하는 값으로 대체 필요)
+      const userId = Number(req.user?.userId);
+      if (!userId) {
+        return res
+          .status(400)
+          .json({ success: false, message: "해당 유저를 찾을수 없습니다." });
+      }
+      const testAction = await actionService.createAction(
+        userId, // userId
+        ActionType.QUOTE_CREATE, // type
+        7, // entityId (예: quoteId)
+        "QUOTE", // entityType
+        { memo: "테스트용 액션 생성" } // metadata
+      );
+      res.status(201).json({ success: true, data: testAction });
+    } catch (error) {
+      const err = error as Error;
+      res.status(500).json({ success: false, message: err.message });
+    }
+  },
+};
+
+export default actionTestController;

--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction } from "express";
+import notificationService from "../services/notification.service";
+
+const notificationController = {
+  // 알림 목록 조회
+  getNotifications: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = Number(req.user?.userId);
+      if (!userId) {
+        return res
+          .status(400)
+          .json({ success: false, message: "해당 유저를 찾을수 없습니다." });
+      }
+      const limit = Number(req.query.limit) || 20;
+      const offset = Number(req.query.offset) || 0;
+      const notifications = await notificationService.getNotifications(
+        userId,
+        limit,
+        offset
+      );
+      res.json({
+        success: true,
+        message: "알림 목록입니다.",
+        data: notifications,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+};
+
+export default notificationController;

--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -27,6 +27,49 @@ const notificationController = {
       next(error);
     }
   },
+  // 알림 읽음 처리
+  readNotification: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const notificationId = Number(req.params.notificationId);
+      if (!notificationId) {
+        return res
+          .status(400)
+          .json({ success: false, message: "해당 알림을 찾을수 없습니다." });
+      }
+      const notification =
+        await notificationService.readNotification(notificationId);
+      res.json({
+        success: true,
+        message: "알림이 읽음 처리되었습니다.",
+        data: notification,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+  // 전체 알림 읽음 처리
+  readAllNotifications: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const userId = Number(req.user?.userId);
+      if (!userId) {
+        return res
+          .status(400)
+          .json({ success: false, message: "해당 유저를 찾을수 없습니다." });
+      }
+      const count = await notificationService.readAllNotifications(userId);
+      res.json({
+        success: true,
+        message: "모든 알림이 읽음 처리되었습니다.",
+        data: { count },
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
 };
 
 export default notificationController;

--- a/src/db/prisma/prisma.ts
+++ b/src/db/prisma/prisma.ts
@@ -1,9 +1,13 @@
 import { PrismaClient } from "@prisma/client";
 import { reviewPrismaMiddleware } from "../../middlewares/reviewMiddleware";
+import { notificationMiddleware } from "../../middlewares/notificationMiddleware";
 
 const prisma = new PrismaClient();
 
 // 리뷰생성 Prisma 미들웨어 등록
 prisma.$use(reviewPrismaMiddleware);
+
+// 알림생성 Prisma 미들웨어 등록
+prisma.$use(notificationMiddleware);
 
 export default prisma;

--- a/src/middlewares/notificationMiddleware.ts
+++ b/src/middlewares/notificationMiddleware.ts
@@ -1,0 +1,54 @@
+import { Prisma } from '@prisma/client';
+import prisma from '../db/prisma/prisma';
+import { actionNotificationMap } from '../utils/actionNotificationMap';
+import { emitNotificationSSE } from '../utils/emitNotificationSSE';
+import { Action } from '@prisma/client';
+
+
+// Prisma 미들웨어: actionCreate 함수에서 새로운 액션이 생성될 때 notification 자동 생성.
+export const notificationMiddleware: Prisma.Middleware = async (params, next) => {
+  const result = await next(params);
+
+  // 액션 생성 감지
+  if (params.model === 'Action' && params.action === 'create') {
+    const action = result as Action; 
+
+    const mapping = actionNotificationMap[action.type];
+    if (!mapping) return result;
+
+    const receivers = await mapping.getReceivers(action);
+
+    const notifications = await Promise.all(
+      receivers.map(async (receiver) => {
+        const message = mapping.buildMessage(action, receiver.role);
+        return prisma.notification.create({
+          data: {
+            userId: receiver.id,
+            actionId: action.id,
+            type: mapping.type,
+            title: message.title,
+            content: message.content,
+            actionUrl: message.actionUrl,
+            isRealTime: true,
+            sseSent: false,
+          },
+        });
+      })
+    );
+
+    // 실시간 알림 SSE 전송
+    for (const notification of notifications) {
+      emitNotificationSSE(notification.userId, {
+        notification,
+        unreadCount: await prisma.notification.count({
+          where: {
+            userId: notification.userId,
+            isRead: false, 
+          },
+        }),
+      });
+    }
+  }
+
+  return result;
+};

--- a/src/repositories/action.repository.ts
+++ b/src/repositories/action.repository.ts
@@ -1,0 +1,26 @@
+import prisma from "../db/prisma/prisma";
+import { ActionType } from "@prisma/client";
+
+interface CreateActionParams {
+  userId: number;
+  type: ActionType;
+  entityId: number;
+  entityType: string;
+  metadata: object;
+}
+
+const actionRepository = {
+  createAction: async (params: CreateActionParams) => {
+    return prisma.action.create({
+      data: {
+        userId: params.userId,
+        type: params.type,
+        entityId: params.entityId,
+        entityType: params.entityType,
+        metadata: params.metadata,
+      },
+    });
+  },
+};
+
+export default actionRepository;

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -1,0 +1,26 @@
+import prisma from "../db/prisma/prisma";
+
+const notificationRepository = {
+  getNotifications: async (userId: number, limit: number, offset: number) => {
+    const [items, total] = await Promise.all([
+      prisma.notification.findMany({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        skip: offset,
+        take: limit,
+      }),
+      prisma.notification.count({ where: { userId } }),
+    ]);
+    return { items, total, limit, offset };
+  },
+  // 안읽은 알림 존재 여부 반환
+  hasUnreadNotification: async (userId: number) => {
+    const unread = await prisma.notification.findFirst({
+      where: { userId, isRead: false },
+      select: { id: true },
+    });
+    return !!unread;
+  },
+};
+
+export default notificationRepository;

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -21,6 +21,19 @@ const notificationRepository = {
     });
     return !!unread;
   },
+  readNotification: async (notificationId: number) => {
+    return prisma.notification.update({
+      where: { id: notificationId },
+      data: { isRead: true },
+    });
+  },
+  readAllNotifications: async (userId: number) => {
+    const { count } = await prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: { isRead: true },
+    });
+    return count;
+  },
 };
 
 export default notificationRepository;

--- a/src/routes/actionTest.route.ts
+++ b/src/routes/actionTest.route.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import actionTestController from "../controllers/actionTest.controller";
+import { verifyAccessToken } from "../middlewares/verifyToken";
+
+const actionTestRouter = Router();
+
+actionTestRouter.post(
+  "/test",
+  verifyAccessToken,
+  actionTestController.createTestAction
+);
+
+export default actionTestRouter;

--- a/src/routes/notification.route.ts
+++ b/src/routes/notification.route.ts
@@ -10,5 +10,17 @@ notificationRouter.get(
   verifyAccessToken,
   notificationController.getNotifications
 );
+// 알림 읽음 처리
+notificationRouter.patch(
+  "/:notificationId/read",
+  verifyAccessToken,
+  notificationController.readNotification
+);
+// 전체 알림 읽음 처리
+notificationRouter.patch(
+  "/read-all",
+  verifyAccessToken,
+  notificationController.readAllNotifications
+);
 
 export default notificationRouter;

--- a/src/routes/notification.route.ts
+++ b/src/routes/notification.route.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import notificationController from "../controllers/notification.controller";
+import { verifyAccessToken } from "../middlewares/verifyToken";
+
+const notificationRouter = Router();
+
+// 알림 목록 조회
+notificationRouter.get(
+  "/",
+  verifyAccessToken,
+  notificationController.getNotifications
+);
+
+export default notificationRouter;

--- a/src/routes/sse.route.ts
+++ b/src/routes/sse.route.ts
@@ -1,0 +1,16 @@
+import { Request, Response, Router } from "express";
+import { registerSSE } from "../utils/emitNotificationSSE";
+import { verifyAccessToken } from "../middlewares/verifyToken";
+
+const sseRouter = Router();
+
+sseRouter.get("/", verifyAccessToken, (req: Request, res: Response) => {
+  const userId = req.user?.userId;
+  if (!userId) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  registerSSE(userId, res);
+});
+
+export default sseRouter;

--- a/src/services/action.service.ts
+++ b/src/services/action.service.ts
@@ -1,0 +1,22 @@
+import { ActionType } from "@prisma/client";
+import actionRepository from "../repositories/action.repository";
+
+const actionService = {
+  createAction: async (
+    userId: number,
+    type: ActionType,
+    entityId: number,
+    entityType: string,
+    metadata: object
+  ) => {
+    return actionRepository.createAction({
+      userId,
+      type,
+      entityId,
+      entityType,
+      metadata,
+    });
+  },
+};
+
+export default actionService; 

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -11,6 +11,12 @@ const notificationService = {
       await notificationRepository.hasUnreadNotification(userId);
     return { ...notifications, hasUnread };
   },
+  readNotification: async (notificationId: number) => {
+    return notificationRepository.readNotification(notificationId);
+  },
+  readAllNotifications: async (userId: number) => {
+    return notificationRepository.readAllNotifications(userId);
+  },
 };
 
 export default notificationService;

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,0 +1,16 @@
+import notificationRepository from "../repositories/notification.repository";
+
+const notificationService = {
+  getNotifications: async (userId: number, limit: number, offset: number) => {
+    const notifications = await notificationRepository.getNotifications(
+      userId,
+      limit,
+      offset
+    );
+    const hasUnread =
+      await notificationRepository.hasUnreadNotification(userId);
+    return { ...notifications, hasUnread };
+  },
+};
+
+export default notificationService;

--- a/src/utils/actionNotificationMap.ts
+++ b/src/utils/actionNotificationMap.ts
@@ -1,0 +1,231 @@
+import { Action, ActionType, NotificationType } from '@prisma/client';
+import prisma from '../db/prisma/prisma';
+
+export interface INotificationPayload {
+  type: NotificationType;
+  getReceivers: (action: Action) => Promise<{ id: number; role: 'CUSTOMER' | 'MOVER' }[]>;
+  buildMessage: (action: Action, role: 'CUSTOMER' | 'MOVER') => {
+    title: string;
+    content: string;
+    actionUrl: string;
+  };
+}
+
+export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
+  QUOTE_CREATE: {
+    type: NotificationType.NEW_QUOTE,
+    getReceivers: async (action: Action) => {
+      // 모든 기사님(userType=MOVER)에게 알림
+      const movers = await prisma.user.findMany({
+        where: { currentRole: 'MOVER' },
+        select: { id: true },
+      });
+      return movers.map((mover) => ({ id: mover.id, role: 'MOVER' as const }));
+    },
+    buildMessage: (action: Action) => ({
+      title: '새 견적 요청이 등록되었습니다.',
+      content: '새로운 견적 요청이 등록되었습니다.',
+      actionUrl: `/quotes/${action.entityId}`,
+    }),
+  },
+  QUOTE_REJECTED: {
+    type: NotificationType.ESTIMATE_REJECTED,
+    getReceivers: async (action:Action) => {
+      // 견적 반려 시 고객에게 알림
+      const quote = await prisma.quote.findUnique({
+        where: { id: action.entityId },
+        select: { userId: true },
+      });
+      return quote ? [{ id: quote.userId, role: 'CUSTOMER' }] : [];
+    },
+    buildMessage: (action) => ({
+      title: '견적이 반려되었습니다.',
+      content: '견적 요청이 반려되었습니다. 상세 내용을 확인하세요.',
+      actionUrl: `/quotes/${action.entityId}`,
+    }),
+  },
+  ESTIMATE_SUBMITTED: {
+    type: NotificationType.ESTIMATE_SUBMITTED,
+    getReceivers: async (action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: { quote: { select: { userId: true } } },
+      });
+      return estimate ? [{ id: estimate.quote.userId, role: 'CUSTOMER' }] : [];
+    },
+    buildMessage: (action) => {
+      const { moverName, movingType, estimateId } = action.metadata as any;
+      return {
+        title: `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">${movingType}</span> 견적이 도착했어요.`,
+        content: '대기중인 견적에서 확인할 수 있어요.',
+        actionUrl: `/estimate/${estimateId}`,
+      };
+    },
+  },
+  ESTIMATE_ACCEPTED: {
+    type: NotificationType.ESTIMATE_CONFIRMED,
+    getReceivers: async (action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: {
+          moverId: true,
+          quote: { select: { userId: true } },
+        },
+      });
+      if (!estimate) return [];
+      return [
+        { id: estimate.moverId, role: 'MOVER' },
+        { id: estimate.quote.userId, role: 'CUSTOMER' },
+      ];
+    },
+    buildMessage: (action, role) => {
+      const { quoteId, moverName, customerName } = action.metadata as any;
+      return {
+        title:
+          role === 'CUSTOMER'
+            ? `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
+            : `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
+        content: '내 견적 관리 > 확정 견적에서 확인할 수 있어요.',
+        actionUrl:
+          role === 'CUSTOMER' ? `/quotes/${quoteId}` : `/estimate/${quoteId}`,
+      };
+    },
+  },
+  ESTIMATE_REJECTED: {
+    type: NotificationType.ESTIMATE_REJECTED,
+    getReceivers: async (action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: { moverId: true },
+      });
+      return estimate ? [{ id: estimate.moverId, role: 'MOVER' }] : [];
+    },
+    buildMessage: (action) => {
+      const { customerName, estimateId } = action.metadata as any;
+      return {
+        title: `<span class="font-bold">${customerName}</span> 고객님의 견적이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
+        content: '반려된 견적 상세를 확인하세요.',
+        actionUrl: `/estimate/${estimateId}`,
+      };
+    },
+  },
+  DESIGNATED_QUOTE_REQUESTED: {
+    type: NotificationType.DESIGNATED_QUOTE_REQUESTED,
+    getReceivers: async (action) => {
+      const request = await prisma.designatedEstimateRequest.findUnique({
+        where: { id: action.entityId },
+        select: { moverId: true },
+      });
+      return request ? [{ id: request.moverId, role: 'MOVER' }] : [];
+    },
+    buildMessage: (action) => {
+      const { customerName, quoteId } = action.metadata as any;
+      return {
+        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="font-bold">지정 견적</span>이 요청되었어요.`,
+        content: '받은 요청 페이지에서 확인해보세요.',
+        actionUrl: `/designated-quote/${quoteId}`,
+      };
+    },
+  },
+  DESIGNATED_ESTIMATE_SUBMITTED: {
+    type: NotificationType.ESTIMATE_SUBMITTED,
+    getReceivers: async (action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: { quote: { select: { userId: true } } },
+      });
+      return estimate ? [{ id: estimate.quote.userId, role: 'CUSTOMER' }] : [];
+    },
+    buildMessage: (action) => {
+      const { moverName, movingType, estimateId } = action.metadata as any;
+      return {
+        title: `<span class="font-bold">지정<span> 요청한 <span class="text-primary-400 font-bold">${movingType}</span> 견적이 도착했어요.`,
+        content: '대기중인 지정 견적에서 확인할 수 있어요.',
+        actionUrl: `/estimate/${estimateId}`,
+      };
+    },
+  },
+  MOVING_COMPLETED: {
+    type: NotificationType.REVIEW_REQUEST,
+    getReceivers: async (action) => {
+      const quote = await prisma.quote.findUnique({
+        where: { id: action.entityId },
+        select: { userId: true },
+      });
+      return quote ? [{ id: quote.userId, role: 'CUSTOMER' }] : [];
+    },
+    buildMessage: (action) => {
+      const { movingType, quoteId } = action.metadata as any;
+      return {
+        title: `어제 <span class="text-primary-400 font-bold">${movingType}</span> 이사는 어떠셨나요? 기사님에 대한 <span class="text-primary-400 font-bold">리뷰</span>를 남겨주세요.`,
+        content: '기사님에 대한 리뷰를 남겨주세요.',
+        actionUrl: `/quotes/${quoteId}/review`,
+      };
+    },
+  },
+  REVIEW_SUBMITTED: {
+    type: NotificationType.REVIEW_REQUEST,
+    getReceivers: async (action) => {
+      const review = await prisma.review.findUnique({
+        where: { id: action.entityId },
+        select: { moverId: true },
+      });
+      return review ? [{ id: review.moverId, role: 'MOVER' }] : [];
+    },
+    buildMessage: () => ({
+      title: '<span class="text-primary-400 font-bold">새 리뷰</span>가 등록되었어요.',
+      content: '고객이 리뷰를 남겼어요. 지금 확인해보세요!',
+      actionUrl: `/mover/reviews`,
+    }),
+  },
+  MOVING_DAY_TOMORROW: {
+    type: NotificationType.MOVING_DAY,
+    getReceivers: async (action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: {
+          moverId: true,
+          quote: { select: { userId: true } },
+        },
+      });
+      if (!estimate) return [];
+      return [
+        { id: estimate.moverId, role: 'MOVER' },
+        { id: estimate.quote.userId, role: 'CUSTOMER' },
+      ];
+    },
+    buildMessage: (action: Action) => {
+      const { quoteId, movingType } = action.metadata as any;
+      return {
+        title: `내일은 <span class="text-primary-400 font-bold">${movingType}</span> 이사 예정일이에요.`,
+        content: '이사 준비를 미리 확인해보세요.',
+        actionUrl: `/quotes/${quoteId}`,
+      };
+    },
+  },
+  MOVING_DAY_TODAY: {
+    type: NotificationType.MOVING_DAY,
+    getReceivers: async (action: Action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: {
+          moverId: true,
+          quote: { select: { userId: true } },
+        },
+      });
+      if (!estimate) return [];
+      return [
+        { id: estimate.moverId, role: 'MOVER' },
+        { id: estimate.quote.userId, role: 'CUSTOMER' },
+      ];
+    },
+    buildMessage: (action: Action) => {
+      const { quoteId, movingType } = action.metadata as any;
+      return {
+        title: `오늘은 <span class="text-primary-400 font-bold">${movingType}</span> 이사 예정일이에요.`,
+        content: '이사가 안전하게 진행되길 바래요.',
+        actionUrl: `/quotes/${quoteId}`,
+      };
+    },
+  },
+};

--- a/src/utils/emitNotificationSSE.ts
+++ b/src/utils/emitNotificationSSE.ts
@@ -1,0 +1,48 @@
+import { Notification } from "@prisma/client";
+import { Response } from "express";
+
+type NotificationEvent = {
+  notification: Notification;
+  unreadCount: number;
+};
+
+// 유저별 SSE 연결 저장소
+const sseClients = new Map<number, Response>();
+
+/**
+ * SSE 연결을 등록합니다.
+ * @param userId 사용자 ID
+ * @param res SSE Response 객체
+ */
+export function registerSSE(userId: number, res: Response) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+
+  res.write("\n"); // 연결 초기화
+
+  sseClients.set(userId, res);
+
+  // 연결 끊김 감지
+  res.on("close", () => {
+    sseClients.delete(userId);
+  });
+}
+
+/**
+ * 해당 사용자에게 알림 SSE를 전송합니다.
+ * @param userId 사용자 ID
+ * @param payload 전송할 알림 데이터
+ */
+export function emitNotificationSSE(
+  userId: number,
+  payload: NotificationEvent
+) {
+  const client = sseClients.get(userId);
+  if (!client) return;
+
+  client.write(`event: notification\n`);
+  client.write(`data: ${JSON.stringify(payload)}\n\n`);
+}


### PR DESCRIPTION
## ✨ 작업 개요

- 알림을 위한 액션 생성 및 알림 생성, 알림 관련 API 구현.

## ✅ 주요 작업 내용

- 액션 생성 함수 구현. -> createAction (repository, service)
- 액션 별 알림 매칭 맵 구현. -> actionNotificationMap.ts
- 액션 데이터 생성을 감지해 알림을 생성하는 프리즈마 미들웨어 구현. -> notificationMiddleware.ts
- 알림이 생성되면 SSE로 알려줄 SSE API 구현 및 CORS 세팅.
- 알림 가져오기 API 구현 및 라우팅.
- 알림 읽음처리 API 구현 및 라우팅.
- 알림 전체 읽음처리 API 구현 및 라우팅. -> 챌린지용.

## 🔄 관련 이슈

Closes #45 -> 액션 생성 함수.
Closes #46 -> 액션 별 알림 생성 미들웨어.
Closes #47 -> 알림 가져오기 API.
Closes #48 -> 알림 읽음처리 API.
#39 - 프로젝트 분석.

## 📎 참고 자료 (선택)

- API 명세서: [Notion 링크](https://admitted-turkey-c17.notion.site/API-2155da6dc98c813891ead8eb7218d631?source=copy_link)
- 프로젝트 분석 [Notion 링크](https://admitted-turkey-c17.notion.site/BE-2245da6dc98c80e681a1f21c8bf66842?source=copy_link)

## 🧪 테스트 방법 (선택)

- [ ] 각 행동 controlloer 에서 actionService.createAction 함수를 임포트 해서 사용. -> 액션 생성.
- [ ] 액션이 생성되면 미들웨어가 데이터를 감지해서 액션타입에 해당하는 알림 생성.
- [ ] SSE로 새로운 알림을 유저에게 알림. 
- [ ] FE에서 새로운 알림을 GET해서 유저에게 View.

## 📝 비고

- 현재 유저가 견적을 등록하면 모든 기사님에게 알림이 가도록 구현. -> 리팩토링을 거쳐 요구사항에 해당되는 기사님에게만 가도록 변경.
