### PR TITLE
[#104] feat : auth 및 user 관련 오류 수정

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -13,6 +13,7 @@ export const authCookieOptions = (maxAgeSeconds: number): TCookieOptions => ({
   maxAge: maxAgeSeconds * 1000,
 });
 
+// 로그인
 const postSignin = async (req: Request, res: Response) => {
   const { email, password, userType } = req.body;
 
@@ -46,6 +47,7 @@ const postSignin = async (req: Request, res: Response) => {
   }
 };
 
+// 회원가입
 const postSignup = async (req: Request, res: Response) => {
   const { name, email, phoneNumber, password, userType } = req.body;
 
@@ -75,7 +77,7 @@ const postSignup = async (req: Request, res: Response) => {
       message: "회원가입 성공",
       user: {
         id,
-        userName,
+        name: userName,
         userType: userTypeResponse,
       },
       accessToken,
@@ -85,6 +87,7 @@ const postSignup = async (req: Request, res: Response) => {
   }
 };
 
+// 로그아웃
 const postLogout = async (req: Request, res: Response) => {
   const { userId } = req.user as { userId: string };
 
@@ -100,6 +103,7 @@ const postLogout = async (req: Request, res: Response) => {
   }
 };
 
+// 토큰 갱신
 const postRefresh = (req: Request, res: Response) => {
   const { refreshToken } = req.body;
   res.status(200).json({ message: "refresh" });

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -44,13 +44,15 @@ const getProfile = async (req: Request, res: Response) => {
   res.json({ success: true, data: profile });
 };
 
-// 프로필 등록 및 수정 -> 수정은 따로 빼기?
+// 프로필 등록
 const postProfile = async (req: Request, res: Response) => {
   try {
     const { userId, userType } = req.user as {
       userId: string;
       userType: TUserRole;
     };
+
+    console.log(userId, userType);
 
     if (userType === "CUSTOMER") {
       // 일반 유저 프로필 등록

--- a/src/middlewares/presignedUrl.ts
+++ b/src/middlewares/presignedUrl.ts
@@ -13,7 +13,7 @@ const generatePresignedUrl = async (req: Request, res: Response) => {
       },
     });
 
-    const { role } = req.user as { role: TUserRole };
+    const { userType } = req.user as { userType: TUserRole };
     const { filename, contentType } = req.body;
 
     if (!filename || !contentType) {
@@ -23,7 +23,7 @@ const generatePresignedUrl = async (req: Request, res: Response) => {
     }
 
     // 역할 기반 폴더 설정
-    const folderPrefix = role === "MOVER" ? "mover" : "customer";
+    const folderPrefix = userType === "MOVER" ? "mover" : "customer";
     const key = `${folderPrefix}/${Date.now()}_${filename}`;
 
     const command = new PutObjectCommand({

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -3,7 +3,8 @@ import { TUserRole, TUserSignup } from "../types/user.types";
 
 const prisma = new PrismaClient();
 
-const saveUser = async (user: TUserSignup) => {
+// 유저 생성
+const createUser = async (user: TUserSignup) => {
   return await prisma.user.create({
     data: {
       email: user.email,
@@ -11,6 +12,8 @@ const saveUser = async (user: TUserSignup) => {
       encryptedPassword: user.encryptedPassword,
       encryptedPhoneNumber: user.encryptedPhoneNumber,
       userType: [user.userType],
+      isCustomer: false,
+      isMover: false,
     },
     select: {
       id: true,
@@ -33,7 +36,8 @@ const findUserByEmailAndPassword = async (email: string) => {
       encryptedPassword: true,
       customerImage: true,
       moverImage: true,
-      nickname: true,
+      isCustomer: true,
+      isMover: true,
     },
   });
 };
@@ -49,11 +53,11 @@ const findUserByEmail = async (email: string) => {
 const updateUserToken = async (
   userId: string,
   refreshToken: string | null,
-  userType: TUserRole
+  userType: TUserRole[]
 ) => {
   return await prisma.user.update({
     where: { id: userId },
-    data: { refreshToken, userType: [userType] },
+    data: { refreshToken, userType },
   });
 };
 
@@ -65,7 +69,7 @@ const findUserById = async (userId: string) => {
 };
 
 export default {
-  saveUser,
+  createUser,
   findUserByEmailAndPassword,
   findUserByEmail,
   updateUserToken,

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -90,6 +90,7 @@ const createCustomerProfile = async (profileData: TCreateCustomerProfile) => {
       currentArea: profileData.currentArea,
       preferredServices: profileData.preferredServices,
       nickname: profileData.nickname,
+      isCustomer: true,
     },
     select: {
       id: true,
@@ -123,6 +124,7 @@ const createMoverProfile = async (profileData: TCreateMoverProfile) => {
     detailIntro: profileData.detailIntro,
     serviceTypes: profileData.serviceTypes,
     currentAreas: profileData.currentAreas,
+    isMover: true,
   };
 
   const result = await prisma.user.update({

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -32,14 +32,13 @@ const signin = async (email: string, password: string, userType: TUserRole) => {
   }
 
   let accessToken, refreshToken;
-
   // 3. 유저 role에 따른 토큰 생성
   if (userType === "CUSTOMER") {
     const { newAccessToken, newRefreshToken } = generateToken({
       id: String(existingUser.id),
       name: existingUser.name,
       userType,
-      nickname: existingUser.nickname || "",
+      hasProfile: existingUser.isCustomer || false,
     });
 
     accessToken = newAccessToken;
@@ -49,7 +48,7 @@ const signin = async (email: string, password: string, userType: TUserRole) => {
       id: String(existingUser.id),
       name: existingUser.name,
       userType,
-      nickname: existingUser.nickname || "",
+      hasProfile: existingUser.isMover || false,
     });
 
     accessToken = newAccessToken;
@@ -60,16 +59,30 @@ const signin = async (email: string, password: string, userType: TUserRole) => {
     throw new ServerError("토큰 생성 실패로 인한 로그인 실패");
   }
 
+  // 현재 유저 타입이 1개이고, MOVER 이고 원본이 "CUSTOMER" 만 존재한다면 배열에 추가 "MOVER" 타입을 추가
+  let currentType = [];
+  if (
+    existingUser.userType?.[0] === "CUSTOMER" &&
+    existingUser.userType.length === 1 &&
+    userType === "MOVER"
+  ) {
+    currentType = [existingUser.userType[0], userType];
+  } else {
+    // 아니라면 원본 유저 타입 그대로 사용
+    // (첫 크로스 로그인 이후로는 아래만 실행됨)
+    currentType = existingUser.userType;
+  }
+
   await authRepository.updateUserToken(
     String(existingUser.id),
     refreshToken,
-    userType
+    currentType as TUserRole[]
   );
 
   return {
     id: existingUser.id,
     userName: existingUser.name,
-    userType: userType === "CUSTOMER" ? "CUSTOMER" : "MOVER",
+    userType,
     accessToken,
     refreshToken,
   };
@@ -100,7 +113,7 @@ const signup = async ({
   const encryptedPhoneNumber = encryptPhoneNumber(phoneNumber);
 
   // 유저 생성
-  const user = await authRepository.saveUser({
+  const user = await authRepository.createUser({
     name,
     email,
     encryptedPassword,
@@ -114,13 +127,20 @@ const signup = async ({
 
   let accessToken, refreshToken;
 
-  // 3. 토큰 생성
+  // 유저 타입 배열에 CUSTOMER가 먼저 있는지 확인 없다면 현재 타입은 MOVER
+  // (저장 순서가  CUSTOMER, MOVER 이므로)
+  const userTypeResponse = user.userType.some((type) => type === "CUSTOMER")
+    ? "CUSTOMER"
+    : "MOVER";
+
+  // 3. 현재 유저 타입에 맞는 토큰 생성
+  // hasProfile은 프로필 등록 여부를 판단하기 위해 사용
   if (userType === "CUSTOMER") {
     const { newAccessToken, newRefreshToken } = generateToken({
       id: String(user.id),
       name: user.name,
-      userType: user.userType[0],
-      nickname: user.nickname || "",
+      userType: userTypeResponse,
+      hasProfile: false,
     });
 
     accessToken = newAccessToken;
@@ -129,8 +149,8 @@ const signup = async ({
     const { newAccessToken, newRefreshToken } = generateToken({
       id: String(user.id),
       name: user.name,
-      userType: user.userType[0],
-      nickname: user.nickname || "",
+      userType: userTypeResponse,
+      hasProfile: false,
     });
 
     accessToken = newAccessToken;
@@ -144,7 +164,7 @@ const signup = async ({
   return {
     id: user.id,
     userName: user.name,
-    userType: userType === "CUSTOMER" ? "CUSTOMER" : "MOVER",
+    userType: userTypeResponse,
     accessToken,
     refreshToken,
   };
@@ -166,7 +186,7 @@ const logout = async (userId: string) => {
     throw new AuthenticationError("이미 로그아웃된 상태입니다");
   }
 
-  await authRepository.updateUserToken(String(userId), null, user.userType[0]);
+  await authRepository.updateUserToken(String(userId), null, user.userType);
 };
 
 export default { signin, signup, logout };

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -113,8 +113,8 @@ const createCustomerProfile = async (
   const { newAccessToken, newRefreshToken } = generateToken({
     id: user.id,
     name: user.name,
-    nickname: profileData.nickname || "",
-    userType: user.userType[0],
+    userType: "CUSTOMER",
+    hasProfile: true,
   });
 
   const result = await createCustomerProfileRepository(createProfileData);
@@ -201,8 +201,8 @@ const createMoverProfile = async (
   const { newAccessToken, newRefreshToken } = generateToken({
     id: user.id,
     name: user.name,
-    nickname: profileData.nickname || "",
-    userType: user.userType[0],
+    userType: "MOVER",
+    hasProfile: true,
   });
 
   const result = await createMoverProfileRepository(createProfileData);

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -90,8 +90,8 @@ export type TUserLegacy = {
 export type TUserTokenCreate = {
   id: string; // 기존 코드 호환성
   name: string;
-  nickname: string;
   userType: TUserRole; // 기존 코드 호환성
+  hasProfile: boolean;
 };
 
 // =============================================================================

--- a/src/utils/generateToken.ts
+++ b/src/utils/generateToken.ts
@@ -6,8 +6,8 @@ export function generateAccessToken(user: TUserTokenCreate): string {
   const payload = {
     userId: user.id,
     name: user.name,
-    nickname: user.nickname,
     userType: user.userType,
+    hasProfile: user.hasProfile,
   };
 
   const accessSecret = process.env.JWT_SECRET_KEY;
@@ -29,7 +29,7 @@ export function generateRefreshToken(user: TUserTokenCreate): string {
     userId: user.id,
     name: user.name,
     userType: user.userType,
-    nickname: user.nickname,
+    hasProfile: user.hasProfile,
   };
 
   const refreshSecret = process.env.JWT_REFRESH_SECRET_KEY;


### PR DESCRIPTION
## ✨ 작업 개요
- 스키마 수정으로 인한 auth 및 user 관련 오류 수정

## ✅ 주요 작업 내용
- 추가된 스키마 isCustomer, isMover 필드에 맞게 프로필 등록 로직 수정
- 토큰에 nickName 속성 대신 hasPorfile 속성을 넣어 FE에서 미들웨서 설정을 하도록 수정
- usetType의 속성명 변경으로 presigned url이 잘못 발급되던 문제 수정
- 크로스 로그인이 가능하도록 유저가 로그인한 타입을 배열로 저장하고, 현재 로그인한 페이지의 타입을 반환하도록 수정

## 🔄 관련 이슈

Closes #104

## 📎 참고 자료 (선택)

### 일반유저 s3
<img width="1629" height="180" alt="기사님 s3 업로드 확인" src="https://github.com/user-attachments/assets/1488a959-f411-46fc-a8f4-7020d084ab48" />

### 기사님 s3
<img width="1631" height="432" alt="일반유저 s3 저장" src="https://github.com/user-attachments/assets/80017ee4-0673-465d-86fb-dfc0b70aa130" />


## 📝 비고
- 이제 토큰 재발급 및 소셜 로그인 작업을 들어갈거 같습니다
