### PR TITLE
[#95] feat: 지정 견적 요청 api

### DIFF
--- a/src/controllers/mover.controller.ts
+++ b/src/controllers/mover.controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response, NextFunction } from "express";
-import { fetchMoverList, fetchFavoriteMovers } from "../services/mover.service";
+import {
+  fetchMoverList,
+  fetchFavoriteMovers,
+  requestDesignatedQuote,
+} from "../services/mover.service";
 import { IMoverListFilter } from "../types/mover.types";
 import { handleError } from "../utils/handleError";
 import moverService from "../services/mover.service";
@@ -7,7 +11,11 @@ import moverService from "../services/mover.service";
 /**
  * 기사님 리스트 조회 (필터, 정렬, 키워드)
  */
-export const getMoverListController = async (req: Request, res: Response, next: NextFunction) => {
+export const getMoverListController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { region, serviceTypeId, search, sort, cursor, take } = req.query;
 
@@ -34,7 +42,11 @@ export const getMoverListController = async (req: Request, res: Response, next: 
 /**
  * 찜한 기사님 조회
  */
-export const getFavoriteMoversController = async (req: Request, res: Response, next: NextFunction) => {
+export const getFavoriteMoversController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const { userId } = req.user as { userId: number };
     const favoriteMovers = await fetchFavoriteMovers(userId);
@@ -48,15 +60,66 @@ export const getFavoriteMoversController = async (req: Request, res: Response, n
   }
 };
 
-export const getMoverDetailController = async (req: Request, res: Response, next: NextFunction) => {
+/**
+ * 기사님 상세 조회
+ */
+export const getMoverDetailController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const id = Number(req.params.moverId);
-    if (!id) return res.status(400).json({ success: false, message: "id가 필요합니다.", data: null });
+    if (!id)
+      return res
+        .status(400)
+        .json({ success: false, message: "id가 필요합니다.", data: null });
     const mover = await moverService.fetchMoverDetail(id);
-    if (!mover) return res.status(404).json({ success: false, message: "존재하지 않는 기사님", data: null });
+    if (!mover)
+      return res
+        .status(404)
+        .json({ success: false, message: "존재하지 않는 기사님", data: null });
     res.json({ success: true, message: "기사님 상세 조회 성공", data: mover });
   } catch (err) {
     next(err);
+  }
+};
+
+/**
+ * 지정 견적 요청 
+ */
+export const postDesignatedQuoteRequestController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const { moverId } = req.params;
+    const { quoteId, message, expiresAt } = req.body;
+    const user = req.user as { userId: number; role: string };
+    if (!user || user.role !== "CUSTOMER") {
+      return res.status(401).json({
+        success: false,
+        message: "회원만 지정 견적 요청이 가능합니다.",
+      });
+    }
+    if (!quoteId || !expiresAt) {
+      return res.status(400).json({ success: false, message: "필수값 누락" });
+    }
+    const request = await requestDesignatedQuote({
+      quoteId: Number(quoteId),
+      moverId: Number(moverId),
+      customerId: user.userId,
+      message,
+      expiresAt: new Date(expiresAt),
+    });
+    res.json({
+      success: true,
+      message: "지정 견적 요청이 성공적으로 생성되었습니다.",
+      data: request,
+    });
+  } catch (err: any) {
+    res.status(400).json({ success: false, message: err.message });
   }
 };
 
@@ -64,6 +127,7 @@ const moverController = {
   getMoverListController,
   getFavoriteMoversController,
   getMoverDetailController,
+  postDesignatedQuoteRequestController,
 };
 
 export default moverController;

--- a/src/repositories/mover.repository.ts
+++ b/src/repositories/mover.repository.ts
@@ -22,7 +22,14 @@ const getOrderBy = (sort: string): TOrderByType => {
  * 기사님 리스트 조회 (필터, 정렬, 키워드)
  */
 export const getMoverList = async (filter: IMoverListFilter) => {
-  const { region, serviceTypeId, search, sort = "review", cursor, take = 20 } = filter;
+  const {
+    region,
+    serviceTypeId,
+    search,
+    sort = "review",
+    cursor,
+    take = 20,
+  } = filter;
 
   // 필터, 검색
   const where: any = {
@@ -101,10 +108,14 @@ export const getFavoriteMovers = async (userId: number) => {
     },
   });
 
-  return favorites.map((favorite) => favorite.mover.profile).filter((profile) => profile !== null);
+  return favorites
+    .map((favorite) => favorite.mover.profile)
+    .filter((profile) => profile !== null);
 };
 
-// 4. 기사님 상세 조회
+/**
+ *  기사님 상세 조회
+ */
 const getMoverDetail = async (id: number) => {
   return prisma.profile.findUnique({
     where: { id },
@@ -116,10 +127,38 @@ const getMoverDetail = async (id: number) => {
   });
 };
 
+/**
+ * 지정 견적 요청 생성
+ */
+export const createDesignatedEstimateRequest = async ({
+  quoteId,
+  customerId,
+  moverId,
+  message,
+  expiresAt,
+}: {
+  quoteId: number;
+  customerId: number;
+  moverId: number;
+  message?: string;
+  expiresAt: Date;
+}) => {
+  return await prisma.designatedEstimateRequest.create({
+    data: {
+      quoteId,
+      customerId,
+      moverId,
+      message,
+      expiresAt,
+    },
+  });
+};
+
 const moverRepository = {
   getMoverList,
   getFavoriteMovers,
   getMoverDetail,
+  createDesignatedEstimateRequest,
 };
 
 export default moverRepository;

--- a/src/routes/mover.routes.ts
+++ b/src/routes/mover.routes.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
-import { getMoverListController, getFavoriteMoversController, getMoverDetailController } from "../controllers/mover.controller";
+import * as moverController from "../controllers/mover.controller";
 import { verifyAccessToken } from "../middlewares/verifyToken";
 
 const moverRouter = Router();
 
 /**
  * GET /movers
- * @summary 기사님 리스트 조회 
+ * @summary 기사님 리스트 조회
  * @tags Mover
  * @description 기사님 목록을 조회
  * @param {string} region.query - 지역 필터
@@ -60,7 +60,7 @@ const moverRouter = Router();
  *   ]
  * }
  */
-moverRouter.get("/", getMoverListController);
+moverRouter.get("/", moverController.getMoverListController);
 
 /**
  * GET /movers/bookmarked
@@ -118,7 +118,11 @@ moverRouter.get("/", getMoverListController);
  *   "message": "인증이 필요합니다."
  * }
  */
-moverRouter.get("/favorite", verifyAccessToken, getFavoriteMoversController);
+moverRouter.get(
+  "/favorite",
+  verifyAccessToken,
+  moverController.getFavoriteMoversController
+);
 
 /**
  * GET /movers/:moverId
@@ -174,6 +178,53 @@ moverRouter.get("/favorite", verifyAccessToken, getFavoriteMoversController);
  *   "message": "기사님을 찾을 수 없습니다."
  * }
  */
-moverRouter.get("/:moverId", getMoverDetailController);
+moverRouter.get("/:moverId", moverController.getMoverDetailController);
+
+/**
+ * POST /movers/:moverId/quote-request
+ * @summary 지정 견적 요청 (회원만 가능)
+ * @tags Mover
+ * @description 본인 견적(quoteId)에 대해 특정 기사님에게 지정 견적을 요청합니다.
+ * @security bearerAuth
+ * @param {number} moverId.path.required - 기사님 ID
+ * @param {object} request.body.required - 요청 바디
+ * @property {integer} quoteId.required - 본인 견적 ID
+ * @property {string} message - 기사님께 전달할 메시지(선택)
+ * @property {string} expiresAt.required - 지정 견적 유효기간(ISO 8601)
+ * @returns {object} 200 - 지정 견적 요청 성공
+ * @returns {object} 400 - 잘못된 요청
+ * @example request - 예시
+ * {
+ *   "quoteId": 4,
+ *   "message": "이사 일정 조율이 필요합니다.",
+ *   "expiresAt": "2025-07-31T23:59:59.000Z"
+ * }
+ * @example response - 200 - 성공 예시
+ * {
+ *   "success": true,
+ *   "message": "지정 견적 요청이 성공적으로 생성되었습니다.",
+ *   "data": {
+ *     "id": 1,
+ *     "quoteId": 4,
+ *     "moverId": 2,
+ *     "customerId": 9,
+ *     "message": "이사 일정 조율이 필요합니다.",
+ *     "expiresAt": "2025-07-31T23:59:59.000Z",
+ *     "status": "PENDING",
+ *     "createdAt": "2025-07-18T08:00:00.000Z",
+ *     "updatedAt": "2025-07-18T08:00:00.000Z"
+ *   }
+ * }
+ * @example response - 400 - 실패 예시
+ * {
+ *   "success": false,
+ *   "message": "필수값 누락"
+ * }
+ */
+moverRouter.post(
+  "/:moverId/quote-request",
+  verifyAccessToken,
+  moverController.postDesignatedQuoteRequestController
+);
 
 export default moverRouter;

--- a/src/services/mover.service.ts
+++ b/src/services/mover.service.ts
@@ -1,13 +1,16 @@
-import { getMoverList, getFavoriteMovers } from "../repositories/mover.repository";
+import {
+  getMoverList,
+  getFavoriteMovers,
+  createDesignatedEstimateRequest,
+} from "../repositories/mover.repository";
 import { IMoverListFilter } from "../types/mover.types";
-import moverRepository from "../repositories/mover.repository";
+import prisma from "../db/prisma/prisma";
 
 /**
  * 기사님 리스트 조회 (필터, 정렬, 키워드)
  */
 export const fetchMoverList = async (filter: IMoverListFilter) => {
   const movers = await getMoverList(filter);
-
   return movers;
 };
 
@@ -16,18 +19,67 @@ export const fetchMoverList = async (filter: IMoverListFilter) => {
  */
 export const fetchFavoriteMovers = async (userId: number) => {
   const movers = await getFavoriteMovers(userId);
-
   return movers;
 };
 
+
+/**
+ * 기사님 상세 조회
+ */
 export const fetchMoverDetail = async (id: number) => {
-  return await moverRepository.getMoverDetail(id);
+  return await prisma.profile.findUnique({
+    where: { id },
+    include: {
+      user: { select: { id: true, name: true, email: true } },
+      serviceRegions: true,
+      serviceTypes: { include: { service: true } },
+    },
+  });
+};
+
+/**
+ * 지정 견적 요청 
+ */
+export const requestDesignatedQuote = async ({
+  quoteId,
+  moverId,
+  customerId,
+  message,
+  expiresAt,
+}: {
+  quoteId: number;
+  moverId: number;
+  customerId: number;
+  message?: string;
+  expiresAt: Date;
+}) => {
+  // 본인 견적 확인
+  const quote = await prisma.quote.findUnique({ where: { id: quoteId } });
+  if (!quote || quote.userId !== customerId) {
+    throw new Error("본인 견적에만 요청할 수 있습니다.");
+  }
+  // 중복 체크
+  const exists = await prisma.designatedEstimateRequest.findUnique({
+    where: { quoteId_moverId: { quoteId, moverId } },
+  });
+  if (exists) {
+    throw new Error("이미 해당 기사님에게 지정 견적을 요청했습니다.");
+  }
+  // 생성
+  return await createDesignatedEstimateRequest({
+    quoteId,
+    customerId,
+    moverId,
+    message,
+    expiresAt,
+  });
 };
 
 const moverService = {
   fetchMoverList,
   fetchFavoriteMovers,
   fetchMoverDetail,
+  requestDesignatedQuote,
 };
 
 export default moverService;


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님에게 지정 견적 요청 API 구현

## ✅ 주요 작업 내용
- 기사님에게 지정 견적 요청 API 구현
- Swagger API 문서화
- 본인 견적(quoteId)에 한해, 특정 기사님(moverId)에게 지정 견적 요청 가능
- 중복 요청 방지

## 🔄 관련 이슈
- Closes #95

## 📎 참고 자료 (선택)
- API 명세서: http://localhost:5050/api-docs


## 📝 비고
- 관련 사항 없음
