### PR TITLE
[#146]fix: 견적요청 리팩토링 및 에러 추가

### DIFF
--- a/src/controllers/estimateRequest.controller.ts
+++ b/src/controllers/estimateRequest.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
 import { MoveType, RequestStatus, EstimateRequest } from "@prisma/client";
 import EstimateRequestService from "../services/estimateRequest.service";
-import { TCreateEstimateRequest } from "../types/estimateRequest.types";
+import { TCreateEstimateRequest, TUpdateEstimateRequest } from "../types/estimateRequest.types";
+import { getKoreaToday, isBeforeKoreaToday } from "../utils/dateUtils";
 
 const estimateRequestService = new EstimateRequestService();
 
@@ -12,126 +13,246 @@ class EstimateRequestController {
       if (!userId) {
         return res.status(401).json({ success: false, message: "인증이 필요합니다." });
       }
+
+      // 유저 유형 확인 - 기사님은 견적 요청을 생성할 수 없음
+      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
+      if (!isCustomer) {
+        return res.status(403).json({
+          success: false,
+          message: "기사님은 견적 요청을 생성할 수 없습니다. 일반 고객으로 로그인해주세요.",
+        });
+      }
+
       const hasPending = await estimateRequestService.hasPendingRequest(userId);
       if (hasPending) {
         return res.status(409).json({ success: false, message: "이미 진행중인 견적 요청이 있습니다." });
       }
-      // 주소 직접 입력 방식으로 파라미터 받기
-      const {
-        moveType,
-        fromCity,
-        fromDistrict,
-        fromDetail,
-        fromRegion,
-        toCity,
-        toDistrict,
-        toDetail,
-        toRegion,
-        moveDate,
-        description,
-      } = req.body;
-      // 출발지와 도착지 주소가 완전히 같은지 검사 (공백, null, undefined, 대소문자 등 모두 안전하게)
+
+      // 프론트엔드 요청 구조에 맞게 파라미터 받기
+      const { movingType, movingDate, departure, arrival, description } = req.body;
+
+      // 이사일이 과거인지 확인 (한국 시간 기준)
+      const moveDate = new Date(movingDate);
+
+      if (isBeforeKoreaToday(moveDate)) {
+        return res.status(400).json({
+          success: false,
+          message: "이사일은 오늘 이후로 설정해주세요.",
+        });
+      }
+
+      // 출발지와 도착지 주소가 완전히 같은지 검사
       const safeEq = (a: any, b: any) => (a || "").toString().trim() === (b || "").toString().trim();
       if (
-        safeEq(fromCity, toCity) &&
-        safeEq(fromDistrict, toDistrict) &&
-        safeEq(fromDetail, toDetail) &&
-        safeEq(fromRegion, toRegion)
+        safeEq(departure?.roadAddress, arrival?.roadAddress) &&
+        safeEq(departure?.detailAddress, arrival?.detailAddress)
       ) {
         return res.status(400).json({ success: false, message: "출발지와 도착지는 달라야 합니다." });
       }
+
       const params: TCreateEstimateRequest = {
         userId,
-        moveType,
-        fromCity,
-        fromDistrict,
-        fromDetail,
-        fromRegion,
-        toCity,
-        toDistrict,
-        toDetail,
-        toRegion,
-        moveDate,
+        movingType,
+        movingDate,
+        departure,
+        arrival,
         description,
       };
+
       const result = await estimateRequestService.createEstimateRequest(params);
       return res.status(201).json({ success: true, message: "견적 요청이 성공적으로 생성되었습니다.", data: result });
     } catch (error) {
+      console.error("견적 요청 생성 에러:", error);
       return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
     }
   }
+
   async getActiveEstimateRequest(req: Request, res: Response) {
     try {
       const userId = (req as any).user?.userId as string;
       if (!userId) {
         return res.status(401).json({ success: false, message: "인증이 필요합니다." });
       }
+
+      // 유저 유형 확인 - 기사님은 견적 요청을 조회할 수 없음
+      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
+      if (!isCustomer) {
+        return res.status(403).json({
+          success: false,
+          message: "기사님은 견적 요청을 조회할 수 없습니다. 일반 고객으로 로그인해주세요.",
+        });
+      }
+
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       const hasActive = !!active;
+
       if (hasActive) {
-        // 주소 레이블 추가 (city, district, detail, region 조합)
-        let fromAddressLabel = undefined;
-        let toAddressLabel = undefined;
-        if (active.fromAddress) {
-          fromAddressLabel =
-            `${active.fromAddress.region} ${active.fromAddress.city} ${active.fromAddress.district} ${active.fromAddress.detail || ""}`.trim();
+        // 견적 요청이 만료되었는지 확인
+        const isExpired = await estimateRequestService.isRequestExpired(active.id);
+        if (isExpired && active.status === RequestStatus.PENDING) {
+          // 만료된 PENDING 상태의 견적 요청을 EXPIRED로 변경
+          await estimateRequestService.expireOverdueRequests();
+          return res.status(200).json({ success: true, hasActive: false });
         }
-        if (active.toAddress) {
-          toAddressLabel =
-            `${active.toAddress.region} ${active.toAddress.city} ${active.toAddress.district} ${active.toAddress.detail || ""}`.trim();
-        }
-        return res
-          .status(200)
-          .json({ success: true, hasActive, data: { ...active, fromAddressLabel, toAddressLabel } });
+
+        // 프론트엔드 응답 구조에 맞게 변환
+        const responseData = {
+          id: active.id,
+          userId: active.customerId,
+          movingType: active.moveType,
+          departureAddress: active.fromAddress
+            ? `${active.fromAddress.region} ${active.fromAddress.city} ${active.fromAddress.district}`
+            : "",
+          arrivalAddress: active.toAddress
+            ? `${active.toAddress.region} ${active.toAddress.city} ${active.toAddress.district}`
+            : "",
+          departureDetailAddress: active.fromAddress?.detail || null,
+          arrivalDetailAddress: active.toAddress?.detail || null,
+          movingDate: active.moveDate.toISOString().split("T")[0], // YYYY-MM-DD 형식
+          status: active.status,
+          createdAt: active.createdAt.toISOString(),
+          updatedAt: active.updatedAt.toISOString(),
+        };
+
+        return res.status(200).json({ success: true, hasActive, data: responseData });
       } else {
         return res.status(200).json({ success: true, hasActive });
       }
     } catch (error) {
+      console.error("활성 견적 요청 조회 에러:", error);
       return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
     }
   }
+
   async updateActiveEstimateRequest(req: Request, res: Response) {
     try {
       const userId = (req as any).user?.userId as string;
+      if (!userId) {
+        return res.status(401).json({ success: false, message: "인증이 필요합니다." });
+      }
+
+      // 유저 유형 확인 - 기사님은 견적 요청을 수정할 수 없음
+      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
+      if (!isCustomer) {
+        return res.status(403).json({
+          success: false,
+          message: "기사님은 견적 요청을 수정할 수 없습니다. 일반 고객으로 로그인해주세요.",
+        });
+      }
+
       const isPending = await estimateRequestService.isActiveRequestPending(userId);
       if (!isPending) {
         return res.status(409).json({ success: false, message: "진행중(PENDING) 상태에서만 수정할 수 있습니다." });
       }
+
       // 활성 견적 요청 찾기
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       if (!active) {
         return res.status(404).json({ success: false, message: "활성 견적 요청이 없습니다." });
       }
-      // 업데이트
-      const updateData = req.body;
+
+      // 견적 요청이 만료되었는지 확인
+      const isExpired = await estimateRequestService.isRequestExpired(active.id);
+      if (isExpired) {
+        return res.status(409).json({
+          success: false,
+          message: "이사일이 지나 만료된 견적 요청은 수정할 수 없습니다.",
+        });
+      }
+
+      // 프론트엔드 요청 구조에 맞게 파라미터 받기
+      const { movingType, movingDate, departure, arrival, description } = req.body;
+
+      // 이사일이 과거인지 확인 (수정 시에만, 한국 시간 기준)
+      if (movingDate) {
+        const moveDate = new Date(movingDate);
+
+        if (isBeforeKoreaToday(moveDate)) {
+          return res.status(400).json({
+            success: false,
+            message: "이사일은 오늘 이후로 설정해주세요.",
+          });
+        }
+      }
+
+      // 출발지와 도착지 주소가 완전히 같은지 검사
+      const safeEq = (a: any, b: any) => (a || "").toString().trim() === (b || "").toString().trim();
+      if (
+        safeEq(departure?.roadAddress, arrival?.roadAddress) &&
+        safeEq(departure?.detailAddress, arrival?.detailAddress)
+      ) {
+        return res.status(400).json({ success: false, message: "출발지와 도착지는 달라야 합니다." });
+      }
+
+      const updateData: TUpdateEstimateRequest = {
+        movingType,
+        movingDate,
+        departure,
+        arrival,
+        description,
+      };
+
       const updated = await estimateRequestService.updateActiveEstimateRequest(active.id, updateData);
       return res.status(200).json({ success: true, message: "견적 요청이 성공적으로 수정되었습니다.", data: updated });
     } catch (error) {
+      console.error("견적 요청 수정 에러:", error);
       return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
     }
   }
+
   async cancelActiveEstimateRequest(req: Request, res: Response) {
     try {
       const userId = (req as any).user?.userId as string;
+      if (!userId) {
+        return res.status(401).json({ success: false, message: "인증이 필요합니다." });
+      }
+
+      // 유저 유형 확인 - 기사님은 견적 요청을 취소할 수 없음
+      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
+      if (!isCustomer) {
+        return res.status(403).json({
+          success: false,
+          message: "기사님은 견적 요청을 취소할 수 없습니다. 일반 고객으로 로그인해주세요.",
+        });
+      }
+
       const isPending = await estimateRequestService.isActiveRequestPending(userId);
       if (!isPending) {
         return res.status(409).json({ success: false, message: "진행중(PENDING) 상태에서만 취소할 수 있습니다." });
       }
+
+      // 기사님이 견적을 제출했는지 확인 (PROPOSED 상태)
       const hasEstimate = await estimateRequestService.hasEstimateFromMover(userId);
       if (hasEstimate) {
-        return res.status(409).json({ success: false, message: "기사님이 견적을 제출한 경우 취소할 수 없습니다." });
+        return res.status(409).json({
+          success: false,
+          message: "기사님이 견적을 제출한 경우 취소할 수 없습니다. 견적을 확인한 후 결정해주세요.",
+        });
       }
+
       // 활성 견적 요청 찾기
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       if (!active) {
         return res.status(404).json({ success: false, message: "활성 견적 요청이 없습니다." });
       }
+
+      // 견적 요청이 만료되었는지 확인
+      const isExpired = await estimateRequestService.isRequestExpired(active.id);
+      if (isExpired) {
+        return res.status(409).json({
+          success: false,
+          message: "이사일이 지나 만료된 견적 요청은 취소할 수 없습니다.",
+        });
+      }
+
       // 취소 처리
       await estimateRequestService.cancelActiveEstimateRequest(active.id);
-      return res.status(204).send();
+      return res.status(200).json({ success: true, message: "견적 요청이 취소되었습니다." });
     } catch (error) {
+      console.error("견적 요청 취소 에러:", error);
       return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
     }
   }
 }
+
 export default EstimateRequestController;

--- a/src/db/prisma/seed.ts
+++ b/src/db/prisma/seed.ts
@@ -35,17 +35,152 @@ async function main() {
   await prisma.address.deleteMany();
   await prisma.user.deleteMany();
 
-  // 주소 데이터 생성 (20개)
-  const addressData = Array.from({ length: 20 }).map((_, i) => ({
-    postalCode: `1000${i}`,
-    city: i % 2 === 0 ? "강남구" : "서초구",
-    district: i % 2 === 0 ? `역삼동${i}` : `서초동${i}`,
-    detail: `테스트로 ${i * 10}`,
-    region: i % 2 === 0 ? RegionType.SEOUL : RegionType.GYEONGGI,
-  }));
-  const addresses = await Promise.all(
-    addressData.map((data) => prisma.address.create({ data }))
-  );
+  // 주소 데이터 생성 (실제 대한민국 주소들)
+  const addressData = [
+    // 서울특별시 주소들
+    {
+      postalCode: "06123",
+      city: "강남구",
+      district: "역삼동",
+      detail: "테헤란로 123",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06124",
+      city: "강남구",
+      district: "삼성동",
+      detail: "영동대로 456",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06125",
+      city: "서초구",
+      district: "서초동",
+      detail: "강남대로 789",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06126",
+      city: "서초구",
+      district: "반포동",
+      detail: "신반포로 321",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06127",
+      city: "마포구",
+      district: "합정동",
+      detail: "양화로 654",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06128",
+      city: "마포구",
+      district: "상암동",
+      detail: "월드컵북로 987",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06129",
+      city: "송파구",
+      district: "잠실동",
+      detail: "올림픽로 135",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06130",
+      city: "송파구",
+      district: "문정동",
+      detail: "송파대로 246",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06131",
+      city: "영등포구",
+      district: "여의도동",
+      detail: "여의대로 357",
+      region: RegionType.SEOUL,
+    },
+    {
+      postalCode: "06132",
+      city: "영등포구",
+      district: "당산동",
+      detail: "당산로 468",
+      region: RegionType.SEOUL,
+    },
+    // 경기도 주소들
+    {
+      postalCode: "16489",
+      city: "수원시",
+      district: "정자동",
+      detail: "정자로 123",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16490",
+      city: "수원시",
+      district: "영통동",
+      detail: "영통로 456",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16491",
+      city: "성남시",
+      district: "분당동",
+      detail: "분당로 789",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16492",
+      city: "성남시",
+      district: "수정동",
+      detail: "수정로 321",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16493",
+      city: "용인시",
+      district: "기흥동",
+      detail: "기흥로 654",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16494",
+      city: "용인시",
+      district: "수지동",
+      detail: "수지로 987",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16495",
+      city: "고양시",
+      district: "일산동",
+      detail: "일산로 135",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16496",
+      city: "고양시",
+      district: "덕양동",
+      detail: "덕양로 246",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16497",
+      city: "부천시",
+      district: "상동",
+      detail: "상동로 357",
+      region: RegionType.GYEONGGI,
+    },
+    {
+      postalCode: "16498",
+      city: "부천시",
+      district: "중동",
+      detail: "중동로 468",
+      region: RegionType.GYEONGGI,
+    },
+  ];
+  const addresses = await Promise.all(addressData.map((data) => prisma.address.create({ data })));
 
   // 유저 30명 생성 (모두 고객+기사)
   const allNames = [
@@ -95,9 +230,7 @@ async function main() {
       moverImage: "",
       currentArea: getRandom([RegionType.SEOUL, RegionType.GYEONGGI]),
 
-      preferredServices: [
-        getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE]),
-      ],
+      preferredServices: [getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE])],
       shortIntro: `${allNames[i]}은(는) 친절하고 꼼꼼한 기사입니다!`,
       detailIntro: `${allNames[i]}은(는) 다양한 이사 경험을 바탕으로 최고의 서비스를 제공합니다.`,
       career: 5 + (i % 10),
@@ -106,15 +239,11 @@ async function main() {
       averageRating: 0, // 실제 리뷰 평점에 따라 업데이트
       totalReviewCount: 0, // 실제 리뷰 생성 후 업데이트
       currentAreas: [getRandom([RegionType.SEOUL, RegionType.GYEONGGI])],
-      serviceTypes: [
-        getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE]),
-      ],
+      serviceTypes: [getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE])],
       totalFavoriteCount: 0, // 실제 찜 생성 후 업데이트
     });
   }
-  const users = await Promise.all(
-    userArr.map((data) => prisma.user.create({ data }))
-  );
+  const users = await Promise.all(userArr.map((data) => prisma.user.create({ data })));
 
   // 기사님 서비스 지역 (모든 유저)
   const moverUsers = users; // 모든 유저가 기사 역할
@@ -126,8 +255,8 @@ async function main() {
           region: getRandom([RegionType.SEOUL, RegionType.GYEONGGI]),
           district: idx % 2 === 0 ? "강남구" : "서초구",
         },
-      })
-    )
+      }),
+    ),
   );
 
   // 사용자별 주소 등록 (각 유저마다 2개씩)
@@ -150,8 +279,8 @@ async function main() {
             customLabel: "이사갈 곳",
           },
         }),
-      ])
-    )
+      ]),
+    ),
   );
 
   // 견적 요청 180개 생성 (고객마다 진행중 1개 + 완료 5개씩)
@@ -161,11 +290,7 @@ async function main() {
     const user = users[userIdx];
 
     // 진행중인 견적 1개 (이사일: 2025년 7월 28일 ~ 9월 15일)
-    const pendingMoveDate = new Date(
-      2025,
-      6,
-      28 + Math.floor(Math.random() * 50)
-    ); // 2025년 7월 28일 ~ 9월 15일
+    const pendingMoveDate = new Date(2025, 6, 28 + Math.floor(Math.random() * 50)); // 2025년 7월 28일 ~ 9월 15일
     estimateRequests.push(
       prisma.estimateRequest.create({
         data: {
@@ -177,32 +302,24 @@ async function main() {
           status: RequestStatus.PENDING,
           description: `${user.name}님의 진행중인 견적 요청`,
         },
-      })
+      }),
     );
 
     // 완료된 견적 5개 (이사일: 5월 22일 ~ 7월 22일)
     for (let j = 0; j < 5; j++) {
-      const completedMoveDate = new Date(
-        2024,
-        4,
-        22 + Math.floor(Math.random() * 62)
-      ); // 5월 22일 ~ 7월 22일
+      const completedMoveDate = new Date(2024, 4, 22 + Math.floor(Math.random() * 62)); // 5월 22일 ~ 7월 22일
       estimateRequests.push(
         prisma.estimateRequest.create({
           data: {
             customerId: user.id,
-            moveType: getRandom([
-              MoveType.HOME,
-              MoveType.SMALL,
-              MoveType.OFFICE,
-            ]),
+            moveType: getRandom([MoveType.HOME, MoveType.SMALL, MoveType.OFFICE]),
             moveDate: completedMoveDate,
             fromAddressId: addresses[(userIdx + j) % addresses.length].id,
             toAddressId: addresses[(userIdx + j + 1) % addresses.length].id,
             status: RequestStatus.COMPLETED,
             description: `${user.name}님의 완료된 견적 요청 ${j + 1}`,
           },
-        })
+        }),
       );
     }
   }
@@ -228,24 +345,21 @@ async function main() {
           data: {
             moverId: mover.id,
             estimateRequestId: pendingEstimateRequest.id,
-            price:
-              Math.floor((150000 + Math.floor(Math.random() * 450000)) / 5000) *
-              5000, // 15만원 ~ 60만원 (5000원 단위)
+            price: Math.floor((150000 + Math.floor(Math.random() * 450000)) / 5000) * 5000, // 15만원 ~ 60만원 (5000원 단위)
             comment: `${mover.name}님의 견적 코멘트`,
             status: EstimateStatus.PROPOSED,
             workingHours: `${2 + (estimateCount % 5)}- ${4 + (estimateCount % 5)}시간`,
             includesPackaging: estimateCount % 2 === 0,
             insuranceAmount: 1000000 + estimateCount * 100000,
           },
-        })
+        }),
       );
       estimateCount++;
     }
 
     // 완료된 견적들에 대한 견적들 (3~6명의 기사가 견적 제출)
     for (let k = 0; k < 5; k++) {
-      const completedEstimateRequest =
-        estimateRequestsResult[userIdx * 6 + 1 + k]; // 완료된 견적들
+      const completedEstimateRequest = estimateRequestsResult[userIdx * 6 + 1 + k]; // 완료된 견적들
       const moverCount = 3 + Math.floor(Math.random() * 4); // 3~6명 랜덤
 
       for (let l = 0; l < moverCount; l++) {
@@ -257,19 +371,14 @@ async function main() {
             data: {
               moverId: mover.id,
               estimateRequestId: completedEstimateRequest.id,
-              price:
-                Math.floor(
-                  (150000 + Math.floor(Math.random() * 450000)) / 5000
-                ) * 5000, // 15만원 ~ 60만원 (5000원 단위)
+              price: Math.floor((150000 + Math.floor(Math.random() * 450000)) / 5000) * 5000, // 15만원 ~ 60만원 (5000원 단위)
               comment: `${mover.name}님의 견적 코멘트`,
-              status: isFirstEstimate
-                ? EstimateStatus.ACCEPTED
-                : EstimateStatus.AUTO_REJECTED,
+              status: isFirstEstimate ? EstimateStatus.ACCEPTED : EstimateStatus.AUTO_REJECTED,
               workingHours: `${2 + (estimateCount % 5)}- ${4 + (estimateCount % 5)}시간`,
               includesPackaging: estimateCount % 2 === 0,
               insuranceAmount: 1000000 + estimateCount * 100000,
             },
-          })
+          }),
         );
         estimateCount++;
       }
@@ -288,27 +397,18 @@ async function main() {
 
     // 이미 견적서를 보낸 기사들의 ID 수집
     const moversWhoSentEstimates = estimates
-      .filter(
-        (estimate) => estimate.estimateRequestId === pendingEstimateRequest.id
-      )
+      .filter((estimate) => estimate.estimateRequestId === pendingEstimateRequest.id)
       .map((estimate) => estimate.moverId);
 
     // 견적서를 보내지 않은 기사들만 필터링
-    const moversWhoDidNotSendEstimates = availableMovers.filter(
-      (mover) => !moversWhoSentEstimates.includes(mover.id)
-    );
+    const moversWhoDidNotSendEstimates = availableMovers.filter((mover) => !moversWhoSentEstimates.includes(mover.id));
 
     // 진행중인 견적에 대해 2-3명의 기사에게 지정 견적 요청 (견적서를 보내지 않은 기사들만)
-    const designatedCount = Math.min(
-      2 + Math.floor(Math.random() * 2),
-      moversWhoDidNotSendEstimates.length
-    ); // 2-3명
+    const designatedCount = Math.min(2 + Math.floor(Math.random() * 2), moversWhoDidNotSendEstimates.length); // 2-3명
 
     for (let j = 0; j < designatedCount; j++) {
       const mover = moversWhoDidNotSendEstimates[j];
-      const expiresAt = new Date(
-        pendingEstimateRequest.moveDate.getTime() - 24 * 60 * 60 * 1000
-      ); // 이사일 하루 전
+      const expiresAt = new Date(pendingEstimateRequest.moveDate.getTime() - 24 * 60 * 60 * 1000); // 이사일 하루 전
 
       designatedRequests.push(
         prisma.designatedMover.create({
@@ -319,7 +419,7 @@ async function main() {
             status: "PENDING",
             expiresAt: expiresAt,
           },
-        })
+        }),
       );
     }
   }
@@ -338,10 +438,7 @@ async function main() {
     const selectedMovers = [];
     const usedIndices = new Set();
 
-    while (
-      selectedMovers.length < favoriteCount &&
-      selectedMovers.length < availableMovers.length
-    ) {
+    while (selectedMovers.length < favoriteCount && selectedMovers.length < availableMovers.length) {
       const randomIdx = Math.floor(Math.random() * availableMovers.length);
       if (!usedIndices.has(randomIdx)) {
         usedIndices.add(randomIdx);
@@ -357,7 +454,7 @@ async function main() {
             customerId: user.id,
             moverId: mover.id,
           },
-        })
+        }),
       );
     }
   }
@@ -380,8 +477,8 @@ async function main() {
       prisma.user.update({
         where: { id: moverId },
         data: { totalFavoriteCount: count },
-      })
-    )
+      }),
+    ),
   );
 
   // 리뷰 생성 (완료된 견적에서 확정된 것들에 대해)
@@ -392,14 +489,12 @@ async function main() {
 
     // 완료된 견적들에 대해 리뷰 생성
     for (let k = 0; k < 5; k++) {
-      const completedEstimateRequest =
-        estimateRequestsResult[userIdx * 6 + 1 + k];
+      const completedEstimateRequest = estimateRequestsResult[userIdx * 6 + 1 + k];
 
       // 해당 견적 요청에서 수락된 견적을 찾기
       const acceptedEstimate = estimates.find(
         (estimate) =>
-          estimate.estimateRequestId === completedEstimateRequest.id &&
-          estimate.status === EstimateStatus.ACCEPTED
+          estimate.estimateRequestId === completedEstimateRequest.id && estimate.status === EstimateStatus.ACCEPTED,
       );
 
       if (acceptedEstimate) {
@@ -412,9 +507,8 @@ async function main() {
               estimateRequestId: completedEstimateRequest.id,
               rating: 3 + Math.floor(Math.random() * 3), // 3~5점 랜덤
               content: `${user.name}님의 리뷰 - ${acceptedEstimate.comment}`,
-              status: "COMPLETED",
             },
-          })
+          }),
         );
       }
     }
@@ -463,12 +557,11 @@ async function main() {
         where: { id: moverId },
         data: {
           totalReviewCount: stats.reviewCount,
-          averageRating:
-            stats.reviewCount > 0 ? stats.totalRating / stats.reviewCount : 0,
+          averageRating: stats.reviewCount > 0 ? stats.totalRating / stats.reviewCount : 0,
           workedCount: stats.workedCount,
         },
-      })
-    )
+      }),
+    ),
   );
 
   // 견적 요청 생성 활동 및 알림
@@ -505,7 +598,7 @@ async function main() {
             content: `${user.name}님이 견적을 요청했습니다.`,
             path: `/estimateRequest/${pendingEstimateRequest.id}`,
           },
-        })
+        }),
       );
     }
   }
@@ -544,14 +637,13 @@ async function main() {
             content: `${mover.name}님이 견적을 제출했습니다.`,
             path: `/estimateRequest/${pendingEstimateRequest.id}`,
           },
-        })
+        }),
       );
     }
 
     // 완료된 견적들에 대한 견적 제출 활동
     for (let k = 0; k < 5; k++) {
-      const completedEstimateRequest =
-        estimateRequestsResult[userIdx * 6 + 1 + k];
+      const completedEstimateRequest = estimateRequestsResult[userIdx * 6 + 1 + k];
       const moverCount = 3 + Math.floor(Math.random() * 4); // 3~6명
 
       for (let l = 0; l < moverCount; l++) {
@@ -579,7 +671,7 @@ async function main() {
               title: "새로운 견적이 도착했습니다",
               content: `${mover.name}님이 견적을 제출했습니다.`,
             },
-          })
+          }),
         );
 
         // 견적 수락/거절 알림 (기사에게)
@@ -604,7 +696,7 @@ async function main() {
                 content: `${user.name}님이 견적을 수락했습니다.`,
                 path: `/estimateRequest/${completedEstimateRequest.id}`,
               },
-            })
+            }),
           );
         } else {
           const rejectAction = await prisma.action.create({
@@ -627,7 +719,7 @@ async function main() {
                 content: `${user.name}님이 다른 견적을 선택했습니다.`,
                 path: `/estimateRequest/${completedEstimateRequest.id}`,
               },
-            })
+            }),
           );
         }
       }
@@ -635,10 +727,7 @@ async function main() {
   }
 
   // 모든 알림 생성
-  await Promise.all([
-    ...estimateRequestNotifications,
-    ...estimateNotifications,
-  ]);
+  await Promise.all([...estimateRequestNotifications, ...estimateNotifications]);
 
   console.log("✅ Seed completed successfully!");
   console.log(`👤 Created ${users.length} users (고객/기사/하이브리드)`);

--- a/src/repositories/estimateRequest.repository.ts
+++ b/src/repositories/estimateRequest.repository.ts
@@ -1,4 +1,5 @@
-import { PrismaClient, MoveType, RequestStatus, EstimateRequest } from "@prisma/client";
+import { PrismaClient, MoveType, RequestStatus, EstimateRequest, UserType } from "@prisma/client";
+import { getKoreaToday } from "../utils/dateUtils";
 
 const prisma = new PrismaClient();
 
@@ -36,6 +37,7 @@ const getActiveEstimateRequestByUserId = async (userId: string): Promise<any | n
       updatedAt: true,
       fromAddress: {
         select: {
+          postalCode: true,
           city: true,
           district: true,
           detail: true,
@@ -44,12 +46,31 @@ const getActiveEstimateRequestByUserId = async (userId: string): Promise<any | n
       },
       toAddress: {
         select: {
+          postalCode: true,
           city: true,
           district: true,
           detail: true,
           region: true,
         },
       },
+    },
+  });
+};
+
+const getEstimateRequestById = async (id: string): Promise<any | null> => {
+  return await prisma.estimateRequest.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      customerId: true,
+      moveType: true,
+      moveDate: true,
+      fromAddressId: true,
+      toAddressId: true,
+      description: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
     },
   });
 };
@@ -60,9 +81,12 @@ const updateEstimateRequest = async (id: string, updateData: any): Promise<Estim
   });
 };
 const cancelEstimateRequest = async (id: string): Promise<EstimateRequest> => {
+  // 한국 시간 기준으로 삭제한 날짜만 저장 (시간은 00:00:00)
+  const koreaToday = getKoreaToday();
+
   return await prisma.estimateRequest.update({
     where: { id },
-    data: { status: RequestStatus.CANCELLED, deletedAt: new Date() },
+    data: { status: RequestStatus.CANCELLED, deletedAt: koreaToday },
   });
 };
 const hasPendingRequest = async (userId: string): Promise<boolean> => {
@@ -105,19 +129,74 @@ const findOrCreateAddress = async ({
     where: { city, district, detail, region: region as any },
   });
   if (!address) {
+    // 우편번호는 나중에 업데이트하거나 빈 문자열로 설정
     address = await prisma.address.create({
       data: { city, district, detail, region: region as any, postalCode: "" },
     });
   }
   return address;
 };
+
+// 유저의 유형을 확인하는 메서드
+const checkUserType = async (userId: string): Promise<{ isCustomer: boolean; isMover: boolean }> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { userType: true, isCustomer: true, isMover: true },
+  });
+
+  if (!user) {
+    throw new Error("사용자를 찾을 수 없습니다.");
+  }
+
+  const isCustomer = user.userType.includes(UserType.CUSTOMER) || user.isCustomer === true;
+  const isMover = user.userType.includes(UserType.MOVER) || user.isMover === true;
+
+  return { isCustomer, isMover };
+};
+
+// 이사일이 지난 견적 요청을 만료 처리하는 메서드
+const expireOverdueRequests = async (today: Date): Promise<void> => {
+  await prisma.estimateRequest.updateMany({
+    where: {
+      moveDate: {
+        lt: today, // 이사일이 오늘보다 이전
+      },
+      status: RequestStatus.PENDING, // PENDING 상태인 것만
+      deletedAt: null,
+    },
+    data: {
+      status: RequestStatus.EXPIRED,
+      updatedAt: new Date(),
+    },
+  });
+};
+
+// 견적 요청이 만료되었는지 확인하는 메서드
+const isRequestExpired = async (estimateRequestId: string): Promise<boolean> => {
+  const request = await prisma.estimateRequest.findUnique({
+    where: { id: estimateRequestId },
+    select: { moveDate: true, status: true },
+  });
+
+  if (!request) {
+    return false;
+  }
+
+  const koreaToday = getKoreaToday();
+  return request.moveDate < koreaToday || request.status === RequestStatus.EXPIRED;
+};
+
 export default {
   createEstimateRequest,
   getActiveEstimateRequestByUserId,
+  getEstimateRequestById,
   updateEstimateRequest,
   cancelEstimateRequest,
   hasPendingRequest,
   isActiveRequestPending,
   hasEstimateFromMover,
   findOrCreateAddress,
+  checkUserType,
+  expireOverdueRequests,
+  isRequestExpired,
 };

--- a/src/routes/estimateRequest.routes.ts
+++ b/src/routes/estimateRequest.routes.ts
@@ -8,32 +8,68 @@ const estimateRequestController = new EstimateRequestController();
 /**
  * POST / (이사 견적 요청 생성)
  * @summary 이사 견적 요청 생성
- * @description 한 사용자는 PENDING 상태의 견적 요청이 1개만 존재할 수 있습니다. 기존 요청이 CANCELLED, EXPIRED, COMPLETED 상태일 때만 새로 생성할 수 있습니다.
+ * @description 한 사용자는 PENDING 상태의 견적 요청이 1개만 존재할 수 있습니다. 기존 요청이 CANCELLED, EXPIRED, COMPLETED 상태일 때만 새로 생성할 수 있습니다. 기사님은 견적 요청을 생성할 수 없습니다.
  * @tags EstimateRequest
  * @security BearerAuth
  * @param {object} request.body.required - 견적 요청 정보
- * @param {string} request.body.moveType.required - 이사 종류 (SMALL, HOME, OFFICE)
- * @param {string} request.body.fromAddressId.required - 출발지 주소 ID
- * @param {string} request.body.toAddressId.required - 도착지 주소 ID
- * @param {string} request.body.moveDate.required - 이사 날짜 (YYYY-MM-DD 형식)
+ * @param {string} request.body.movingType.required - 이사 종류 (small, home, office)
+ * @param {string} request.body.movingDate.required - 이사 날짜 (YYYY-MM-DD 형식, 오늘 이후만 가능)
+ * @param {object} request.body.departure.required - 출발지 주소 정보
+ * @param {string} request.body.departure.roadAddress.required - 출발지 도로명주소 (예: "서울특별시 강남구 테헤란로 123")
+ * @param {string} request.body.departure.detailAddress - 출발지 상세주소 (예: "456호")
+ * @param {object} request.body.arrival.required - 도착지 주소 정보
+ * @param {string} request.body.arrival.roadAddress.required - 도착지 도로명주소 (예: "경기도 성남시 분당구 판교로 456")
+ * @param {string} request.body.arrival.detailAddress - 도착지 상세주소 (예: "789호")
  * @param {string} request.body.description - 추가 설명
  * @returns {object} 201 - 견적 요청 생성 성공
+ * @returns {object} 400 - 잘못된 요청 (이사일이 과거, 출발지/도착지 동일 등)
+ * @returns {object} 403 - 기사님은 견적 요청을 생성할 수 없음
  * @returns {object} 409 - 이미 진행중인 견적 요청 존재
  * @returns {object} 401 - 인증 실패
  * @returns {object} 500 - 서버 내부 오류
  * @example request - 요청 예시
  * {
- *   "moveType": "HOME",
- *   "fromAddressId": "clx123abc456",
- *   "toAddressId": "clx789def012",
- *   "moveDate": "2024-07-01",
+ *   "movingType": "home",
+ *   "movingDate": "2024-07-01",
+ *   "departure": {
+ *     "roadAddress": "서울특별시 강남구 테헤란로 123",
+ *     "detailAddress": "456호"
+ *   },
+ *   "arrival": {
+ *     "roadAddress": "경기도 성남시 분당구 판교로 456",
+ *     "detailAddress": "789호"
+ *   },
  *   "description": "엘리베이터 있음, 반려동물 동반"
  * }
  * @example response - 201 - 성공 예시
  * {
  *   "success": true,
  *   "message": "견적 요청이 성공적으로 생성되었습니다.",
- *   "data": { "id": "abc123", "moveType": "HOME", "moveDate": "2024-07-01", "description": "엘리베이터 있음, 반려동물 동반" }
+ *   "data": {
+ *     "id": "abc123",
+ *     "movingType": "HOME",
+ *     "movingDate": "2024-07-01",
+ *     "departureAddress": "서울특별시 강남구 테헤란로 123",
+ *     "arrivalAddress": "경기도 성남시 분당구 판교로 456",
+ *     "departureDetailAddress": "456호",
+ *     "arrivalDetailAddress": "789호",
+ *     "description": "엘리베이터 있음, 반려동물 동반"
+ *   }
+ * }
+ * @example response - 400 - 이사일이 과거
+ * {
+ *   "success": false,
+ *   "message": "이사일은 오늘 이후로 설정해주세요."
+ * }
+ * @example response - 400 - 출발지와 도착지 동일
+ * {
+ *   "success": false,
+ *   "message": "출발지와 도착지는 달라야 합니다."
+ * }
+ * @example response - 403 - 기사님은 생성 불가
+ * {
+ *   "success": false,
+ *   "message": "기사님은 견적 요청을 생성할 수 없습니다. 일반 고객으로 로그인해주세요."
  * }
  * @example response - 409 - 이미 진행중인 견적 요청이 있습니다.
  * {
@@ -56,16 +92,40 @@ router.post("/", verifyAccessToken, estimateRequestController.createEstimateRequ
 /**
  * GET /active (활성 견적 요청 조회)
  * @summary 활성 견적 요청 조회
- * @description 현재 사용자의 활성 상태(PENDING) 견적 요청이 있는지 true/false로 반환합니다.
+ * @description 현재 사용자의 활성 상태(PENDING) 견적 요청이 있는지 확인하고, 만료된 요청은 자동으로 EXPIRED로 변경합니다. 기사님은 견적 요청을 조회할 수 없습니다.
  * @tags EstimateRequest
  * @security BearerAuth
  * @returns {object} 200 - 활성 견적 요청 조회 성공
+ * @returns {object} 403 - 기사님은 견적 요청을 조회할 수 없음
  * @returns {object} 401 - 인증 실패
  * @returns {object} 500 - 서버 내부 오류
- * @example response - 200 - 성공 예시
+ * @example response - 200 - 활성 견적 요청 있음
  * {
  *   "success": true,
- *   "hasActive": true
+ *   "hasActive": true,
+ *   "data": {
+ *     "id": "abc123",
+ *     "userId": "user123",
+ *     "movingType": "HOME",
+ *     "departureAddress": "서울특별시 강남구 테헤란로 123",
+ *     "arrivalAddress": "경기도 성남시 분당구 판교로 456",
+ *     "departureDetailAddress": "456호",
+ *     "arrivalDetailAddress": "789호",
+ *     "movingDate": "2024-07-01",
+ *     "status": "PENDING",
+ *     "createdAt": "2024-01-15T10:30:00.000Z",
+ *     "updatedAt": "2024-01-15T10:30:00.000Z"
+ *   }
+ * }
+ * @example response - 200 - 활성 견적 요청 없음
+ * {
+ *   "success": true,
+ *   "hasActive": false
+ * }
+ * @example response - 403 - 기사님은 조회 불가
+ * {
+ *   "success": false,
+ *   "message": "기사님은 견적 요청을 조회할 수 없습니다. 일반 고객으로 로그인해주세요."
  * }
  * @example response - 401 - 인증 실패
  * {
@@ -83,36 +143,79 @@ router.get("/active", verifyAccessToken, estimateRequestController.getActiveEsti
 /**
  * PATCH /active (활성 견적 요청 수정)
  * @summary 활성 견적 요청 수정
- * @description PENDING 상태일 때만 수정 가능
+ * @description PENDING 상태이면서 만료되지 않은 견적 요청만 수정 가능. 기사님은 수정할 수 없음.
  * @tags EstimateRequest
  * @security BearerAuth
  * @param {object} request.body.required - 수정할 견적 요청 정보
- * @param {string} request.body.moveType - 이사 종류 (SMALL, HOME, OFFICE)
- * @param {string} request.body.fromAddressId - 출발지 주소 ID
- * @param {string} request.body.toAddressId - 도착지 주소 ID
- * @param {string} request.body.moveDate - 이사 날짜 (YYYY-MM-DD 형식)
+ * @param {string} request.body.movingType.required - 이사 종류 (small, home, office)
+ * @param {string} request.body.movingDate.required - 이사 날짜 (YYYY-MM-DD 형식, 오늘 이후만 가능)
+ * @param {object} request.body.departure.required - 출발지 주소 정보
+ * @param {string} request.body.departure.roadAddress.required - 출발지 도로명주소 (예: "서울특별시 강남구 테헤란로 123")
+ * @param {string} request.body.departure.detailAddress - 출발지 상세주소 (예: "456호")
+ * @param {object} request.body.arrival.required - 도착지 주소 정보
+ * @param {string} request.body.arrival.roadAddress.required - 도착지 도로명주소 (예: "경기도 성남시 분당구 판교로 456")
+ * @param {string} request.body.arrival.detailAddress - 도착지 상세주소 (예: "789호")
  * @param {string} request.body.description - 추가 설명
  * @returns {object} 200 - 견적 요청 수정 성공
+ * @returns {object} 400 - 잘못된 요청 (이사일이 과거, 출발지/도착지 동일 등)
+ * @returns {object} 403 - 기사님은 견적 요청을 수정할 수 없음
  * @returns {object} 404 - 활성 견적 요청 없음
- * @returns {object} 409 - 진행중(PENDING) 상태가 아님/기사 견적 제출됨 등
+ * @returns {object} 409 - 진행중(PENDING) 상태가 아님/만료된 요청 등
  * @returns {object} 401 - 인증 실패
  * @returns {object} 500 - 서버 내부 오류
  * @example request - 요청 예시
  * {
- *   "moveType": "OFFICE",
- *   "moveDate": "2024-07-10",
+ *   "movingType": "office",
+ *   "movingDate": "2024-07-10",
+ *   "departure": {
+ *     "roadAddress": "서울특별시 강남구 테헤란로 123",
+ *     "detailAddress": "456호"
+ *   },
+ *   "arrival": {
+ *     "roadAddress": "경기도 성남시 분당구 판교로 456",
+ *     "detailAddress": "789호"
+ *   },
  *   "description": "짐이 많음, 사다리차 필요"
  * }
  * @example response - 200 - 성공 예시
  * {
  *   "success": true,
  *   "message": "견적 요청이 성공적으로 수정되었습니다.",
- *   "data": { "id": "abc123", "moveType": "OFFICE", "moveDate": "2024-07-10", "description": "짐이 많음, 사다리차 필요" }
+ *   "data": {
+ *     "id": "abc123",
+ *     "movingType": "OFFICE",
+ *     "movingDate": "2024-07-10",
+ *     "departureAddress": "서울특별시 강남구 테헤란로 123",
+ *     "arrivalAddress": "경기도 성남시 분당구 판교로 456",
+ *     "departureDetailAddress": "456호",
+ *     "arrivalDetailAddress": "789호",
+ *     "description": "짐이 많음, 사다리차 필요"
+ *   }
+ * }
+ * @example response - 400 - 이사일이 과거
+ * {
+ *   "success": false,
+ *   "message": "이사일은 오늘 이후로 설정해주세요."
+ * }
+ * @example response - 400 - 출발지와 도착지 동일
+ * {
+ *   "success": false,
+ *   "message": "출발지와 도착지는 달라야 합니다."
+ * }
+ * @example response - 403 - 기사님은 수정 불가
+ * {
+ *   "success": false,
+ *   "message": "기사님은 견적 요청을 수정할 수 없습니다. 일반 고객으로 로그인해주세요."
  * }
  * @example response - 409 - 진행중(PENDING) 상태가 아님
  * {
  *   "success": false,
  *   "message": "진행중(PENDING) 상태에서만 수정할 수 있습니다."
+ * }
+ * @example response - 409 - 만료된 요청
+ * {
+ *   "success": false,
+ *   "message": "이사일이 지나 만료된 견적 요청은 수정할 수 없습니다."
  * }
  * @example response - 404 - 활성 견적 요청 없음
  * {
@@ -135,14 +238,25 @@ router.patch("/active", verifyAccessToken, estimateRequestController.updateActiv
 /**
  * DELETE /active (활성 견적 요청 취소)
  * @summary 활성 견적 요청 취소
- * @description PENDING 상태이면서 기사 견적이 없는 경우만 취소 가능. 취소 시 상태는 CANCELLED로 변경
+ * @description PENDING 상태이면서 만료되지 않은 견적 요청만 취소 가능. 기사님이 견적을 제출한 경우 취소할 수 없습니다. 기사님은 견적 요청을 취소할 수 없습니다. 취소 시 상태는 CANCELLED로 변경됩니다.
  * @tags EstimateRequest
  * @security BearerAuth
- * @returns {object} 204 - 견적 요청 취소 성공 (No Content)
+ * @returns {object} 200 - 견적 요청 취소 성공
+ * @returns {object} 403 - 기사님은 견적 요청을 취소할 수 없음
  * @returns {object} 404 - 활성 견적 요청 없음
- * @returns {object} 409 - 진행중(PENDING) 상태가 아님/기사 견적 제출됨 등
+ * @returns {object} 409 - 진행중(PENDING) 상태가 아님/기사 견적 제출됨/만료된 요청 등
  * @returns {object} 401 - 인증 실패
  * @returns {object} 500 - 서버 내부 오류
+ * @example response - 200 - 취소 성공
+ * {
+ *   "success": true,
+ *   "message": "견적 요청이 취소되었습니다."
+ * }
+ * @example response - 403 - 기사님은 취소 불가
+ * {
+ *   "success": false,
+ *   "message": "기사님은 견적 요청을 취소할 수 없습니다. 일반 고객으로 로그인해주세요."
+ * }
  * @example response - 409 - 진행중(PENDING) 상태가 아님
  * {
  *   "success": false,
@@ -151,7 +265,12 @@ router.patch("/active", verifyAccessToken, estimateRequestController.updateActiv
  * @example response - 409 - 기사 견적 제출됨
  * {
  *   "success": false,
- *   "message": "기사님이 견적을 제출한 경우 취소할 수 없습니다."
+ *   "message": "기사님이 견적을 제출한 경우 취소할 수 없습니다. 견적을 확인한 후 결정해주세요."
+ * }
+ * @example response - 409 - 만료된 요청
+ * {
+ *   "success": false,
+ *   "message": "이사일이 지나 만료된 견적 요청은 취소할 수 없습니다."
  * }
  * @example response - 404 - 활성 견적 요청 없음
  * {

--- a/src/services/estimateRequest.service.ts
+++ b/src/services/estimateRequest.service.ts
@@ -1,54 +1,135 @@
 import estimateRequestRepository from "../repositories/estimateRequest.repository";
-import { TCreateEstimateRequest } from "../types/estimateRequest.types";
-// Prisma 관련 import 및 선언 제거
+import { TCreateEstimateRequest, TUpdateEstimateRequest } from "../types/estimateRequest.types";
+import { getKoreaToday } from "../utils/dateUtils";
 
 class EstimateRequestService {
+  // 유저의 유형을 확인하는 메서드
+  async checkUserType(userId: string): Promise<{ isCustomer: boolean; isMover: boolean }> {
+    return await estimateRequestRepository.checkUserType(userId);
+  }
+
   async hasPendingRequest(userId: string): Promise<boolean> {
     return await estimateRequestRepository.hasPendingRequest(userId);
   }
+
   async isActiveRequestPending(userId: string): Promise<boolean> {
     return await estimateRequestRepository.isActiveRequestPending(userId);
   }
+
   async hasEstimateFromMover(userId: string): Promise<boolean> {
     return await estimateRequestRepository.hasEstimateFromMover(userId);
   }
+
+  // 이사일이 지난 견적 요청을 만료 처리하는 메서드
+  async expireOverdueRequests(): Promise<void> {
+    const koreaToday = getKoreaToday();
+    await estimateRequestRepository.expireOverdueRequests(koreaToday);
+  }
+
+  // 견적 요청이 만료되었는지 확인하는 메서드
+  async isRequestExpired(estimateRequestId: string): Promise<boolean> {
+    return await estimateRequestRepository.isRequestExpired(estimateRequestId);
+  }
+
   async getActiveEstimateRequestByUserId(userId: string) {
     return await estimateRequestRepository.getActiveEstimateRequestByUserId(userId);
   }
+
   async createEstimateRequest(params: TCreateEstimateRequest) {
-    const {
-      userId,
-      moveType,
-      fromCity,
-      fromDistrict,
-      fromDetail,
-      fromRegion,
-      toCity,
-      toDistrict,
-      toDetail,
-      toRegion,
-      moveDate,
-      description,
-    } = params;
-    // 출발지 주소 생성 또는 검색 (레포 함수 사용)
-    const fromAddress = await estimateRequestRepository.findOrCreateAddress({
-      city: fromCity,
-      district: fromDistrict,
-      detail: fromDetail,
-      region: fromRegion,
-    });
-    // 도착지 주소 생성 또는 검색 (레포 함수 사용)
-    const toAddress = await estimateRequestRepository.findOrCreateAddress({
-      city: toCity,
-      district: toDistrict,
-      detail: toDetail,
-      region: toRegion,
-    });
+    const { userId, movingType, movingDate, departure, arrival, description } = params;
+
+    // 주소 파싱 함수
+    const parseAddress = (addressObj: any) => {
+      const roadAddress = addressObj.roadAddress;
+      console.log("파싱할 주소:", roadAddress); // 디버깅용
+
+      // 카카오 주소 API에서 오는 형태: "서울특별시 강남구 테헤란로 123"
+      // 또는 "경기도 성남시 분당구 경부고속도로 409"
+
+      // 주소를 공백으로 분리
+      const parts = roadAddress.split(" ");
+      console.log("분리된 주소 부분들:", parts); // 디버깅용
+
+      // 첫 번째 부분이 시/도인지 확인
+      const firstPart = parts[0];
+      console.log("첫 번째 부분:", firstPart); // 디버깅용
+
+      // 시/도 매핑이 가능한지 확인
+      const mappedRegion = this.mapRegionToEnum(firstPart);
+      console.log("매핑된 지역:", mappedRegion); // 디버깅용
+
+      // 매핑이 성공한 경우 (첫 번째 부분이 시/도인 경우)
+      if (mappedRegion !== "SEOUL" || firstPart === "서울" || firstPart === "서울특별시") {
+        if (parts.length >= 4) {
+          // "서울특별시 강남구 역삼동 테헤란로 123" 형태
+          const region = parts[0]; // 서울특별시
+          const city = parts[1]; // 강남구
+          const district = parts[2]; // 역삼동
+          const detail = parts.slice(3).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
+
+          console.log("파싱 결과 (4개 이상):", { region, city, district, detail }); // 디버깅용
+
+          return {
+            city,
+            district,
+            detail,
+            region: this.mapRegionToEnum(region),
+          };
+        } else if (parts.length === 3) {
+          // "서울특별시 강남구 테헤란로 123" 형태
+          const region = parts[0]; // 서울특별시
+          const city = parts[1]; // 강남구
+          const district = ""; // 빈 문자열
+          const detail = parts.slice(2).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
+
+          console.log("파싱 결과 (3개):", { region, city, district, detail }); // 디버깅용
+
+          return {
+            city,
+            district,
+            detail,
+            region: this.mapRegionToEnum(region),
+          };
+        } else if (parts.length === 2) {
+          // "강원특별자치도 홍천군" 형태 - city에 다 넣지 말고 detail에 넣기
+          const region = parts[0]; // 강원특별자치도
+          const city = ""; // 빈 문자열로 설정
+          const detail = parts[1] + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 홍천군 1
+
+          console.log("파싱 결과 (2개):", { region, city, district: "", detail }); // 디버깅용
+
+          return {
+            city,
+            district: "",
+            detail,
+            region: this.mapRegionToEnum(region),
+          };
+        }
+      }
+
+      // 매핑되지 않는 경우 기본값
+      console.log("매핑되지 않는 주소 형태, 기본값 사용");
+      return {
+        city: roadAddress,
+        district: "",
+        detail: addressObj.detailAddress || "",
+        region: "SEOUL" as any,
+      };
+    };
+
+    // 출발지 주소 생성 또는 검색
+    const fromAddressData = parseAddress(departure);
+    const fromAddress = await estimateRequestRepository.findOrCreateAddress(fromAddressData);
+
+    // 도착지 주소 생성 또는 검색
+    const toAddressData = parseAddress(arrival);
+    const toAddress = await estimateRequestRepository.findOrCreateAddress(toAddressData);
+
     // EstimateRequest 생성
     return await estimateRequestRepository.createEstimateRequest(
       {
-        moveType,
-        moveDate,
+        moveType: movingType.toUpperCase(),
+        moveDate: movingDate,
         fromAddressId: fromAddress.id,
         toAddressId: toAddress.id,
         description,
@@ -57,19 +138,203 @@ class EstimateRequestService {
     );
   }
 
-  async updateActiveEstimateRequest(id: string, updateData: any) {
-    // moveDate가 있으면 Date 타입으로 변환
-    if (updateData.moveDate) {
-      updateData.moveDate = new Date(updateData.moveDate);
+  async updateActiveEstimateRequest(id: string, updateData: TUpdateEstimateRequest) {
+    const updatePayload: any = {};
+
+    // moveType 업데이트
+    if (updateData.movingType) {
+      updatePayload.moveType = updateData.movingType.toUpperCase();
     }
-    return await estimateRequestRepository.updateEstimateRequest(id, updateData);
+
+    // moveDate 업데이트
+    if (updateData.movingDate) {
+      updatePayload.moveDate = new Date(updateData.movingDate);
+    }
+
+    // description 업데이트
+    if (updateData.description !== undefined) {
+      updatePayload.description = updateData.description;
+    }
+
+    // 주소 업데이트가 있는 경우
+    if (updateData.departure || updateData.arrival) {
+      const currentRequest = await estimateRequestRepository.getEstimateRequestById(id);
+      if (!currentRequest) {
+        throw new Error("견적 요청을 찾을 수 없습니다.");
+      }
+
+      // 주소 파싱 함수
+      const parseAddress = (addressObj: any) => {
+        const roadAddress = addressObj.roadAddress;
+        console.log("업데이트 파싱할 주소:", roadAddress); // 디버깅용
+
+        // 카카오 주소 API에서 오는 형태: "서울특별시 강남구 테헤란로 123"
+        // 또는 "경기도 성남시 분당구 경부고속도로 409"
+
+        // 주소를 공백으로 분리
+        const parts = roadAddress.split(" ");
+        console.log("업데이트 분리된 주소 부분들:", parts); // 디버깅용
+
+        // 첫 번째 부분이 시/도인지 확인
+        const firstPart = parts[0];
+        console.log("업데이트 첫 번째 부분:", firstPart); // 디버깅용
+
+        // 시/도 매핑이 가능한지 확인
+        const mappedRegion = this.mapRegionToEnum(firstPart);
+        console.log("업데이트 매핑된 지역:", mappedRegion); // 디버깅용
+
+        // 매핑이 성공한 경우 (첫 번째 부분이 시/도인 경우)
+        if (mappedRegion !== "SEOUL" || firstPart === "서울" || firstPart === "서울특별시") {
+          if (parts.length >= 4) {
+            // "서울특별시 강남구 역삼동 테헤란로 123" 형태
+            const region = parts[0]; // 서울특별시
+            const city = parts[1]; // 강남구
+            const district = parts[2]; // 역삼동
+            const detail = parts.slice(3).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
+
+            console.log("업데이트 파싱 결과 (4개 이상):", { region, city, district, detail }); // 디버깅용
+
+            return {
+              city,
+              district,
+              detail,
+              region: this.mapRegionToEnum(region),
+            };
+          } else if (parts.length === 3) {
+            // "서울특별시 강남구 테헤란로 123" 형태
+            const region = parts[0]; // 서울특별시
+            const city = parts[1]; // 강남구
+            const district = ""; // 빈 문자열
+            const detail = parts.slice(2).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
+
+            console.log("업데이트 파싱 결과 (3개):", { region, city, district, detail }); // 디버깅용
+
+            return {
+              city,
+              district,
+              detail,
+              region: this.mapRegionToEnum(region),
+            };
+          } else if (parts.length === 2) {
+            // "강원특별자치도 홍천군" 형태 - city에 다 넣지 말고 detail에 넣기
+            const region = parts[0]; // 강원특별자치도
+            const city = ""; // 빈 문자열로 설정
+            const detail = parts[1] + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 홍천군 1
+
+            console.log("업데이트 파싱 결과 (2개):", { region, city, district: "", detail }); // 디버깅용
+
+            return {
+              city,
+              district: "",
+              detail,
+              region: this.mapRegionToEnum(region),
+            };
+          }
+        }
+
+        // 매핑되지 않는 경우 기본값
+        console.log("업데이트 매핑되지 않는 주소 형태, 기본값 사용");
+        return {
+          city: roadAddress,
+          district: "",
+          detail: addressObj.detailAddress || "",
+          region: "SEOUL" as any,
+        };
+      };
+
+      // 출발지 주소 업데이트
+      if (updateData.departure) {
+        const fromAddressData = parseAddress(updateData.departure);
+        const fromAddress = await estimateRequestRepository.findOrCreateAddress(fromAddressData);
+        updatePayload.fromAddressId = fromAddress.id;
+      }
+
+      // 도착지 주소 업데이트
+      if (updateData.arrival) {
+        const toAddressData = parseAddress(updateData.arrival);
+        const toAddress = await estimateRequestRepository.findOrCreateAddress(toAddressData);
+        updatePayload.toAddressId = toAddress.id;
+      }
+    }
+
+    return await estimateRequestRepository.updateEstimateRequest(id, updatePayload);
   }
 
   async cancelActiveEstimateRequest(id: string) {
     return await estimateRequestRepository.cancelEstimateRequest(id);
   }
 
-  // findOrCreateAddress 함수는 더 이상 서비스에 필요 없음
-  // 기타 필요한 estimateRequest 관련 메서드 추가 가능
+  // 한국 지역명을 enum으로 매핑
+  private mapRegionToEnum(region: string): string {
+    console.log("매핑할 지역명:", region); // 디버깅용
+
+    const regionMap: { [key: string]: string } = {
+      // 한국어 지역명
+      서울특별시: "SEOUL",
+      서울: "SEOUL",
+      부산광역시: "BUSAN",
+      부산: "BUSAN",
+      대구광역시: "DAEGU",
+      대구: "DAEGU",
+      인천광역시: "INCHEON",
+      인천: "INCHEON",
+      광주광역시: "GWANGJU",
+      광주: "GWANGJU",
+      대전광역시: "DAEJEON",
+      대전: "DAEJEON",
+      울산광역시: "ULSAN",
+      울산: "ULSAN",
+      세종특별자치시: "SEJONG",
+      세종: "SEJONG",
+      경기도: "GYEONGGI",
+      경기: "GYEONGGI",
+      강원도: "GANGWON",
+      강원: "GANGWON",
+      강원특별자치도: "GANGWON",
+      충청북도: "CHUNGBUK",
+      충북: "CHUNGBUK",
+      충청남도: "CHUNGNAM",
+      충남: "CHUNGNAM",
+      전라북도: "JEONBUK",
+      전북: "JEONBUK",
+      전라남도: "JEONNAM",
+      전남: "JEONNAM",
+      경상북도: "GYEONGBUK",
+      경북: "GYEONGBUK",
+      경상남도: "GYEONGNAM",
+      경남: "GYEONGNAM",
+      제주특별자치도: "JEJU",
+      제주: "JEJU",
+
+      // 영어 지역명 (카카오 주소 API에서 오는 경우)
+      SEOUL: "SEOUL",
+      BUSAN: "BUSAN",
+      DAEGU: "DAEGU",
+      INCHEON: "INCHEON",
+      GWANGJU: "GWANGJU",
+      DAEJEON: "DAEJEON",
+      ULSAN: "ULSAN",
+      SEJONG: "SEJONG",
+      GYEONGGI: "GYEONGGI",
+      GANGWON: "GANGWON",
+      CHUNGBUK: "CHUNGBUK",
+      CHUNGNAM: "CHUNGNAM",
+      JEONBUK: "JEONBUK",
+      JEONNAM: "JEONNAM",
+      GYEONGBUK: "GYEONGBUK",
+      GYEONGNAM: "GYEONGNAM",
+      JEJU: "JEJU",
+    };
+
+    const mappedRegion = regionMap[region];
+    if (!mappedRegion) {
+      console.warn(`매핑되지 않은 지역명: "${region}", 기본값 SEOUL 사용`);
+    } else {
+      console.log(`지역명 매핑: "${region}" -> "${mappedRegion}"`);
+    }
+
+    return mappedRegion || "SEOUL";
+  }
 }
+
 export default EstimateRequestService;

--- a/src/types/estimateRequest.types.ts
+++ b/src/types/estimateRequest.types.ts
@@ -1,14 +1,40 @@
 export type TCreateEstimateRequest = {
   userId: string;
-  moveType: string;
-  fromCity: string;
-  fromDistrict: string;
-  fromDetail?: string;
-  fromRegion: string;
-  toCity: string;
-  toDistrict: string;
-  toDetail?: string;
-  toRegion: string;
-  moveDate: string;
+  movingType: string;
+  movingDate: string;
+  departure: {
+    roadAddress: string;
+    detailAddress?: string;
+    zonecode: string;
+    jibunAddress: string;
+    extraAddress: string;
+  };
+  arrival: {
+    roadAddress: string;
+    detailAddress?: string;
+    zonecode: string;
+    jibunAddress: string;
+    extraAddress: string;
+  };
+  description?: string;
+};
+
+export type TUpdateEstimateRequest = {
+  movingType?: string;
+  movingDate?: string;
+  departure?: {
+    roadAddress: string;
+    detailAddress?: string;
+    zonecode: string;
+    jibunAddress: string;
+    extraAddress: string;
+  };
+  arrival?: {
+    roadAddress: string;
+    detailAddress?: string;
+    zonecode: string;
+    jibunAddress: string;
+    extraAddress: string;
+  };
   description?: string;
 };

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,21 @@
+/**
+ * 한국 시간(KST) 기준으로 오늘 날짜의 시작(00:00:00)을 반환합니다.
+ * @returns 한국 시간 기준 오늘 날짜의 시작
+ */
+export const getKoreaToday = (): Date => {
+  const today = new Date();
+  // 한국 시간(KST) 기준으로 오늘 날짜 계산
+  const koreaTime = new Date(today.toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+  koreaTime.setHours(0, 0, 0, 0);
+  return koreaTime;
+};
+
+/**
+ * 주어진 날짜가 한국 시간 기준 오늘보다 이전인지 확인합니다.
+ * @param date 확인할 날짜
+ * @returns 오늘보다 이전이면 true, 아니면 false
+ */
+export const isBeforeKoreaToday = (date: Date): boolean => {
+  const koreaToday = getKoreaToday();
+  return date < koreaToday;
+};


### PR DESCRIPTION
## ✨ 작업 개요

- 견적 요청 리팩토링

## ✅ 주요 작업 내용
- 프론트 응답에 백엔드 매핑하도록 로직 수정
- 유저 타입에 맞게 기사님 타입일 경우 모든 api 에러 처리
- 본인 견적을 본인이 수락 못하게 에러 처리
- 삭제 시 deletedAt에 날짜 기입
## 🔄 관련 이슈

#146

## 📎 참고 자료 (선택)

- API 명세서: swagger

## 🧪 테스트 방법 (선택)
- 프론트 연동 확인함
- 데이터 넣어진거 확인함
## 📝 비고
- 또 한번의 수정이 필요할 거 같아 일단 이슈는 안닫고 있겠습니다