### PR TITLE
[#135] feat : JWT 슬라이딩 세션을 이용한 토큰 재발급 로직 구현

### DIFF
--- a/src/constants/token.constants.ts
+++ b/src/constants/token.constants.ts
@@ -7,8 +7,13 @@ export const TIME = {
 } as const;
 
 export const TOKEN_EXPIRES = {
-  ACCESS_TOKEN: "2w", // 2주 , 테스트용
+  // 토큰 만료 시간
+  ACCESS_TOKEN: "30m", // 30분
   REFRESH_TOKEN: "2w", // 2주
-  ACCESS_TOKEN_COOKIE: 2 * TIME.WEEK, // 1209600초 (2주)
-  REFRESH_TOKEN_COOKIE: 2 * TIME.WEEK, // 1209600초 (2주)
+
+  // 쿠키 만료 시간
+  ACCESS_TOKEN_COOKIE: 30 * TIME.MINUTE, //  30분
+  REFRESH_TOKEN_COOKIE: 2 * TIME.WEEK, //  2주
 } as const;
+
+export const REFRESH_TOKEN_REISSUE_THRESHOLD_SECONDS = 60 * 60 * 24 * 5;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import { TOKEN_EXPIRES } from "../constants/token.constants";
 
 import { handleError } from "../utils/handleError";
 import { TCookieOptions } from "../types/cookie.types";
+import { TUserRole } from "../types/user.types";
 
 export const authCookieOptions = (maxAgeSeconds: number): TCookieOptions => ({
   httpOnly: true,
@@ -104,9 +105,37 @@ const postLogout = async (req: Request, res: Response) => {
 };
 
 // 토큰 갱신
-const postRefresh = (req: Request, res: Response) => {
-  const { refreshToken } = req.body;
-  res.status(200).json({ message: "refresh" });
+const postRefresh = async (req: Request, res: Response) => {
+  const { userId, userType, exp } = req.refreshToken as {
+    userId: string;
+    userType: TUserRole;
+    exp: number;
+  };
+
+  try {
+    const { accessToken, refreshToken } = await authService.refresh({
+      exp,
+      userType,
+      userId,
+    });
+
+    // 리프레쉬 쿠키까지 재발급 된다면 저장
+    if (refreshToken) {
+      res.cookie(
+        "refreshToken",
+        refreshToken,
+        authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+      );
+    }
+
+    res.status(200).json({
+      success: true,
+      message: "토큰 갱신 성공",
+      accessToken,
+    });
+  } catch (error: any) {
+    handleError(res, error);
+  }
 };
 
 export { postSignin, postSignup, postLogout, postRefresh };

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -27,9 +27,13 @@ const getUser = async (req: Request, res: Response) => {
     userType: TUserRole;
   };
 
-  const user = await userInfo(userId, userType);
+  try {
+    const user = await userInfo(userId, userType);
 
-  res.json({ success: true, data: user });
+    res.json({ success: true, data: user });
+  } catch (error) {
+    handleError(res, error);
+  }
 };
 
 // 프로필 조회

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -18,12 +18,80 @@ export const verifyAccessToken = (
       userId: string;
       name: string;
       userType: TUserRole;
+      hasProfile: boolean;
+      iat: number;
+      exp: number;
     };
+
     req.user = decoded;
     next();
-  } catch (err) {
-    return res
-      .status(401)
-      .json({ message: "Access token이 유효하지 않습니다." });
+  } catch (err: unknown) {
+    if (err instanceof jwt.TokenExpiredError) {
+      return res
+        .status(401)
+        .json({ success: false, message: "토큰 만료 시간이 지났습니다." });
+    }
+
+    if (err instanceof jwt.JsonWebTokenError) {
+      return res.status(401).json({
+        success: false,
+        message: "Access token이 변조되었거나 잘못된 형식입니다.",
+      });
+    }
+
+    return res.status(401).json({
+      success: false,
+      message: "Access token이 유효하지 않습니다.",
+    });
+  }
+};
+
+export const verifyRefreshToken = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const token = req.cookies.refreshToken;
+
+  if (!token) {
+    return res.status(401).json({
+      success: false,
+      message: "로그인이 필요합니다.",
+    });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_REFRESH_SECRET_KEY!) as {
+      userId: string;
+      name: string;
+      userType: TUserRole;
+      hasProfile: boolean;
+      iat: number;
+      exp: number;
+    };
+
+    req.refreshToken = decoded;
+
+    next();
+  } catch (err: unknown) {
+    if (err instanceof jwt.TokenExpiredError) {
+      return res.status(401).json({
+        success: false,
+        message: "토큰 만료 시간이 지났습니다. 다시 로그인해 주세요.",
+      });
+    }
+
+    if (err instanceof jwt.JsonWebTokenError) {
+      return res.status(401).json({
+        success: false,
+        message:
+          "Refresh token이 변조되었거나 잘못된 형식입니다. 다시 로그인해 주세요.",
+      });
+    }
+
+    return res.status(401).json({
+      success: false,
+      message: "Refresh token이 유효하지 않습니다.  다시 로그인해 주세요.",
+    });
   }
 };

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -5,7 +5,10 @@ import {
   postLogout,
   postRefresh,
 } from "../controllers/auth.controller";
-import { verifyAccessToken } from "../middlewares/verifyToken";
+import {
+  verifyAccessToken,
+  verifyRefreshToken,
+} from "../middlewares/verifyToken";
 
 const authRouter = Router();
 
@@ -196,12 +199,13 @@ authRouter.post("/logout", verifyAccessToken, postLogout);
 /**
  * POST /auth/refresh-token
  * @summary 액세스 토큰 갱신
- * @description 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.
+ * @description 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다 (리프레쉬 토큰의 유효기간이 발급 만료 시간에 해당할 경우 리프레시 토큰도 갱신).
  * @tags Auth
  * @param {RefreshTokenRequest} request.body.required - 토큰 갱신 정보
  * @return {SuccessResponse} 200 - 토큰 갱신 성공
- * @return {ErrorResponse} 400 - 유효하지 않은 리프레시 토큰
+ * @return {ErrorResponse} 401 - 유효하지 않은 리프레시 토큰
  * @return {ErrorResponse} 401 - 만료된 리프레시 토큰
+ * @return {ErrorResponse} 401 - 토큰이 없을 경우
  * @return {ErrorResponse} 500 - 서버 내부 오류
  * @example request - 토큰 갱신 요청 예시
  * {
@@ -212,8 +216,27 @@ authRouter.post("/logout", verifyAccessToken, postLogout);
  *   "success": true,
  *   "message": "토큰 갱신 성공"
  * }
+ * @example response - 401 - 유효하지 않은 리프레시 토큰 응답 예시
+ * {
+ *   "status": 401,
+ *   "success": false,
+ *   "message": "Refresh token이 변조되었거나 잘못된 형식입니다. 다시 로그인해 주세요.",
+ *   "error": "JsonWebTokenError"
+ * }
+ * @example response - 401 - 만료된 리프레시 토큰 응답 예시
+ * {
+ *   "status": 401,
+ *   "success": false,
+ *   "message": "리프레시 토큰 만료 시간이 지났습니다. 다시 로그인해 주세요.",
+ *   "error": "TokenExpiredError"
+ * }
+ * @example response - 401 - 토큰이 없을 경우 응답 예시
+ * {
+ *   "status": 401,
+ *   "success": false,
+ *   "message": "로그인이 필요합니다.",
+ * }
  */
-// TODO: 토큰 검사 필요
-authRouter.post("/refresh-token", postRefresh);
+authRouter.post("/refresh-token", verifyRefreshToken, postRefresh);
 
 export default authRouter;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,6 +1,10 @@
 import authRepository from "../repositories/auth.repository";
 import bcrypt from "bcrypt";
-import { generateToken } from "../utils/generateToken";
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  generateToken,
+} from "../utils/generateToken";
 import { TUserRole, TUserSignupInput } from "../types/user.types";
 import { encryptPhoneNumber } from "../utils/phoneEncryption";
 import { validateUserSignupInput } from "../utils/validators/userValidator";
@@ -11,6 +15,13 @@ import {
   ServerError,
   ValidationError,
 } from "../types/commonError.types";
+import { REFRESH_TOKEN_REISSUE_THRESHOLD_SECONDS } from "../constants/token.constants";
+
+type TDecodedToken = {
+  userId: string;
+  userType: TUserRole;
+  exp: number;
+};
 
 // 로그인 검증
 const signin = async (email: string, password: string, userType: TUserRole) => {
@@ -189,4 +200,40 @@ const logout = async (userId: string) => {
   await authRepository.updateUserToken(String(userId), null, user.userType);
 };
 
-export default { signin, signup, logout };
+// JWT 슬라이딩 세션 토큰 갱신
+const refresh = async (decoded: TDecodedToken) => {
+  const user = await authRepository.findUserById(decoded.userId);
+  if (!user) throw new NotFoundError("존재하지 않는 유저입니다");
+
+  const now = Date.now() / 1000;
+  const refreshExp = decoded.exp;
+
+  const accessToken = generateAccessToken({
+    id: user.id,
+    name: user.name,
+    userType: decoded.userType,
+    hasProfile: user.isCustomer || false,
+  });
+
+  let refreshToken = undefined;
+  // 만료 시간이 5일 이하라면 리프레쉬 토큰 재발급
+  if (refreshExp - now <= REFRESH_TOKEN_REISSUE_THRESHOLD_SECONDS) {
+    refreshToken = generateRefreshToken({
+      id: user.id,
+      name: user.name,
+      userType: decoded.userType,
+      hasProfile: user.isCustomer || false,
+    });
+
+    await authRepository.updateUserToken(
+      user.id,
+      refreshToken || null,
+      user.userType
+    );
+  }
+
+  // refreshToken은 optional
+  return { accessToken, refreshToken };
+};
+
+export default { signin, signup, logout, refresh };

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -4,6 +4,17 @@ declare namespace Express {
       userId: string;
       name: string;
       userType: "CUSTOMER" | "MOVER";
+      hasProfile: boolean;
+      iat: number;
+      exp: number;
+    };
+    refreshToken?: {
+      userId: string;
+      name: string;
+      userType: "CUSTOMER" | "MOVER";
+      hasProfile: boolean;
+      iat: number;
+      exp: number;
     };
   }
 }


### PR DESCRIPTION
## ✨ 작업 개요

- 슬라이딩 세션 기반의 JWT 토큰 재발급 로직을 구현하였습니다.
- 엑세스 토큰 만료 시 리프레쉬 토큰을 통한 재발급 API를 제공합니다.
- 리프레쉬 토큰의 재발급 조건(5일 이하 남은 경우) 또한 함께 적용됩니다.

## ✅ 주요 작업 내용

- [x] `/auth/refresh-token` API 구현
- [x] 엑세스 토큰 만료 시 리프레쉬 토큰 기반 재발급 처리
- [x] 리프레쉬 토큰 만료 여부 판단 및 조건부 재발급 처리
- [x] 실패 시 에러 코드에 따라 프론트 로그아웃 유도
- [x] 유닛 테스트 및 예외 상황 로깅 처리

## 🔄 관련 이슈

Closes #135

## 📎 참고 자료 (선택)
### 엑세스 토큰만 재발급
<img width="579" height="498" alt="액세스토큰만 재발급" src="https://github.com/user-attachments/assets/a3a24696-6692-457d-aa15-0710e02492ad" />

### 리프레쉬 토큰도 같이 재발급
<img width="557" height="671" alt="리프레쉬 토큰도 같이 재발급" src="https://github.com/user-attachments/assets/dffae08a-37a3-4713-9484-28d273dcb314" />


## 🧪 테스트 방법 (선택)

- [ ] 엑세스 토큰 만료 시 `/auth/refresh-token` 요청을 통해 재발급되는지 확인
- [ ] 리프레쉬 토큰이 5일 이하 남았을 경우, 엑세스 토큰과 함께 재발급되는지 확인
- [ ] 리프레쉬 토큰 만료 시 로그아웃 처리되는지 확인

## 📝 비고
- 프론트엔드에서는 `fetcher.api.ts`에서 자동으로 재발급 API를 호출하며, 최대 1회 재시도됩니다.
- 현재 엑세스 토큰 유효기간은 **30분**, 리프레쉬 토큰 유효기간은 **2주**, 재발급 조건은 **5일 이하 남았을 경우**입니다.
