### PR TITLE
[#24] feat : 일반 유저 프로필 정보 조회 api 추가

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -4,6 +4,7 @@ import {
   createCustomerProfile,
   createMoverProfile,
   updateMoverBasicInfo,
+  getProfileData,
 } from "../services/user.service";
 import { handleError } from "../utils/handleError";
 import {
@@ -28,6 +29,18 @@ const getUser = async (req: Request, res: Response) => {
   const user = await userInfo(userId, userType);
 
   res.json({ success: true, data: user });
+};
+
+// 프로필 조회
+const getProfile = async (req: Request, res: Response) => {
+  const { userId, userType } = req.user as {
+    userId: string;
+    userType: TUserRole;
+  };
+
+  const profile = await getProfileData(userId, userType);
+
+  res.json({ success: true, data: profile });
 };
 
 // 프로필 등록 및 수정 -> 수정은 따로 빼기?
@@ -126,4 +139,4 @@ const patchMoverBasicInfo = async (req: Request, res: Response) => {
   }
 };
 
-export { getUser, postProfile, patchMoverBasicInfo };
+export { getUser, postProfile, getProfile, patchMoverBasicInfo };

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -46,6 +46,40 @@ const getUserWithPassword = async (userId: string) => {
   return user;
 };
 
+// 일반유저 프로필 조회
+const getCustomerProfile = async (userId: string) => {
+  const profile = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      name: true,
+      nickname: true,
+      email: true,
+      encryptedPhoneNumber: true,
+      customerImage: true,
+      preferredServices: true,
+      currentArea: true,
+    },
+  });
+  return profile;
+};
+
+// 기사님 프로필 조회
+const getMoverProfile = async (userId: string) => {
+  const profile = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      name: true,
+      nickname: true,
+      moverImage: true,
+      career: true,
+      shortIntro: true,
+      detailIntro: true,
+      serviceTypes: true,
+      currentAreas: true,
+    },
+  });
+  return profile;
+};
 // 일반 유저(CUSTOMER) 프로필 생성 및 유저 정보 업데이트
 const createCustomerProfile = async (profileData: TCreateCustomerProfile) => {
   return await prisma.user.update({
@@ -196,6 +230,8 @@ const updateUserProfile = async (
 export {
   getUserById,
   getUserWithPassword,
+  getCustomerProfile,
+  getMoverProfile,
   createCustomerProfile,
   createMoverProfile as createMoverProfileRepository,
   updateUserProfile,

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -3,6 +3,7 @@ import {
   getUser,
   postProfile,
   patchMoverBasicInfo,
+  getProfile,
 } from "../controllers/user.controller";
 import { verifyAccessToken } from "../middlewares/verifyToken";
 import generatePresignedUrls from "../middlewares/presignedUrl";
@@ -101,6 +102,19 @@ const userRouter = Router();
  * }
  */
 userRouter.get("/", verifyAccessToken, getUser);
+
+/**
+ * GET /users/profile
+ * @summary 프로필 조회
+ * @description 사용자 타입에 따라 고객 또는 기사님 프로필을 조회합니다.
+ * @tags Users
+ * @security BearerAuth
+ * @return {SuccessResponse} 200 - 프로필 조회 성공
+ * @return {ErrorResponse} 401 - 인증 실패 (유효하지 않은 토큰)
+ * @return {ErrorResponse} 404 - 사용자를 찾을 수 없음
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ */
+userRouter.get("/profile", verifyAccessToken, getProfile);
 
 /**
  * POST /users/profile

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -166,7 +166,7 @@ const logout = async (userId: string) => {
     throw new AuthenticationError("이미 로그아웃된 상태입니다");
   }
 
-  await authRepository.updateUserToken(String(userId), null);
+  await authRepository.updateUserToken(String(userId), null, user.userType[0]);
 };
 
 export default { signin, signup, logout };

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
 import bcrypt from "bcrypt";
 import {
   getUserById,
@@ -6,9 +5,13 @@ import {
   createCustomerProfile as createCustomerProfileRepository,
   createMoverProfileRepository,
   updateUserProfile,
-  checkNicknameExists,
+  getCustomerProfile,
+  getMoverProfile,
 } from "../repositories/user.repository";
-import { encryptPhoneNumber, decryptPhoneNumber } from "../utils/phoneEncryption";
+import {
+  encryptPhoneNumber,
+  decryptPhoneNumber,
+} from "../utils/phoneEncryption";
 import { NotFoundError, ValidationError } from "../types/commonError.types";
 import {
   TCustomerProfileInput,
@@ -38,7 +41,9 @@ const userInfo = async (userId: string, userType: TUserRole) => {
       id: user.id,
       name: user.name,
       email: user.email,
-      phoneNumber: user.encryptedPhoneNumber ? decryptPhoneNumber(user.encryptedPhoneNumber) : null,
+      phoneNumber: user.encryptedPhoneNumber
+        ? decryptPhoneNumber(user.encryptedPhoneNumber)
+        : null,
       nickname: user.nickname,
       customerImage: user.customerImage || "",
       userType,
@@ -48,11 +53,34 @@ const userInfo = async (userId: string, userType: TUserRole) => {
       id: user.id,
       name: user.name,
       email: user.email,
-      phoneNumber: user.encryptedPhoneNumber ? decryptPhoneNumber(user.encryptedPhoneNumber) : null,
+      phoneNumber: user.encryptedPhoneNumber
+        ? decryptPhoneNumber(user.encryptedPhoneNumber)
+        : null,
       nickname: user.nickname,
       moverImage: user.moverImage || "",
       userType,
     };
+  }
+};
+
+// 프로필 정보 조회
+const getProfileData = async (userId: string, userType: TUserRole) => {
+  if (userType === "CUSTOMER") {
+    const profile = await getCustomerProfile(userId);
+
+    if (!profile) {
+      throw new NotFoundError(PROFILE_ERROR_MESSAGES.PROFILE_NOT_FOUND);
+    }
+
+    const { encryptedPhoneNumber, ...rest } = profile;
+    const phoneNumber = encryptedPhoneNumber
+      ? decryptPhoneNumber(encryptedPhoneNumber)
+      : null;
+
+    return { ...rest, phoneNumber };
+  } else if (userType === "MOVER") {
+    const profile = await getMoverProfile(userId);
+    return profile;
   }
 };
 
@@ -190,6 +218,7 @@ const updateMoverBasicInfo = async (
 
 export {
   userInfo,
+  getProfileData,
   createCustomerProfile,
   createMoverProfile,
   updateMoverBasicInfo,


### PR DESCRIPTION
## ✨ 작업 개요
- FE의 일반 유저 프로필 수정 페이지에서 기본 값으로 사용하기 위해 정보 조회용으로 제작 하였습니다

## ✅ 주요 작업 내용
- 프로필 조회 라우트 추가(GET)
- userType에 따라 다른 조회 로직이 실행 되도록 구현

## 🔄 관련 이슈
Closes #24
Closes #104

## 📎 참고 자료 (선택)
<img width="755" height="585" alt="image" src="https://github.com/user-attachments/assets/5d885cbb-3451-4e52-a824-ad568080aa02" />

## 📝 비고
- 일반 유저 프로필 FE api 연결 후 마무리 예정입니다. 
