### PR TITLE
Feat:찜하기 상태 확인

### DIFF
--- a/src/controllers/favorite.controller.ts
+++ b/src/controllers/favorite.controller.ts
@@ -105,6 +105,45 @@ class FavoriteController {
       });
     }
   }
+
+  // 찜하기 상태 확인
+  async getFavoriteStatus(req: IUserRequest, res: Response) {
+    try {
+      const customerId = req.user?.userId;
+      const moverId = req.params.moverId;
+
+      // 입력 검증
+      if (!moverId || typeof moverId !== "string") {
+        return res.status(400).json({
+          success: false,
+          message: "유효하지 않은 기사님 ID입니다.",
+        });
+      }
+
+      // 사용자 역할 검증 (일반 유저만 찜하기 가능)
+      const userType = req.user?.userType;
+      if (userType !== "CUSTOMER") {
+        return res.status(403).json({
+          success: false,
+          message: "일반 유저만 찜하기를 사용할 수 있습니다.",
+        });
+      }
+
+      const status = await favoriteRepository.getFavoriteStatus(customerId!, moverId);
+
+      return res.status(200).json({
+        success: true,
+        message: "찜하기 상태를 성공적으로 조회했습니다.",
+        data: status,
+      });
+    } catch (error) {
+      console.error("찜하기 상태 확인 컨트롤러 오류:", error);
+      return res.status(500).json({
+        success: false,
+        message: "서버 내부 오류가 발생했습니다.",
+      });
+    }
+  }
 }
 
 export default new FavoriteController();

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -78,6 +78,11 @@ const getMoverProfile = async (userId: string) => {
       detailIntro: true,
       serviceTypes: true,
       currentAreas: true,
+      isVeteran: true,
+      workedCount: true,
+      averageRating: true,
+      totalReviewCount: true,
+      totalFavoriteCount: true,
     },
   });
   return profile;
@@ -141,6 +146,11 @@ const createMoverProfile = async (profileData: TCreateMoverProfile) => {
       detailIntro: true,
       serviceTypes: true,
       currentAreas: true,
+      isVeteran: true,
+      workedCount: true,
+      averageRating: true,
+      totalReviewCount: true,
+      totalFavoriteCount: true,
     },
   });
 
@@ -171,6 +181,10 @@ const updateMoverProfile = async (
       serviceTypes: true,
       currentAreas: true,
       isVeteran: true,
+      workedCount: true,
+      averageRating: true,
+      totalReviewCount: true,
+      totalFavoriteCount: true,
     },
   });
 };

--- a/src/routes/favorite.routes.ts
+++ b/src/routes/favorite.routes.ts
@@ -33,6 +33,29 @@ const router = Router();
 router.post("/", verifyAccessToken, favoriteController.addFavorite);
 
 /**
+ * GET /favorites/:moverId/status
+ * @summary 찜하기 상태 확인
+ * @tags Favorites
+ * @security BearerAuth
+ * @param {string} moverId.path.required - 기사님 ID
+ * @return {object} 200 - 찜하기 상태 조회 성공
+ * @return {object} 400 - 잘못된 요청
+ * @return {object} 401 - 인증 실패
+ * @return {object} 403 - 권한 없음
+ * @return {object} 500 - 서버 오류
+ * @example response - 200 - 찜하기 상태 조회 성공
+ * {
+ *   "success": true,
+ *   "message": "찜하기 상태를 성공적으로 조회했습니다.",
+ *   "data": {
+ *     "isFavorited": true,
+ *     "favoriteCount": 5
+ *   }
+ * }
+ */
+router.get("/:moverId/status", verifyAccessToken, favoriteController.getFavoriteStatus);
+
+/**
  * DELETE /favorites/:moverId
  * @summary 찜하기 제거
  * @tags Favorites


### PR DESCRIPTION
## ✨ 작업 개요

- 기사님 찜하기 상태를 실시간으로 확인할 수 있는 API를 구현하여 프론트엔드에서 찜하기 버튼의 상태를 정확하게 표시할 수 있도록 했습니다.
- 찜하기 상태와 함께 해당 기사님의 총 찜 개수를 함께 제공하여 UI에서 활용할 수 있도록 했습니다.

## ✅ 주요 작업 내용

- 찜하기 상태 확인 API 구현 (GET /favorites/:moverId/status)
- 특정 기사님에 대한 현재 사용자의 찜하기 상태 조회

## 🔄 관련 이슈

Closes #

## 📎 참고 자료 (선택)

- API 명세서: [링크]

## 🧪 테스트 방법 (선택)

- [ ] 고객으로 로그인 후 특정 기사님의 찜하기 상태 조회 API 호출
- [ ] 기사님의 총 찜 개수가 정확하게 계산되어 반환되는지 확인

## 📝 비고

- (추가 예정 기능, 보완 필요 등)
