### PR TITLE
[#127, #128, #132] Refactor/review 리뷰에서 사용되는 데이터만 추론 및 스키마 변경에 따른 타입 변경

### DIFF
--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -3,7 +3,11 @@ import reviewService from "../services/review.service";
 
 const reviewController = {
   // 1. 리뷰 작성 (PATCH)
-  postReview: async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  postReview: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
     try {
       const reviewId = Number(req.params.reviewId);
       const { rating, content } = req.body;
@@ -23,7 +27,11 @@ const reviewController = {
   },
 
   // 2. 리뷰 작성 가능한 Quote 리스트 조회
-  getWritableQuotes: async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  getWritableQuotes: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
     try {
       const customerId = Number(req.user?.userId);
       if (!customerId) {
@@ -32,7 +40,10 @@ const reviewController = {
       }
       const page = Number(req.query.page) || 1;
       const pageSize = Number(req.query.pageSize) || 4;
-      const quotes = await reviewService.getWritableQuotes(customerId, { page, pageSize });
+      const quotes = await reviewService.getWritableQuotes(customerId, {
+        page,
+        pageSize,
+      });
       res.json({
         success: true,
         message: "리뷰 작성 가능한 견적 리스트입니다.",
@@ -44,7 +55,11 @@ const reviewController = {
   },
 
   // 3. 내가 쓴 리뷰 목록 조회
-  getWrittenReviews: async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  getWrittenReviews: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
     try {
       const customerId = Number(req.params.customerId);
       if (!customerId) {
@@ -53,7 +68,10 @@ const reviewController = {
       }
       const page = Number(req.query.page) || 1;
       const pageSize = Number(req.query.pageSize) || 4;
-      const reviews = await reviewService.getWrittenReviews(customerId, { page, pageSize });
+      const reviews = await reviewService.getWrittenReviews(customerId, {
+        page,
+        pageSize,
+      });
       res.json({
         success: true,
         message: "내가 쓴 리뷰 목록입니다.",
@@ -77,7 +95,10 @@ const reviewController = {
       }
       const page = Number(req.query.page) || 1;
       const pageSize = Number(req.query.pageSize) || 5;
-      const reviews = await reviewService.getReceivedReviews(moverId, { page, pageSize });
+      const reviews = await reviewService.getReceivedReviews(moverId, {
+        page,
+        pageSize,
+      });
       res.json({
         success: true,
         message: "내가 받은 리뷰 목록입니다.",

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -9,7 +9,7 @@ const reviewController = {
     next: NextFunction
   ): Promise<void> => {
     try {
-      const reviewId = Number(req.params.reviewId);
+      const reviewId = req.params.reviewId;
       const { rating, content } = req.body;
       if (!reviewId || rating == null || content == null) {
         res.status(400).json({ message: "reviewId, rating, content required" });
@@ -26,28 +26,28 @@ const reviewController = {
     }
   },
 
-  // 2. 리뷰 작성 가능한 Quote 리스트 조회
-  getWritableQuotes: async (
+  // 2. 리뷰 작성 가능한 estimateRequests 리스트 조회
+  getWritableEstimateRequests: async (
     req: Request,
     res: Response,
     next: NextFunction
   ): Promise<void> => {
     try {
-      const customerId = Number(req.user?.userId);
+      const customerId = req.user?.userId;
       if (!customerId) {
         res.status(400).json({ message: "유저를 찾을수 없습니다." });
         return;
       }
       const page = Number(req.query.page) || 1;
       const pageSize = Number(req.query.pageSize) || 4;
-      const quotes = await reviewService.getWritableQuotes(customerId, {
-        page,
-        pageSize,
-      });
+      const estimateRequests = await reviewService.getWritableEstimateRequests(
+        customerId,
+        { page, pageSize }
+      );
       res.json({
         success: true,
-        message: "리뷰 작성 가능한 견적 리스트입니다.",
-        data: quotes,
+        message: "리뷰 작성 가능한 견적 요청 리스트입니다.",
+        data: estimateRequests,
       });
     } catch (error) {
       next(error);
@@ -61,7 +61,7 @@ const reviewController = {
     next: NextFunction
   ): Promise<void> => {
     try {
-      const customerId = Number(req.params.customerId);
+      const customerId = req.params.customerId;
       if (!customerId) {
         res.status(400).json({ message: "유저를 찾을수 없습니다." });
         return;
@@ -88,7 +88,7 @@ const reviewController = {
     next: NextFunction
   ): Promise<void> => {
     try {
-      const moverId = Number(req.params.moverId);
+      const moverId = req.params.moverId;
       if (!moverId) {
         res.status(400).json({ message: "유저를 찾을수 없습니다." });
         return;

--- a/src/db/prisma/migrations/20250722161637_add_review_status/migration.sql
+++ b/src/db/prisma/migrations/20250722161637_add_review_status/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "ReviewStatus" AS ENUM ('PENDING', 'COMPLETED', 'EXPIRED');
+
+-- AlterTable
+ALTER TABLE "reviews" ADD COLUMN     "status" "ReviewStatus" NOT NULL DEFAULT 'PENDING',
+ALTER COLUMN "rating" SET DEFAULT 0,
+ALTER COLUMN "content" SET DEFAULT '';

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -109,6 +109,12 @@ enum ActionType {
   MOVE_DAY_REVIEW_REQUEST // 이사 다음날
 }
 
+enum ReviewStatus {
+  PENDING
+  COMPLETED
+  EXPIRED
+}
+
 //////////////////// MODELS ////////////////////
 
 // 통합 사용자 모델 (일반 고객과 기사님 모두)
@@ -317,14 +323,15 @@ model Estimate {
 
 // 리뷰 테이블 (1개의 견적 요청당 1개만)
 model Review {
-  id                String    @id @default(cuid())
+  id                String       @id @default(cuid())
   customerId        String // 작성자 ID
   moverId           String // 대상 기사님 ID
   estimateRequestId String // 견적 요청 ID
-  rating            Int // 평점 (1-5)
-  content           String // 리뷰 내용
-  createdAt         DateTime  @default(now())
-  updatedAt         DateTime  @updatedAt
+  rating            Int          @default(0)
+  content           String       @default("")
+  status            ReviewStatus @default(PENDING)
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
   deletedAt         DateTime? // 소프트 삭제
 
   // 관계

--- a/src/db/prisma/seed.ts
+++ b/src/db/prisma/seed.ts
@@ -95,7 +95,9 @@ async function main() {
       moverImage: "",
       currentArea: getRandom([RegionType.SEOUL, RegionType.GYEONGGI]),
 
-      preferredServices: [getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE])],
+      preferredServices: [
+        getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE]),
+      ],
       shortIntro: `${allNames[i]}은(는) 친절하고 꼼꼼한 기사입니다!`,
       detailIntro: `${allNames[i]}은(는) 다양한 이사 경험을 바탕으로 최고의 서비스를 제공합니다.`,
       career: 5 + (i % 10),
@@ -104,12 +106,15 @@ async function main() {
       averageRating: 4.2 + (i % 3) * 0.2,
       totalReviewCount: 5 + i,
       currentAreas: [getRandom([RegionType.SEOUL, RegionType.GYEONGGI])],
-      serviceTypes: [getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE])],
+      serviceTypes: [
+        getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE]),
+      ],
       totalFavoriteCount: 0,
     });
   }
-  const users = await Promise.all(userArr.map((data) => prisma.user.create({ data })));
-
+  const users = await Promise.all(
+    userArr.map((data) => prisma.user.create({ data }))
+  );
 
   // 기사님 서비스 지역 (모든 유저)
   const moverUsers = users; // 모든 유저가 기사 역할
@@ -180,7 +185,9 @@ async function main() {
     let estimateRequestIdx, moverIdx, pairKey;
     let tryCount = 0;
     do {
-      estimateRequestIdx = getRandom([...Array(estimateRequests.length).keys()]);
+      estimateRequestIdx = getRandom([
+        ...Array(estimateRequests.length).keys(),
+      ]);
       moverIdx = getRandom([...Array(users.length).keys()]);
       pairKey = `${estimateRequestIdx}_${moverIdx}`;
       tryCount++;
@@ -204,12 +211,10 @@ async function main() {
           includesPackaging: i % 2 === 0,
           insuranceAmount: 1000000 + i * 100000,
         },
-
-      }),
+      })
     );
   }
   const estimates = await Promise.all(estimatesArr);
-
 
   // 찜 100개 생성 (고객이 기사/하이브리드 찜, 모든 유저 랜덤, 중복 방지)
   const favoritePairs = new Set();
@@ -245,10 +250,15 @@ async function main() {
   const usedEstimateRequestIds = new Set();
   const reviewArr = [];
   let reviewCount = 0;
-  while (reviewCount < 30 && usedEstimateRequestIds.size < estimateRequests.length) {
+  while (
+    reviewCount < 30 &&
+    usedEstimateRequestIds.size < estimateRequests.length
+  ) {
     let estimateRequestIdx;
     do {
-      estimateRequestIdx = getRandom([...Array(estimateRequests.length).keys()]);
+      estimateRequestIdx = getRandom([
+        ...Array(estimateRequests.length).keys(),
+      ]);
     } while (usedEstimateRequestIds.has(estimateRequestIdx));
     usedEstimateRequestIds.add(estimateRequestIdx);
 
@@ -266,14 +276,13 @@ async function main() {
           estimateRequestId: estimateRequests[estimateRequestIdx].id,
           rating: 3 + (reviewCount % 3),
           content: `테스트 리뷰 내용 ${reviewCount + 1}`,
+          status: "COMPLETED",
         },
-
-      }),
+      })
     );
     reviewCount++;
   }
   await Promise.all(reviewArr);
-
 
   // 사용자 활동 30개 생성
   const actions = await Promise.all(

--- a/src/middlewares/reviewMiddleware.ts
+++ b/src/middlewares/reviewMiddleware.ts
@@ -1,36 +1,43 @@
 import { Prisma } from "@prisma/client";
 import prisma from "../db/prisma/prisma";
 
-// Prisma 미들웨어: Quote.update에서 confirmedEstimateId가 새로 설정될 때 Review 자동 생성
-export const reviewPrismaMiddleware: Prisma.Middleware = async (params, next) => {
-  if (params.model === "Quote" && params.action === "update" && params.args?.data?.confirmedEstimateId !== undefined) {
-    // 기존 Quote를 먼저 조회
-    const quote = await prisma.quote.findUnique({
+// Prisma 미들웨어: EstimateRequest.update에서 확정 견적이 설정될 때 Review 자동 생성
+export const reviewPrismaMiddleware: Prisma.Middleware = async (
+  params,
+  next
+) => {
+  if (
+    params.model === "EstimateRequest" &&
+    params.action === "update" &&
+    params.args?.data?.status === "COMPLETED"
+  ) {
+    // 기존 EstimateRequest를 먼저 조회
+    const estimateRequest = await prisma.estimateRequest.findUnique({
       where: params.args.where,
-      select: { confirmedEstimateId: true, id: true, userId: true },
+      include: {
+        estimates: true,
+        review: true,
+      },
     });
-    const afterId = params.args.data.confirmedEstimateId;
-    if (quote && !quote.confirmedEstimateId && afterId) {
-      // 이미 해당 quoteId, userId로 리뷰가 있는지 확인
-      const reviewExists = await prisma.review.findFirst({
-        where: {
-          quoteId: quote.id,
-          userId: quote.userId,
-        },
-      });
-      if (!reviewExists) {
-        // estimateId, moverId를 찾아야 할 수 있음
-        const estimate = await prisma.estimate.findUnique({
-          where: { id: afterId },
-          select: { id: true, moverId: true },
+    if (estimateRequest && !estimateRequest.review) {
+      // 확정된 견적 찾기 (status: 'ACCEPTED')
+      const acceptedEstimate = estimateRequest.estimates.find(
+        (e: any) => e.status === "ACCEPTED"
+      );
+      if (acceptedEstimate) {
+        // 이미 해당 estimateRequestId, customerId로 리뷰가 있는지 확인
+        const reviewExists = await prisma.review.findFirst({
+          where: {
+            estimateRequestId: estimateRequest.id,
+            customerId: estimateRequest.customerId,
+          },
         });
-        if (estimate) {
+        if (!reviewExists) {
           await prisma.review.create({
             data: {
-              quoteId: quote.id,
-              estimateId: estimate.id,
-              userId: quote.userId,
-              moverId: estimate.moverId,
+              estimateRequestId: estimateRequest.id,
+              customerId: estimateRequest.customerId,
+              moverId: acceptedEstimate.moverId,
               rating: 0,
               content: "",
             },

--- a/src/repositories/review.repository.ts
+++ b/src/repositories/review.repository.ts
@@ -1,49 +1,43 @@
 import prisma from "../db/prisma/prisma";
-import { ReviewStatus } from "@prisma/client";
 
 const reviewRepository = {
   // 1. 리뷰 작성 (PATCH)
-  postReview: async (reviewId: number, rating: number, content: string) => {
+  postReview: async (reviewId: string, rating: number, content: string) => {
     return prisma.review.update({
       where: { id: reviewId },
-      data: { rating, content, status: ReviewStatus.COMPLETED },
+      data: { rating, content },
     });
   },
 
-  // 2. 리뷰 작성 가능한 Quote 리스트 조회
-  getWritableQuotes: async (userId: number, pageQuery: { page: number; pageSize: number }) => {
+  // 2. 리뷰 작성 가능한 EstimateRequest 리스트 조회
+  getWritableEstimateRequests: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
-      prisma.quote.findMany({
+      prisma.estimateRequest.findMany({
         where: {
-          userId,
-          confirmedEstimateId: { not: null },
-          reviews: {
-            some: { status: ReviewStatus.PENDING },
-          },
+          customerId,
+          status: "COMPLETED",
+          review: null, // 리뷰가 아직 작성되지 않은 견적 요청
         },
         include: {
-          confirmedEstimate: {
+          estimates: {
+            where: { status: "ACCEPTED" },
             include: {
-              mover: {
-                include: {
-                  profile: true,
-                },
-              },
+              mover: { include: { profile: true } },
             },
           },
+          fromAddress: true,
+          toAddress: true,
         },
         skip,
         take: pageSize,
       }),
-      prisma.quote.count({
+      prisma.estimateRequest.count({
         where: {
-          userId,
-          confirmedEstimateId: { not: null },
-          reviews: {
-            some: { status: ReviewStatus.PENDING },
-          },
+          customerId,
+          status: "COMPLETED",
+          review: null,
         },
       }),
     ]);
@@ -51,43 +45,46 @@ const reviewRepository = {
   },
 
   // 3. 내가 쓴 리뷰 목록 조회
-  getWrittenReviews: async (userId: number, pageQuery: { page: number; pageSize: number }) => {
+  getWrittenReviews: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
       prisma.review.findMany({
-        where: { userId },
+        where: { customerId },
         include: {
-          quote: true,
-          estimate: true,
-          mover: {
+          estimateRequest: {
             include: {
-              profile: true,
+              fromAddress: true,
+              toAddress: true,
             },
           },
+          estimate: true,
+          mover: { include: { profile: true } },
         },
         skip,
         take: pageSize,
       }),
-      prisma.review.count({ where: { userId } }),
+      prisma.review.count({ where: { customerId } }),
     ]);
     return { items, total, page, pageSize };
   },
+
   // 4. 내가 받은 리뷰 목록 조회
-  getReceivedReviews: async (moverId: number, pageQuery: { page: number; pageSize: number }) => {
+  getReceivedReviews: async (moverId: string, pageQuery: { page: number; pageSize: number }) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
       prisma.review.findMany({
         where: { moverId },
         include: {
-          quote: true,
-          estimate: true,
-          user: {
+          estimateRequest: {
             include: {
-              profile: true,
+              fromAddress: true,
+              toAddress: true,
             },
           },
+          estimate: true,
+          writer: { include: { profile: true } },
         },
         skip,
         take: pageSize,

--- a/src/repositories/review.repository.ts
+++ b/src/repositories/review.repository.ts
@@ -9,8 +9,11 @@ const reviewRepository = {
     });
   },
 
-  // 2. 리뷰 작성 가능한 EstimateRequest 리스트 조회
-  getWritableEstimateRequests: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
+  // 2. 리뷰 작성 가능한 견적 요청 리스트 조회
+  getWritableEstimateRequests: async (
+    customerId: string,
+    pageQuery: { page: number; pageSize: number }
+  ) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
@@ -18,17 +21,18 @@ const reviewRepository = {
         where: {
           customerId,
           status: "COMPLETED",
-          review: null, // 리뷰가 아직 작성되지 않은 견적 요청
+          review: { is: { status: "PENDING" } },
         },
         include: {
           estimates: {
             where: { status: "ACCEPTED" },
             include: {
-              mover: { include: { profile: true } },
+              mover: true,
             },
           },
           fromAddress: true,
           toAddress: true,
+          review: true,
         },
         skip,
         take: pageSize,
@@ -37,7 +41,7 @@ const reviewRepository = {
         where: {
           customerId,
           status: "COMPLETED",
-          review: null,
+          review: { is: { status: "PENDING" } },
         },
       }),
     ]);
@@ -45,21 +49,24 @@ const reviewRepository = {
   },
 
   // 3. 내가 쓴 리뷰 목록 조회
-  getWrittenReviews: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
+  getWrittenReviews: async (
+    customerId: string,
+    pageQuery: { page: number; pageSize: number }
+  ) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
       prisma.review.findMany({
         where: { customerId },
         include: {
-          estimateRequest: {
+          request: {
             include: {
               fromAddress: true,
               toAddress: true,
+              estimates: true,
             },
           },
-          estimate: true,
-          mover: { include: { profile: true } },
+          mover: true,
         },
         skip,
         take: pageSize,
@@ -70,21 +77,24 @@ const reviewRepository = {
   },
 
   // 4. 내가 받은 리뷰 목록 조회
-  getReceivedReviews: async (moverId: string, pageQuery: { page: number; pageSize: number }) => {
+  getReceivedReviews: async (
+    moverId: string,
+    pageQuery: { page: number; pageSize: number }
+  ) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
       prisma.review.findMany({
         where: { moverId },
         include: {
-          estimateRequest: {
+          request: {
             include: {
               fromAddress: true,
               toAddress: true,
+              estimates: true,
             },
           },
-          estimate: true,
-          writer: { include: { profile: true } },
+          writer: true,
         },
         skip,
         take: pageSize,

--- a/src/repositories/review.repository.ts
+++ b/src/repositories/review.repository.ts
@@ -24,9 +24,14 @@ const reviewRepository = {
           },
         },
         include: {
-          confirmedEstimate: true,
-          reviews: {
-            where: { status: ReviewStatus.PENDING },
+          confirmedEstimate: {
+            include: {
+              mover: {
+                include: {
+                  profile: true,
+                },
+              },
+            },
           },
         },
         skip,
@@ -55,6 +60,11 @@ const reviewRepository = {
         include: {
           quote: true,
           estimate: true,
+          mover: {
+            include: {
+              profile: true,
+            },
+          },
         },
         skip,
         take: pageSize,
@@ -73,6 +83,11 @@ const reviewRepository = {
         include: {
           quote: true,
           estimate: true,
+          user: {
+            include: {
+              profile: true,
+            },
+          },
         },
         skip,
         take: pageSize,

--- a/src/routes/review.route.ts
+++ b/src/routes/review.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import reviewController from "../controllers/review.controller";
+import { verifyAccessToken } from "../middlewares/verifyToken";
 
 const reviewRouter = Router();
 
@@ -32,7 +33,11 @@ const reviewRouter = Router();
  *   }
  * }
  */
-reviewRouter.patch("/:reviewId", reviewController.postReview);
+reviewRouter.patch(
+  "/:reviewId",
+  verifyAccessToken,
+  reviewController.postReview
+);
 
 /**
  * GET /reviews/writable-quotes
@@ -48,17 +53,34 @@ reviewRouter.patch("/:reviewId", reviewController.postReview);
  *   "success": true,
  *   "message": "리뷰 작성 가능한 견적 리스트입니다.",
  *   "data": {
- *     "items": [ ... ],
- *     "total": 8,
+ *     "items": [
+ *       {
+ *         "id": "123",
+ *         "profileImage": "https://.../profile.png", // 기사 프로필 이미지 URL
+ *         "nickname": "김코드 기사님", // 기사 이름
+ *         "movingType": "SMALL", // 이사 유형
+ *         "isDesigned": true, // 지정 견적 여부
+ *         "moverIntroduction": "이사부터 정리까지 꼼꼼한 마무리!", // 기사 소개
+ *         "departureAddr": "서울시 중구", // 출발지 주소
+ *         "arrivalAddr": "경기도 수원시", // 도착지 주소
+ *         "movingDate": "2024-07-01", // 이사 예정일(ISO 8601)
+ *         "price": 180000 // 이사 비용(견적가)
+ *       }
+ *     ],
+ *     "total": 3,
  *     "page": 1,
  *     "pageSize": 4
  *   }
  * }
  */
-reviewRouter.get("/writable-quotes", reviewController.getWritableQuotes);
+reviewRouter.get(
+  "/writable-quotes",
+  verifyAccessToken,
+  reviewController.getWritableQuotes
+);
 
 /**
- * GET /reviews/customer/{customerId}
+ * GET /reviews/customer/:customerId
  * @summary 내가 쓴 리뷰 목록 조회
  * @description 내가 작성한 리뷰 목록을 조회합니다.
  * @tags Review
@@ -71,17 +93,37 @@ reviewRouter.get("/writable-quotes", reviewController.getWritableQuotes);
  *   "success": true,
  *   "message": "내가 쓴 리뷰 목록입니다.",
  *   "data": {
- *     "items": [ ... ],
+ *     "items": [
+ *       {
+ *         "id": 1, // 리뷰 ID
+ *         "moverId": 7, // 기사님 ID
+ *         "profileImage": "https://.../profile.png", // 기사 프로필 이미지 URL
+ *         "nickname": "김코드 기사님", // 기사 이름
+ *         "moverIntroduction": "이사부터 정리까지 꼼꼼한 마무리!", // 기사 소개
+ *         "movingType": "SMALL", // 이사 유형
+ *         "isDesigned": true, // 지정 견적 여부
+ *         "departureAddr": "서울시 중구", // 출발지 주소
+ *         "arrivalAddr": "경기도 수원시", // 도착지 주소
+ *         "movingDate": "2024-07-01", // 이사일(ISO 8601)
+ *         "rating": 5, // 별점
+ *         "content": "아주 만족스러웠어요!", // 리뷰 내용
+ *         "createdAt": "2024-07-18T12:34:56.000Z" // 리뷰 작성일시(ISO 8601)
+ *       }
+ *     ],
  *     "total": 12,
  *     "page": 1,
  *     "pageSize": 4
  *   }
  * }
  */
-reviewRouter.get("/customer/:customerId", reviewController.getWrittenReviews);
+reviewRouter.get(
+  "/customer/:customerId",
+  verifyAccessToken,
+  reviewController.getWrittenReviews
+);
 
 /**
- * GET /reviews/mover/{moverId}
+ * GET /reviews/mover/:moverId
  * @summary 내가 받은 리뷰 목록 조회
  * @description 내가 받은 리뷰 목록을 조회합니다.
  * @tags Review
@@ -94,13 +136,84 @@ reviewRouter.get("/customer/:customerId", reviewController.getWrittenReviews);
  *   "success": true,
  *   "message": "내가 받은 리뷰 목록입니다.",
  *   "data": {
- *     "items": [ ... ],
+ *     "items": [
+ *       {
+ *         "id": 1,
+ *         "quoteId": 10,
+ *         "estimateId": 20,
+ *         "userId": 5,
+ *         "moverId": 7,
+ *         "rating": 4,
+ *         "content": "기사님이 친절하게 잘 해주셨어요!",
+ *         "status": "COMPLETED",
+ *         "isPublic": true,
+ *         "deletedAt": null,
+ *         "createdAt": "2024-07-11T09:12:34.000Z",
+ *         "updatedAt": "2024-07-11T09:12:34.000Z",
+ *         "quote": {
+ *           "id": 10,
+ *           "userId": 5,
+ *           "movingType": "HOME",
+ *           "movingDate": "2024-07-10T00:00:00.000Z",
+ *           "departureAddr": "서울시 강남구",
+ *           "arrivalAddr": "경기도 고양시",
+ *           "departureDetail": "101동 202호",
+ *           "arrivalDetail": "301동 404호",
+ *           "departureRegion": "SEOUL",
+ *           "arrivalRegion": "GYEONGGI",
+ *           "description": "가구가 많아요",
+ *           "status": "COMPLETED",
+ *           "confirmedEstimateId": 20,
+ *           "estimatedDistance": 25.5,
+ *           "floor": 10,
+ *           "hasElevator": true,
+ *           "estimateCount": 3,
+ *           "isUrgent": false,
+ *           "maxBudget": 200000,
+ *           "maxEstimateCount": 8,
+ *           "designatedEstimateCount": 1,
+ *           "maxDesignatedEstimates": 3,
+ *           "departureZipCode": "12345",
+ *           "arrivalZipCode": "54321",
+ *           "departureLatitude": 37.12345,
+ *           "departureLongitude": 127.12345,
+ *           "arrivalLatitude": 37.54321,
+ *           "arrivalLongitude": 127.54321,
+ *           "deletedAt": null,
+ *           "createdAt": "2024-07-01T10:00:00.000Z",
+ *           "updatedAt": "2024-07-10T09:00:00.000Z"
+ *         },
+ *         "estimate": {
+ *           "id": 20,
+ *           "quoteId": 10,
+ *           "moverId": 7,
+ *           "price": 180000,
+ *           "description": "포장 포함, 추가 비용 없음",
+ *           "status": "ACCEPTED",
+ *           "isDesignated": true,
+ *           "designatedEstimateRequestId": null,
+ *           "validUntil": "2024-07-09T23:59:59.000Z",
+ *           "responseTime": 30,
+ *           "isReadByCustomer": true,
+ *           "workingHours": "4-6시간",
+ *           "includesPackaging": true,
+ *           "insuranceAmount": 1000000,
+ *           "deletedAt": null,
+ *           "createdAt": "2024-07-01T12:00:00.000Z",
+ *           "updatedAt": "2024-07-10T09:00:00.000Z"
+ *         }
+ *       }
+ *     ],
  *     "total": 7,
  *     "page": 1,
  *     "pageSize": 5
  *   }
  * }
  */
-reviewRouter.get("/mover/:moverId", reviewController.getReceivedReviews);
+reviewRouter.get(
+  "/mover/:moverId",
+  verifyAccessToken,
+  reviewController.getReceivedReviews
+);
 
 export default reviewRouter;

--- a/src/routes/review.route.ts
+++ b/src/routes/review.route.ts
@@ -5,12 +5,12 @@ import { verifyAccessToken } from "../middlewares/verifyToken";
 const reviewRouter = Router();
 
 /**
- * PATCH /reviews/{reviewId}
+ * PATCH /reviews/:reviewId
  * @summary 리뷰 작성(완료 처리)
  * @description 리뷰를 작성(완료 처리)합니다.
  * @tags Review
  * @security BearerAuth
- * @param {number} reviewId.path.required - 리뷰 ID
+ * @param {string} reviewId.path.required - 리뷰 ID (cuid)
  * @param {object} request.body.required - 리뷰 작성 정보
  * @param {number} request.body.rating.required - 평점 (1~5)
  * @param {string} request.body.content.required - 리뷰 내용
@@ -25,11 +25,14 @@ const reviewRouter = Router();
  *   "success": true,
  *   "message": "리뷰가 작성되었습니다.",
  *   "data": {
- *     "id": 1,
- *     "rating": 5,
- *     "content": "정말 친절하고 만족스러운 서비스였습니다!",
- *     "status": "COMPLETED",
- *     "createdAt": "2025-07-10T00:33:16.456Z"
+ *     "id": "clx...", // 리뷰 ID (cuid)
+ *     "customerId": "clx...", // 리뷰 작성자(고객) ID (cuid)
+ *     "moverId": "clx...", // 기사님 ID (cuid)
+ *     "estimateRequestId": "clx...", // 견적 요청 ID (cuid)
+ *     "rating": 5, // 평점
+ *     "content": "정말 친절하고 만족스러운 서비스였습니다!", // 리뷰 내용
+ *     "status": "COMPLETED", // 리뷰 상태
+ *     "createdAt": "2025-07-10T00:33:16.456Z" // 리뷰 작성일시(ISO 8601)
  *   }
  * }
  */
@@ -40,30 +43,40 @@ reviewRouter.patch(
 );
 
 /**
- * GET /reviews/writable-quotes
- * @summary 리뷰 작성 가능한 견적 리스트 조회
- * @description 리뷰를 작성할 수 있는 견적 리스트를 조회합니다.
+ * GET /reviews/writable-estimateRequests
+ * @summary 리뷰 작성 가능한 견적 요청 리스트 조회
+ * @description 리뷰를 작성할 수 있는 견적 요청 리스트를 조회합니다.
  * @tags Review
  * @security BearerAuth
  * @param {number} page.query - 페이지 번호 (기본값: 1)
  * @param {number} pageSize.query - 페이지당 개수 (기본값: 4)
- * @returns {object} 200 - 리뷰 작성 가능한 견적 리스트 조회 성공
+ * @returns {object} 200 - 리뷰 작성 가능한 견적 요청 리스트 조회 성공
  * @example response - 200 - 성공 예시
  * {
  *   "success": true,
- *   "message": "리뷰 작성 가능한 견적 리스트입니다.",
+ *   "message": "리뷰 작성 가능한 견적 요청 리스트입니다.",
  *   "data": {
  *     "items": [
  *       {
- *         "id": "123",
+ *         "id": "clx...", // 견적 요청 ID (cuid)
  *         "profileImage": "https://.../profile.png", // 기사 프로필 이미지 URL
- *         "nickname": "김코드 기사님", // 기사 이름
- *         "movingType": "SMALL", // 이사 유형
+ *         "nickname": "김코드 기사님", // 기사 닉네임
+ *         "moveType": "SMALL", // 이사 유형
  *         "isDesigned": true, // 지정 견적 여부
  *         "moverIntroduction": "이사부터 정리까지 꼼꼼한 마무리!", // 기사 소개
- *         "departureAddr": "서울시 중구", // 출발지 주소
- *         "arrivalAddr": "경기도 수원시", // 도착지 주소
- *         "movingDate": "2024-07-01", // 이사 예정일(ISO 8601)
+ *         "fromAddress": {
+ *           "city": "서울시 중구",
+ *           "district": "을지로동",
+ *           "detail": "101동 202호",
+ *           "region": "SEOUL"
+ *         },
+ *         "toAddress": {
+ *           "city": "경기도 수원시",
+ *           "district": "영통구",
+ *           "detail": "301동 404호",
+ *           "region": "GYEONGGI"
+ *         },
+ *         "moveDate": "2024-07-01T00:00:00.000Z", // 이사 예정일(ISO 8601)
  *         "price": 180000 // 이사 비용(견적가)
  *       }
  *     ],
@@ -74,9 +87,9 @@ reviewRouter.patch(
  * }
  */
 reviewRouter.get(
-  "/writable-quotes",
+  "/writable-estimateRequests",
   verifyAccessToken,
-  reviewController.getWritableQuotes
+  reviewController.getWritableEstimateRequests
 );
 
 /**
@@ -84,7 +97,7 @@ reviewRouter.get(
  * @summary 내가 쓴 리뷰 목록 조회
  * @description 내가 작성한 리뷰 목록을 조회합니다.
  * @tags Review
- * @param {number} customerId.path.required - 고객 ID
+ * @param {string} customerId.path.required - 고객 ID
  * @param {number} page.query - 페이지 번호 (기본값: 1)
  * @param {number} pageSize.query - 페이지당 개수 (기본값: 4)
  * @returns {object} 200 - 내가 쓴 리뷰 목록 조회 성공
@@ -95,16 +108,26 @@ reviewRouter.get(
  *   "data": {
  *     "items": [
  *       {
- *         "id": 1, // 리뷰 ID
- *         "moverId": 7, // 기사님 ID
+ *         "id": "clx...", // 리뷰 ID (cuid)
+ *         "moverId": "clx...", // 기사님 ID (cuid)
  *         "profileImage": "https://.../profile.png", // 기사 프로필 이미지 URL
- *         "nickname": "김코드 기사님", // 기사 이름
+ *         "nickname": "김코드 기사님", // 기사 닉네임
  *         "moverIntroduction": "이사부터 정리까지 꼼꼼한 마무리!", // 기사 소개
- *         "movingType": "SMALL", // 이사 유형
+ *         "moveType": "SMALL", // 이사 유형
  *         "isDesigned": true, // 지정 견적 여부
- *         "departureAddr": "서울시 중구", // 출발지 주소
- *         "arrivalAddr": "경기도 수원시", // 도착지 주소
- *         "movingDate": "2024-07-01", // 이사일(ISO 8601)
+ *         "fromAddress": {
+ *           "city": "서울시 중구",
+ *           "district": "을지로동",
+ *           "detail": "101동 202호",
+ *           "region": "SEOUL"
+ *         },
+ *         "toAddress": {
+ *           "city": "경기도 수원시",
+ *           "district": "영통구",
+ *           "detail": "301동 404호",
+ *           "region": "GYEONGGI"
+ *         },
+ *         "moveDate": "2024-07-01T00:00:00.000Z", // 이사 날짜(ISO 8601)
  *         "rating": 5, // 별점
  *         "content": "아주 만족스러웠어요!", // 리뷰 내용
  *         "createdAt": "2024-07-18T12:34:56.000Z" // 리뷰 작성일시(ISO 8601)
@@ -112,7 +135,7 @@ reviewRouter.get(
  *     ],
  *     "total": 12,
  *     "page": 1,
- *     "pageSize": 4
+ *     "pageSize": 10
  *   }
  * }
  */
@@ -127,7 +150,7 @@ reviewRouter.get(
  * @summary 내가 받은 리뷰 목록 조회
  * @description 내가 받은 리뷰 목록을 조회합니다.
  * @tags Review
- * @param {number} moverId.path.required - 기사님 ID
+ * @param {string} moverId.path.required - 기사님 ID
  * @param {number} page.query - 페이지 번호 (기본값: 1)
  * @param {number} pageSize.query - 페이지당 개수 (기본값: 5)
  * @returns {object} 200 - 내가 받은 리뷰 목록 조회 성공
@@ -138,70 +161,30 @@ reviewRouter.get(
  *   "data": {
  *     "items": [
  *       {
- *         "id": 1,
- *         "quoteId": 10,
- *         "estimateId": 20,
- *         "userId": 5,
- *         "moverId": 7,
- *         "rating": 4,
- *         "content": "기사님이 친절하게 잘 해주셨어요!",
- *         "status": "COMPLETED",
- *         "isPublic": true,
- *         "deletedAt": null,
- *         "createdAt": "2024-07-11T09:12:34.000Z",
- *         "updatedAt": "2024-07-11T09:12:34.000Z",
- *         "quote": {
- *           "id": 10,
- *           "userId": 5,
- *           "movingType": "HOME",
- *           "movingDate": "2024-07-10T00:00:00.000Z",
- *           "departureAddr": "서울시 강남구",
- *           "arrivalAddr": "경기도 고양시",
- *           "departureDetail": "101동 202호",
- *           "arrivalDetail": "301동 404호",
- *           "departureRegion": "SEOUL",
- *           "arrivalRegion": "GYEONGGI",
- *           "description": "가구가 많아요",
- *           "status": "COMPLETED",
- *           "confirmedEstimateId": 20,
- *           "estimatedDistance": 25.5,
- *           "floor": 10,
- *           "hasElevator": true,
- *           "estimateCount": 3,
- *           "isUrgent": false,
- *           "maxBudget": 200000,
- *           "maxEstimateCount": 8,
- *           "designatedEstimateCount": 1,
- *           "maxDesignatedEstimates": 3,
- *           "departureZipCode": "12345",
- *           "arrivalZipCode": "54321",
- *           "departureLatitude": 37.12345,
- *           "departureLongitude": 127.12345,
- *           "arrivalLatitude": 37.54321,
- *           "arrivalLongitude": 127.54321,
- *           "deletedAt": null,
- *           "createdAt": "2024-07-01T10:00:00.000Z",
- *           "updatedAt": "2024-07-10T09:00:00.000Z"
+ *         "id": "clx...", // 리뷰 ID (cuid)
+ *         "estimateRequestId": "clx...", // 견적 요청 ID (cuid)
+ *         "customerId": "clx...", // 리뷰 작성자(고객) ID (cuid)
+ *         "moverId": "clx...", // 기사님 ID (cuid)
+ *         "profileImage": "https://.../profile.png", // 고객 프로필 이미지 URL
+ *         "nickname": "홍길동", // 고객 닉네임
+ *         "moveType": "SMALL", // 이사 유형
+ *         "isDesigned": true, // 지정 견적 여부
+ *         "fromAddress": {
+ *           "city": "서울시 강남구",
+ *           "district": "역삼동",
+ *           "detail": "101동 202호",
+ *           "region": "SEOUL"
  *         },
- *         "estimate": {
- *           "id": 20,
- *           "quoteId": 10,
- *           "moverId": 7,
- *           "price": 180000,
- *           "description": "포장 포함, 추가 비용 없음",
- *           "status": "ACCEPTED",
- *           "isDesignated": true,
- *           "designatedEstimateRequestId": null,
- *           "validUntil": "2024-07-09T23:59:59.000Z",
- *           "responseTime": 30,
- *           "isReadByCustomer": true,
- *           "workingHours": "4-6시간",
- *           "includesPackaging": true,
- *           "insuranceAmount": 1000000,
- *           "deletedAt": null,
- *           "createdAt": "2024-07-01T12:00:00.000Z",
- *           "updatedAt": "2024-07-10T09:00:00.000Z"
- *         }
+ *         "toAddress": {
+ *           "city": "경기도 고양시",
+ *           "district": "일산동구",
+ *           "detail": "301동 404호",
+ *           "region": "GYEONGGI"
+ *         },
+ *         "moveDate": "2024-07-10T00:00:00.000Z", // 이사 날짜(ISO 8601)
+ *         "rating": 4, // 별점
+ *         "content": "기사님이 친절하게 잘 해주셨어요!", // 리뷰 내용
+ *         "createdAt": "2024-07-11T09:12:34.000Z" // 리뷰 작성일시(ISO 8601)
  *       }
  *     ],
  *     "total": 7,

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -5,20 +5,25 @@ const reviewService = {
     return reviewRepository.postReview(reviewId, rating, content);
   },
 
-  getWritableEstimateRequests: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
-    const { items, total, page, pageSize } = await reviewRepository.getWritableEstimateRequests(customerId, pageQuery);
-    // FE가 원하는 필드만 추출 (예시)
+  getWritableEstimateRequests: async (
+    customerId: string,
+    pageQuery: { page: number; pageSize: number }
+  ) => {
+    const { items, total, page, pageSize } =
+      await reviewRepository.getWritableEstimateRequests(customerId, pageQuery);
     const mappedItems = items.map((req: any) => {
-      const acceptedEstimate = req.estimates?.find((e: any) => e.status === "ACCEPTED");
+      const acceptedEstimate = req.estimates?.find(
+        (e: any) => e.status === "ACCEPTED"
+      );
       return {
         id: req.id,
-        profileImage: acceptedEstimate?.mover?.profile?.profileImage ?? null,
-        nickname: acceptedEstimate?.mover?.profile?.nickname ?? null,
+        profileImage: acceptedEstimate?.mover?.profileImage ?? null,
+        nickname: acceptedEstimate?.mover?.nickname ?? null,
         moveType: req.moveType,
         isDesigned: acceptedEstimate?.isDesignated ?? false,
-        moverIntroduction: acceptedEstimate?.mover?.profile?.introduction ?? null,
-        fromAddress: req.fromAddress,
-        toAddress: req.toAddress,
+        moverIntroduction: acceptedEstimate?.mover?.introduction ?? null,
+        fromAddress: req.fromAddress ?? null,
+        toAddress: req.toAddress ?? null,
         moveDate: req.moveDate,
         price: acceptedEstimate?.price ?? null,
       };
@@ -26,20 +31,27 @@ const reviewService = {
     return { items: mappedItems, total, page, pageSize };
   },
 
-  getWrittenReviews: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
-    const { items, total, page, pageSize } = await reviewRepository.getWrittenReviews(customerId, pageQuery);
+  getWrittenReviews: async (
+    customerId: string,
+    pageQuery: { page: number; pageSize: number }
+  ) => {
+    const { items, total, page, pageSize } =
+      await reviewRepository.getWrittenReviews(customerId, pageQuery);
     const mappedItems = items.map((review: any) => {
+      const acceptedEstimate = review.request?.estimates?.find(
+        (e: any) => e.status === "ACCEPTED"
+      );
       return {
         id: review.id,
         moverId: review.moverId,
-        profileImage: review.mover?.profile?.profileImage ?? null,
-        nickname: review.mover?.profile?.nickname ?? null,
-        moverIntroduction: review.mover?.profile?.introduction ?? null,
-        moveType: review.estimateRequest?.moveType ?? null,
-        isDesigned: review.estimate?.isDesignated ?? false,
-        fromAddress: review.estimateRequest?.fromAddress ?? null,
-        toAddress: review.estimateRequest?.toAddress ?? null,
-        moveDate: review.estimateRequest?.moveDate ?? null,
+        profileImage: review.mover?.profileImage ?? null,
+        nickname: review.mover?.nickname ?? null,
+        moverIntroduction: review.mover?.introduction ?? null,
+        moveType: review.request?.moveType ?? null,
+        isDesigned: acceptedEstimate?.isDesignated ?? false,
+        fromAddress: review.request?.fromAddress ?? null,
+        toAddress: review.request?.toAddress ?? null,
+        moveDate: review.request?.moveDate ?? null,
         rating: review.rating,
         content: review.content,
         createdAt: review.createdAt,
@@ -48,21 +60,49 @@ const reviewService = {
     return { items: mappedItems, total, page, pageSize };
   },
 
-  getReceivedReviews: async (moverId: string, pageQuery: { page: number; pageSize: number }) => {
-    const { items, total, page, pageSize } = await reviewRepository.getReceivedReviews(moverId, pageQuery);
-    const mappedItems = items.map((review: any) => ({
-      id: review.id,
-      customerId: review.customerId,
-      nickname: review.writer?.profile?.nickname ?? null,
-      profileImage: review.writer?.profile?.profileImage ?? null,
-      moveType: review.estimateRequest?.moveType ?? null,
-      fromAddress: review.estimateRequest?.fromAddress ?? null,
-      toAddress: review.estimateRequest?.toAddress ?? null,
-      moveDate: review.estimateRequest?.moveDate ?? null,
-      rating: review.rating,
-      content: review.content,
-      createdAt: review.createdAt,
-    }));
+  getReceivedReviews: async (
+    moverId: string,
+    pageQuery: { page: number; pageSize: number }
+  ) => {
+    const { items, total, page, pageSize } =
+      await reviewRepository.getReceivedReviews(moverId, pageQuery);
+    const mappedItems = items.map((review: any) => {
+      const acceptedEstimate = review.request?.estimates?.find(
+        (e: any) => e.status === "ACCEPTED"
+      );
+      return {
+        id: review.id,
+        estimateRequestId: review.request?.id ?? null,
+        customerId: review.customerId,
+        moverId: review.moverId,
+        profileImage: review.writer?.profileImage ?? null,
+        nickname: review.writer?.nickname ?? null,
+        moveType: review.request?.moveType ?? null,
+        isDesigned: acceptedEstimate?.isDesignated ?? false,
+        moverIntroduction: review.writer?.introduction ?? null,
+        fromAddress: review.request?.fromAddress ?? null,
+        toAddress: review.request?.toAddress ?? null,
+        moveDate: review.request?.moveDate ?? null,
+        rating: review.rating,
+        content: review.content,
+        createdAt: review.createdAt,
+        estimate: acceptedEstimate
+          ? {
+              id: acceptedEstimate.id,
+              price: acceptedEstimate.price,
+              comment: acceptedEstimate.comment,
+              status: acceptedEstimate.status,
+              isDesignated: acceptedEstimate.isDesignated,
+              validUntil: acceptedEstimate.validUntil,
+              workingHours: acceptedEstimate.workingHours,
+              includesPackaging: acceptedEstimate.includesPackaging,
+              insuranceAmount: acceptedEstimate.insuranceAmount,
+              createdAt: acceptedEstimate.createdAt,
+              updatedAt: acceptedEstimate.updatedAt,
+            }
+          : null,
+      };
+    });
     return { items: mappedItems, total, page, pageSize };
   },
 };

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -1,30 +1,33 @@
 import reviewRepository from "../repositories/review.repository";
 
 const reviewService = {
-  postReview: async (reviewId: number, rating: number, content: string) => {
+  postReview: async (reviewId: string, rating: number, content: string) => {
     return reviewRepository.postReview(reviewId, rating, content);
   },
 
-  getWritableQuotes: async (customerId: number, pageQuery: { page: number; pageSize: number }) => {
-    const { items, total, page, pageSize } = await reviewRepository.getWritableQuotes(customerId, pageQuery);
-    const mappedItems = items.map((quote: any) => ({
-      id: quote.id,
-      profileImage: quote.confirmedEstimate?.mover?.profile?.profileImage ?? null,
-      nickname: quote.confirmedEstimate?.mover?.profile?.nickname ?? null,
-      movingType: quote.movingType,
-      isDesigned: quote.confirmedEstimate?.isDesignated ?? false,
-      moverIntroduction: quote.confirmedEstimate?.mover?.profile?.introduction ?? null,
-      departureAddr: quote.departureAddr,
-      arrivalAddr: quote.arrivalAddr,
-      movingDate: quote.movingDate,
-      price: quote.confirmedEstimate?.price ?? null,
-    }));
+  getWritableEstimateRequests: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
+    const { items, total, page, pageSize } = await reviewRepository.getWritableEstimateRequests(customerId, pageQuery);
+    // FE가 원하는 필드만 추출 (예시)
+    const mappedItems = items.map((req: any) => {
+      const acceptedEstimate = req.estimates?.find((e: any) => e.status === "ACCEPTED");
+      return {
+        id: req.id,
+        profileImage: acceptedEstimate?.mover?.profile?.profileImage ?? null,
+        nickname: acceptedEstimate?.mover?.profile?.nickname ?? null,
+        moveType: req.moveType,
+        isDesigned: acceptedEstimate?.isDesignated ?? false,
+        moverIntroduction: acceptedEstimate?.mover?.profile?.introduction ?? null,
+        fromAddress: req.fromAddress,
+        toAddress: req.toAddress,
+        moveDate: req.moveDate,
+        price: acceptedEstimate?.price ?? null,
+      };
+    });
     return { items: mappedItems, total, page, pageSize };
   },
 
-  getWrittenReviews: async (customerId: number, pageQuery: { page: number; pageSize: number }) => {
+  getWrittenReviews: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
     const { items, total, page, pageSize } = await reviewRepository.getWrittenReviews(customerId, pageQuery);
-    // FE가 원하는 필드만 추출
     const mappedItems = items.map((review: any) => {
       return {
         id: review.id,
@@ -32,11 +35,11 @@ const reviewService = {
         profileImage: review.mover?.profile?.profileImage ?? null,
         nickname: review.mover?.profile?.nickname ?? null,
         moverIntroduction: review.mover?.profile?.introduction ?? null,
-        movingType: review.quote?.movingType ?? null,
+        moveType: review.estimateRequest?.moveType ?? null,
         isDesigned: review.estimate?.isDesignated ?? false,
-        departureAddr: review.quote?.departureAddr ?? null,
-        arrivalAddr: review.quote?.arrivalAddr ?? null,
-        movingDate: review.quote?.movingDate ?? null,
+        fromAddress: review.estimateRequest?.fromAddress ?? null,
+        toAddress: review.estimateRequest?.toAddress ?? null,
+        moveDate: review.estimateRequest?.moveDate ?? null,
         rating: review.rating,
         content: review.content,
         createdAt: review.createdAt,
@@ -44,17 +47,18 @@ const reviewService = {
     });
     return { items: mappedItems, total, page, pageSize };
   },
-  getReceivedReviews: async (moverId: number, pageQuery: { page: number; pageSize: number }) => {
+
+  getReceivedReviews: async (moverId: string, pageQuery: { page: number; pageSize: number }) => {
     const { items, total, page, pageSize } = await reviewRepository.getReceivedReviews(moverId, pageQuery);
     const mappedItems = items.map((review: any) => ({
       id: review.id,
-      userId: review.userId,
-      nickname: review.user?.profile?.nickname ?? null,
-      profileImage: review.user?.profile?.profileImage ?? null,
-      movingType: review.quote?.movingType ?? null,
-      departureAddr: review.quote?.departureAddr ?? null,
-      arrivalAddr: review.quote?.arrivalAddr ?? null,
-      movingDate: review.quote?.movingDate ?? null,
+      customerId: review.customerId,
+      nickname: review.writer?.profile?.nickname ?? null,
+      profileImage: review.writer?.profile?.profileImage ?? null,
+      moveType: review.estimateRequest?.moveType ?? null,
+      fromAddress: review.estimateRequest?.fromAddress ?? null,
+      toAddress: review.estimateRequest?.toAddress ?? null,
+      moveDate: review.estimateRequest?.moveDate ?? null,
       rating: review.rating,
       content: review.content,
       createdAt: review.createdAt,

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -6,14 +6,60 @@ const reviewService = {
   },
 
   getWritableQuotes: async (customerId: number, pageQuery: { page: number; pageSize: number }) => {
-    return reviewRepository.getWritableQuotes(customerId, pageQuery);
+    const { items, total, page, pageSize } = await reviewRepository.getWritableQuotes(customerId, pageQuery);
+    const mappedItems = items.map((quote: any) => ({
+      id: quote.id,
+      profileImage: quote.confirmedEstimate?.mover?.profile?.profileImage ?? null,
+      nickname: quote.confirmedEstimate?.mover?.profile?.nickname ?? null,
+      movingType: quote.movingType,
+      isDesigned: quote.confirmedEstimate?.isDesignated ?? false,
+      moverIntroduction: quote.confirmedEstimate?.mover?.profile?.introduction ?? null,
+      departureAddr: quote.departureAddr,
+      arrivalAddr: quote.arrivalAddr,
+      movingDate: quote.movingDate,
+      price: quote.confirmedEstimate?.price ?? null,
+    }));
+    return { items: mappedItems, total, page, pageSize };
   },
 
   getWrittenReviews: async (customerId: number, pageQuery: { page: number; pageSize: number }) => {
-    return reviewRepository.getWrittenReviews(customerId, pageQuery);
+    const { items, total, page, pageSize } = await reviewRepository.getWrittenReviews(customerId, pageQuery);
+    // FE가 원하는 필드만 추출
+    const mappedItems = items.map((review: any) => {
+      return {
+        id: review.id,
+        moverId: review.moverId,
+        profileImage: review.mover?.profile?.profileImage ?? null,
+        nickname: review.mover?.profile?.nickname ?? null,
+        moverIntroduction: review.mover?.profile?.introduction ?? null,
+        movingType: review.quote?.movingType ?? null,
+        isDesigned: review.estimate?.isDesignated ?? false,
+        departureAddr: review.quote?.departureAddr ?? null,
+        arrivalAddr: review.quote?.arrivalAddr ?? null,
+        movingDate: review.quote?.movingDate ?? null,
+        rating: review.rating,
+        content: review.content,
+        createdAt: review.createdAt,
+      };
+    });
+    return { items: mappedItems, total, page, pageSize };
   },
   getReceivedReviews: async (moverId: number, pageQuery: { page: number; pageSize: number }) => {
-    return reviewRepository.getReceivedReviews(moverId, pageQuery);
+    const { items, total, page, pageSize } = await reviewRepository.getReceivedReviews(moverId, pageQuery);
+    const mappedItems = items.map((review: any) => ({
+      id: review.id,
+      userId: review.userId,
+      nickname: review.user?.profile?.nickname ?? null,
+      profileImage: review.user?.profile?.profileImage ?? null,
+      movingType: review.quote?.movingType ?? null,
+      departureAddr: review.quote?.departureAddr ?? null,
+      arrivalAddr: review.quote?.arrivalAddr ?? null,
+      movingDate: review.quote?.movingDate ?? null,
+      rating: review.rating,
+      content: review.content,
+      createdAt: review.createdAt,
+    }));
+    return { items: mappedItems, total, page, pageSize };
   },
 };
 


### PR DESCRIPTION
## ✨ 작업 개요

- 리뷰에서 사용되는 데이터만 내보내도록 변경.
- 스키마 대공사에 따라 변경 사항에 맞게 타입 변경.
- 누락된 리뷰 상태(reviewStatus) Enum 추가 및 리뷰 테이블에 추가.

## ✅ 주요 작업 내용

- 내가 쓴 리뷰 가져오기 API 수정.
- 리뷰 작성 가능 리스트 가져오기 API 수정.
- 받은 리뷰 가져오기 API 수정.
- 리뷰 생성 미들웨어 수정.
- 스키마에 누락된 리뷰 상태(reviewStatus) 추가.
- 마이그레이션 진행.
- 시드 데이터 수정.

## 🔄 관련 이슈

Closes #127 - 사용 되는 데이터만 넘겨주기.
Closes #128 - 스키마 대공사에 따른 변경.
Closes #132 - 누락된 리뷰 상태 추가.

## 📎 참고 자료 (선택)

- API 명세서: [Notion 링크](https://admitted-turkey-c17.notion.site/API-2155da6dc98c813891ead8eb7218d631?source=copy_link)
- 프로젝트 분석 [Notion 링크](https://admitted-turkey-c17.notion.site/BE-2245da6dc98c80e681a1f21c8bf66842?source=copy_link)

## 📝 비고

- 현재 받은 리뷰 가저오기 API는 다른 페이지에서 사용되기에 리뷰에 대한 모든 데이터(견적관련 데이터)를 넘겨주고 있음. 
- 스웨거 보시고 사용하시는 분들(기사님 마이페이지와 기사님 상세페이지로 추정)이 사용되는 데이터만 추려주시면 해당 데이터만 넘겨주는 것으로 수정 예정.