### PR TITLE
[#155] Refactor/notification 스키마 변경에 따른 타입 변경 및 액션별 알림 메시지 매핑 수정.

### DIFF
--- a/src/controllers/actionTest.controller.ts
+++ b/src/controllers/actionTest.controller.ts
@@ -7,7 +7,7 @@ const actionTestController = {
   createTestAction: async (req: Request, res: Response) => {
     try {
       // 테스트용 임의 값 (userId, entityId 등은 실제 존재하는 값으로 대체 필요)
-      const userId = Number(req.user?.userId);
+      const userId = req.user?.userId;
       if (!userId) {
         return res
           .status(400)
@@ -15,9 +15,9 @@ const actionTestController = {
       }
       const testAction = await actionService.createAction(
         userId, // userId
-        ActionType.QUOTE_CREATE, // type
-        7, // entityId (예: quoteId)
-        "QUOTE", // entityType
+        ActionType.ESTIMATE_REQUEST_CREATE, // type
+        "cmdgsc8cx00ft4wv3u8v53uhk", // entityId (예: quoteId)
+        "EstimateRequest", // entityType
         { memo: "테스트용 액션 생성" } // metadata
       );
       res.status(201).json({ success: true, data: testAction });

--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -5,16 +5,16 @@ const notificationController = {
   // 알림 목록 조회
   getNotifications: async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const userId = Number(req.user?.userId);
+      const userId = req.user?.userId;
       if (!userId) {
         return res
           .status(400)
           .json({ success: false, message: "해당 유저를 찾을수 없습니다." });
       }
-      const limit = Number(req.query.limit) || 20;
+      const limit = Number(req.query.limit) || 5;
       const offset = Number(req.query.offset) || 0;
       const notifications = await notificationService.getNotifications(
-        userId,
+        userId as string,
         limit,
         offset
       );
@@ -30,14 +30,14 @@ const notificationController = {
   // 알림 읽음 처리
   readNotification: async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const notificationId = Number(req.params.notificationId);
+      const notificationId = req.params.notificationId;
       if (!notificationId) {
         return res
           .status(400)
           .json({ success: false, message: "해당 알림을 찾을수 없습니다." });
       }
       const notification =
-        await notificationService.readNotification(notificationId);
+        await notificationService.readNotification(notificationId as string);
       res.json({
         success: true,
         message: "알림이 읽음 처리되었습니다.",
@@ -54,13 +54,13 @@ const notificationController = {
     next: NextFunction
   ) => {
     try {
-      const userId = Number(req.user?.userId);
+      const userId = req.user?.userId;
       if (!userId) {
         return res
           .status(400)
           .json({ success: false, message: "해당 유저를 찾을수 없습니다." });
       }
-      const count = await notificationService.readAllNotifications(userId);
+      const count = await notificationService.readAllNotifications(userId as string);
       res.json({
         success: true,
         message: "모든 알림이 읽음 처리되었습니다.",

--- a/src/middlewares/notificationMiddleware.ts
+++ b/src/middlewares/notificationMiddleware.ts
@@ -1,17 +1,19 @@
-import { Prisma } from '@prisma/client';
-import prisma from '../db/prisma/prisma';
-import { actionNotificationMap } from '../utils/actionNotificationMap';
-import { emitNotificationSSE } from '../utils/emitNotificationSSE';
-import { Action } from '@prisma/client';
-
+import { Prisma } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
+import { actionNotificationMap } from "../utils/actionNotificationMap";
+import { emitNotificationSSE } from "../utils/emitNotificationSSE";
+import { Action } from "@prisma/client";
 
 // Prisma 미들웨어: actionCreate 함수에서 새로운 액션이 생성될 때 notification 자동 생성.
-export const notificationMiddleware: Prisma.Middleware = async (params, next) => {
+export const notificationMiddleware: Prisma.Middleware = async (
+  params,
+  next
+) => {
   const result = await next(params);
 
   // 액션 생성 감지
-  if (params.model === 'Action' && params.action === 'create') {
-    const action = result as Action; 
+  if (params.model === "Action" && params.action === "create") {
+    const action = result as Action;
 
     const mapping = actionNotificationMap[action.type];
     if (!mapping) return result;
@@ -20,7 +22,7 @@ export const notificationMiddleware: Prisma.Middleware = async (params, next) =>
 
     const notifications = await Promise.all(
       receivers.map(async (receiver) => {
-        const message = mapping.buildMessage(action, receiver.role);
+        const message = mapping.buildMessage(action, receiver.userType);
         return prisma.notification.create({
           data: {
             userId: receiver.id,
@@ -28,9 +30,7 @@ export const notificationMiddleware: Prisma.Middleware = async (params, next) =>
             type: mapping.type,
             title: message.title,
             content: message.content,
-            actionUrl: message.actionUrl,
-            isRealTime: true,
-            sseSent: false,
+            path: message.path,
           },
         });
       })
@@ -38,15 +38,7 @@ export const notificationMiddleware: Prisma.Middleware = async (params, next) =>
 
     // 실시간 알림 SSE 전송
     for (const notification of notifications) {
-      emitNotificationSSE(notification.userId, {
-        notification,
-        unreadCount: await prisma.notification.count({
-          where: {
-            userId: notification.userId,
-            isRead: false, 
-          },
-        }),
-      });
+      emitNotificationSSE(notification.userId, notification);
     }
   }
 

--- a/src/repositories/action.repository.ts
+++ b/src/repositories/action.repository.ts
@@ -2,9 +2,9 @@ import prisma from "../db/prisma/prisma";
 import { ActionType } from "@prisma/client";
 
 interface CreateActionParams {
-  userId: number;
+  userId: string;
   type: ActionType;
-  entityId: number;
+  entityId: string;
   entityType: string;
   metadata: object;
 }

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -1,7 +1,7 @@
 import prisma from "../db/prisma/prisma";
 
 const notificationRepository = {
-  getNotifications: async (userId: number, limit: number, offset: number) => {
+  getNotifications: async (userId: string, limit: number, offset: number) => {
     const [items, total] = await Promise.all([
       prisma.notification.findMany({
         where: { userId },
@@ -14,20 +14,20 @@ const notificationRepository = {
     return { items, total, limit, offset };
   },
   // 안읽은 알림 존재 여부 반환
-  hasUnreadNotification: async (userId: number) => {
+  hasUnreadNotification: async (userId: string) => {
     const unread = await prisma.notification.findFirst({
       where: { userId, isRead: false },
       select: { id: true },
     });
     return !!unread;
   },
-  readNotification: async (notificationId: number) => {
+  readNotification: async (notificationId: string) => {
     return prisma.notification.update({
       where: { id: notificationId },
       data: { isRead: true },
     });
   },
-  readAllNotifications: async (userId: number) => {
+  readAllNotifications: async (userId: string) => {
     const { count } = await prisma.notification.updateMany({
       where: { userId, isRead: false },
       data: { isRead: true },

--- a/src/routes/notification.route.ts
+++ b/src/routes/notification.route.ts
@@ -4,19 +4,87 @@ import { verifyAccessToken } from "../middlewares/verifyToken";
 
 const notificationRouter = Router();
 
-// 알림 목록 조회
+/**
+ * GET /notifications
+ * @summary 알림 목록 조회
+ * @description 로그인한 사용자의 알림 목록을 조회합니다.
+ * @tags Notification
+ * @security BearerAuth
+ * @param {number} limit.query - 한 번에 가져올 알림 개수 (기본값: 5)
+ * @param {number} offset.query - 페이지네이션 오프셋 (기본값: 0)
+ * @returns {object} 200 - 알림 목록 조회 성공
+ * @example response - 200 - 성공 예시
+ * {
+ *   "success": true,
+ *   "message": "알림 목록입니다.",
+ *   "data": {
+ *     "items": [
+ *       {
+ *         "id": "clx...",
+ *         "actionId": "clx...",
+ *         "userId": "clx...",
+ *         "type": "ESTIMATE_ARRIVED",
+ *         "title": "새 견적 요청이 등록되었습니다.",
+ *         "content": "새로운 견적 요청이 등록되었습니다.",
+ *         "path": "/estimateRequests/clx...",
+ *         "isRead": false,
+ *         "createdAt": "2025-07-10T00:33:16.456Z",
+ *         "updatedAt": "2025-07-10T00:33:16.456Z"
+ *       }
+ *     ],
+ *     "total": 10,
+ *     "limit": 5,
+ *     "offset": 0,
+ *     "hasUnread": true
+ *   }
+ * }
+ */
 notificationRouter.get(
   "/",
   verifyAccessToken,
   notificationController.getNotifications
 );
-// 알림 읽음 처리
+
+/**
+ * PATCH /notifications/:notificationId/read
+ * @summary 알림 읽음 처리
+ * @description 특정 알림을 읽음 처리합니다.
+ * @tags Notification
+ * @security BearerAuth
+ * @param {string} notificationId.path.required - 알림 ID (cuid)
+ * @returns {object} 200 - 알림 읽음 처리 성공
+ * @example response - 200 - 성공 예시
+ * {
+ *   "success": true,
+ *   "message": "알림이 읽음 처리되었습니다.",
+ *   "data": {
+ *     "id": "clx...",
+ *     "isRead": true
+ *   }
+ * }
+ */
 notificationRouter.patch(
   "/:notificationId/read",
   verifyAccessToken,
   notificationController.readNotification
 );
-// 전체 알림 읽음 처리
+
+/**
+ * PATCH /notifications/read-all
+ * @summary 전체 알림 읽음 처리
+ * @description 로그인한 사용자의 모든 알림을 읽음 처리합니다.
+ * @tags Notification
+ * @security BearerAuth
+ * @returns {object} 200 - 전체 알림 읽음 처리 성공
+ * @example response - 200 - 성공 예시
+ * {
+ *   "success": true,
+ *   "message": "모든 알림이 읽음 처리되었습니다.",
+ *   "data": {
+ *     "count": 7
+ *   }
+ * }
+ */
 notificationRouter.patch(
   "/read-all",
   verifyAccessToken,

--- a/src/routes/notificationIndex.routes.ts
+++ b/src/routes/notificationIndex.routes.ts
@@ -7,7 +7,7 @@ const notificationIndexRoutes = Router();
 
 // 알림 관련 라우터
 notificationIndexRoutes.use("/notifications", notificationRouter);
-notificationIndexRoutes.use("/sse/notification", sseRouter);
+notificationIndexRoutes.use("/sse/notifications", sseRouter);
 notificationIndexRoutes.use("/actions", actionTestRouter);
 
 export default notificationIndexRoutes;

--- a/src/routes/sse.route.ts
+++ b/src/routes/sse.route.ts
@@ -4,6 +4,16 @@ import { verifyAccessToken } from "../middlewares/verifyToken";
 
 const sseRouter = Router();
 
+/**
+ * GET /sse/notifications
+ * @summary SSE 알림 실시간 구독
+ * @description 로그인한 사용자가 서버로부터 실시간 알림을 구독합니다. (Server-Sent Events)
+ * @tags Notification
+ * @security BearerAuth
+ * @returns {string} 200 - SSE 연결 성공 (event-stream)
+ * @example response - 200 - SSE 연결 예시
+ * event: notification\ndata: {"notification":{...},"unreadCount":3,"hasUnread":true}\n\n
+ */
 sseRouter.get("/", verifyAccessToken, (req: Request, res: Response) => {
   const userId = req.user?.userId;
   if (!userId) {

--- a/src/services/action.service.ts
+++ b/src/services/action.service.ts
@@ -3,9 +3,9 @@ import actionRepository from "../repositories/action.repository";
 
 const actionService = {
   createAction: async (
-    userId: number,
+    userId: string,
     type: ActionType,
-    entityId: number,
+    entityId: string,
     entityType: string,
     metadata: object
   ) => {
@@ -19,4 +19,4 @@ const actionService = {
   },
 };
 
-export default actionService; 
+export default actionService;

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,21 +1,22 @@
 import notificationRepository from "../repositories/notification.repository";
 
 const notificationService = {
-  getNotifications: async (userId: number, limit: number, offset: number) => {
+  getNotifications: async (userId: string, limit: number, offset: number) => {
     const notifications = await notificationRepository.getNotifications(
-      userId,
+      userId as string,
       limit,
       offset
     );
-    const hasUnread =
-      await notificationRepository.hasUnreadNotification(userId);
+    const hasUnread = await notificationRepository.hasUnreadNotification(
+      userId as string
+    );
     return { ...notifications, hasUnread };
   },
-  readNotification: async (notificationId: number) => {
-    return notificationRepository.readNotification(notificationId);
+  readNotification: async (notificationId: string) => {
+    return notificationRepository.readNotification(notificationId as string);
   },
-  readAllNotifications: async (userId: number) => {
-    return notificationRepository.readAllNotifications(userId);
+  readAllNotifications: async (userId: string) => {
+    return notificationRepository.readAllNotifications(userId as string);
   },
 };
 

--- a/src/types/notification.types.ts
+++ b/src/types/notification.types.ts
@@ -1,0 +1,14 @@
+export interface IActionMetadata {
+  moverName?: string;
+  customerName?: string;
+  moveType?: string;
+  estimateRequestId?: string;
+  estimateId?: string;
+  reviewId?: string;
+  favoriteId?: string;
+  moverId?: string;
+  customerId?: string;
+    
+  // 필요한 경우 추가 변수 선언
+  [key: string]: any;
+} 

--- a/src/utils/actionNotificationMap.ts
+++ b/src/utils/actionNotificationMap.ts
@@ -1,230 +1,452 @@
-import { Action, ActionType, NotificationType } from '@prisma/client';
-import prisma from '../db/prisma/prisma';
+import { Action, ActionType, MoveType, NotificationType } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
+import { IActionMetadata } from "../types/notification.types";
 
 export interface INotificationPayload {
   type: NotificationType;
-  getReceivers: (action: Action) => Promise<{ id: number; role: 'CUSTOMER' | 'MOVER' }[]>;
-  buildMessage: (action: Action, role: 'CUSTOMER' | 'MOVER') => {
+  getReceivers: (
+    action: Action
+  ) => Promise<{ id: string; userType: "CUSTOMER" | "MOVER" }[]>;
+  buildMessage: (
+    action: Action,
+    userType: "CUSTOMER" | "MOVER"
+  ) => {
     title: string;
     content: string;
-    actionUrl: string;
+    path: string;
   };
 }
 
 export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
-  QUOTE_CREATE: {
-    type: NotificationType.NEW_QUOTE,
-    getReceivers: async (action: Action) => {
-      // 모든 기사님(userType=MOVER)에게 알림
-      const movers = await prisma.user.findMany({
-        where: { currentRole: 'MOVER' },
-        select: { id: true },
-      });
-      return movers.map((mover) => ({ id: mover.id, role: 'MOVER' as const }));
-    },
-    buildMessage: (action: Action) => ({
-      title: '새 견적 요청이 등록되었습니다.',
-      content: '새로운 견적 요청이 등록되었습니다.',
-      actionUrl: `/quotes/${action.entityId}`,
+  WELCOME: {
+    type: NotificationType.WELCOME,
+    getReceivers: async (action: Action) => [
+      { id: action.userId, userType: "CUSTOMER" },
+    ],
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => ({
+      title: '<span class="font-bold">회원가입</span>을 환영합니다!',
+      content: "서비스 이용을 시작해보세요.",
+      path: "/",
     }),
   },
-  QUOTE_REJECTED: {
-    type: NotificationType.ESTIMATE_REJECTED,
-    getReceivers: async (action:Action) => {
-      // 견적 반려 시 고객에게 알림
-      const quote = await prisma.quote.findUnique({
-        where: { id: action.entityId },
-        select: { userId: true },
+  ESTIMATE_REQUEST_CREATE: {
+    type: NotificationType.ESTIMATE_REQUEST_ARRIVED,
+    getReceivers: async (action: Action) => {
+      // // TODO: 출발지 정보(region, district)를 사용하여 필터링
+      // const estimateRequest = await prisma.estimateRequest.findUnique({
+      //   where: { id: action.entityId },
+      //   select: { fromAddress: true },
+      // });
+      // const fromRegion = estimateRequest?.fromAddress?.region;
+      // const fromDistrict = estimateRequest?.fromAddress?.district;
+
+      const movers = await prisma.user.findMany({
+        where: {
+          userType: {
+            has: "MOVER",
+          },
+          id: {
+            not: action.userId,
+          },
+          // TODO: 출발지 정보(region, district)를 사용하여 필터링
+          // serviceAreas: {
+          //   some: {
+          //     region: fromRegion,
+          //     district: fromDistrict,
+          //   },
+          // },
+        },
+        select: { id: true },
       });
-      return quote ? [{ id: quote.userId, role: 'CUSTOMER' }] : [];
+      return movers.map((mover) => ({ id: mover.id, userType: "MOVER" }));
     },
-    buildMessage: (action) => ({
-      title: '견적이 반려되었습니다.',
-      content: '견적 요청이 반려되었습니다. 상세 내용을 확인하세요.',
-      actionUrl: `/quotes/${action.entityId}`,
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => ({
+      title: "새 견적 요청이 등록되었습니다.",
+      content: "새로운 견적 요청이 등록되었습니다.",
+      path: `/estimateRequests/${action.entityId}`,
     }),
   },
   ESTIMATE_SUBMITTED: {
-    type: NotificationType.ESTIMATE_SUBMITTED,
-    getReceivers: async (action) => {
-      const estimate = await prisma.estimate.findUnique({
-        where: { id: action.entityId },
-        select: { quote: { select: { userId: true } } },
-      });
-      return estimate ? [{ id: estimate.quote.userId, role: 'CUSTOMER' }] : [];
+    type: NotificationType.ESTIMATE_ARRIVED,
+    getReceivers: async (action: Action) => {
+      return [{ id: action.userId, userType: "CUSTOMER" }];
     },
-    buildMessage: (action) => {
-      const { moverName, movingType, estimateId } = action.metadata as any;
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moverName = "" } = (action.metadata as IActionMetadata) || {};
       return {
-        title: `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">${movingType}</span> 견적이 도착했어요.`,
-        content: '대기중인 견적에서 확인할 수 있어요.',
-        actionUrl: `/estimate/${estimateId}`,
+        title: `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">견적</span>이 도착했어요.`,
+        content: "새로운 견적이 도착했습니다.",
+        path: `/estimateRequests/${action.entityId}`,
       };
     },
   },
   ESTIMATE_ACCEPTED: {
-    type: NotificationType.ESTIMATE_CONFIRMED,
-    getReceivers: async (action) => {
-      const estimate = await prisma.estimate.findUnique({
-        where: { id: action.entityId },
-        select: {
-          moverId: true,
-          quote: { select: { userId: true } },
-        },
-      });
-      if (!estimate) return [];
-      return [
-        { id: estimate.moverId, role: 'MOVER' },
-        { id: estimate.quote.userId, role: 'CUSTOMER' },
-      ];
+    type: NotificationType.ESTIMATE_STATUS_UPDATED,
+    getReceivers: async (action: Action) => {
+      let moverId: string | undefined;
+      let customerId: string | undefined;
+      if (action.entityType === "ESTIMATE") {
+        const estimate = await prisma.estimate.findUnique({
+          where: { id: action.entityId },
+          select: {
+            moverId: true,
+            estimateRequestId: true,
+            estimateRequest: { select: { customerId: true } },
+          },
+        });
+        if (estimate) {
+          moverId = estimate.moverId;
+          customerId = estimate.estimateRequest.customerId;
+        }
+      } else if (action.entityType === "ESTIMATE_REQUEST") {
+        const estimateRequest = await prisma.estimateRequest.findUnique({
+          where: { id: action.entityId },
+          select: { customerId: true },
+        });
+        customerId = estimateRequest?.customerId;
+      }
+      const receivers: { id: string; userType: "MOVER" | "CUSTOMER" }[] = [];
+      if (moverId) receivers.push({ id: moverId, userType: "MOVER" });
+      if (customerId) receivers.push({ id: customerId, userType: "CUSTOMER" });
+      return receivers;
     },
-    buildMessage: (action, role) => {
-      const { quoteId, moverName, customerName } = action.metadata as any;
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const {
+        moverName = "",
+        customerName = "",
+        estimateRequestId = "",
+        estimateId = "",
+      } = (action.metadata as IActionMetadata) || {};
       return {
         title:
-          role === 'CUSTOMER'
+          userType === "CUSTOMER"
             ? `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
             : `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
-        content: '내 견적 관리 > 확정 견적에서 확인할 수 있어요.',
-        actionUrl:
-          role === 'CUSTOMER' ? `/quotes/${quoteId}` : `/estimate/${quoteId}`,
+        content: "내 견적 관리 > 확정 견적에서 확인할 수 있어요.",
+        path:
+          userType === "CUSTOMER"
+            ? `/estimateRequests/${estimateRequestId}`
+            : `/estimate/${estimateId}`,
       };
     },
   },
   ESTIMATE_REJECTED: {
-    type: NotificationType.ESTIMATE_REJECTED,
-    getReceivers: async (action) => {
+    type: NotificationType.ESTIMATE_STATUS_UPDATED,
+    getReceivers: async (action: Action) => {
       const estimate = await prisma.estimate.findUnique({
         where: { id: action.entityId },
         select: { moverId: true },
       });
-      return estimate ? [{ id: estimate.moverId, role: 'MOVER' }] : [];
+      return estimate ? [{ id: estimate.moverId, userType: "MOVER" }] : [];
     },
-    buildMessage: (action) => {
-      const { customerName, estimateId } = action.metadata as any;
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moveType = "", customerName = "" } =
+        (action.metadata as IActionMetadata) || {};
       return {
-        title: `<span class="font-bold">${customerName}</span> 고객님의 견적이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
-        content: '반려된 견적 상세를 확인하세요.',
-        actionUrl: `/estimate/${estimateId}`,
+        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">${moveType}</span> 견적이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
+        content: "반려된 견적 상세를 확인하세요.",
+        path: `/estimateRequests/${action.entityId}`,
       };
     },
   },
-  DESIGNATED_QUOTE_REQUESTED: {
-    type: NotificationType.DESIGNATED_QUOTE_REQUESTED,
-    getReceivers: async (action) => {
-      const request = await prisma.designatedEstimateRequest.findUnique({
-        where: { id: action.entityId },
+  DESIGNATED_ESTIMATE_REQUEST_SUBMITTED: {
+    type: NotificationType.DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED,
+    getReceivers: async (action: Action) => {
+      const designatedMovers = await prisma.designatedMover.findMany({
+        where: { estimateRequestId: action.entityId, status: "PENDING" },
         select: { moverId: true },
+        orderBy: { createdAt: "desc" },
       });
-      return request ? [{ id: request.moverId, role: 'MOVER' }] : [];
+      return designatedMovers.length > 0
+        ? [{ id: designatedMovers[0].moverId, userType: "MOVER" }]
+        : [];
     },
-    buildMessage: (action) => {
-      const { customerName, quoteId } = action.metadata as any;
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { customerName = "" } = (action.metadata as IActionMetadata) || {};
       return {
-        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="font-bold">지정 견적</span>이 요청되었어요.`,
-        content: '받은 요청 페이지에서 확인해보세요.',
-        actionUrl: `/designated-quote/${quoteId}`,
+        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">지정 견적</span>이 요청되었어요.`,
+        content: "지정 견적이 요청되었습니다.",
+        path: `/estimateRequests/${action.entityId}`,
+      };
+    },
+  },
+  DESIGNATED_ESTIMATE_REQUEST_REJECTED: {
+    type: NotificationType.DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED,
+    getReceivers: async (action: Action) => {
+      const estimateRequest = await prisma.estimateRequest.findUnique({
+        where: { id: action.entityId },
+        select: { customerId: true },
+      });
+      return estimateRequest
+        ? [{ id: estimateRequest.customerId, userType: "CUSTOMER" }]
+        : [];
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moveType = "" } = (action.metadata as IActionMetadata) || {};
+      return {
+        title: `<span class="font-bold">${moveType}</span>  <span class="text-primary-400 font-bold">지정 견적 요청</span>이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
+        content: "지정 견적 요청이 반려 되었습니다.",
+        path: `/estimateRequests/${action.entityId}`,
       };
     },
   },
   DESIGNATED_ESTIMATE_SUBMITTED: {
-    type: NotificationType.ESTIMATE_SUBMITTED,
-    getReceivers: async (action) => {
-      const estimate = await prisma.estimate.findUnique({
-        where: { id: action.entityId },
-        select: { quote: { select: { userId: true } } },
-      });
-      return estimate ? [{ id: estimate.quote.userId, role: 'CUSTOMER' }] : [];
-    },
-    buildMessage: (action) => {
-      const { moverName, movingType, estimateId } = action.metadata as any;
-      return {
-        title: `<span class="font-bold">지정<span> 요청한 <span class="text-primary-400 font-bold">${movingType}</span> 견적이 도착했어요.`,
-        content: '대기중인 지정 견적에서 확인할 수 있어요.',
-        actionUrl: `/estimate/${estimateId}`,
-      };
-    },
-  },
-  MOVING_COMPLETED: {
-    type: NotificationType.REVIEW_REQUEST,
-    getReceivers: async (action) => {
-      const quote = await prisma.quote.findUnique({
-        where: { id: action.entityId },
-        select: { userId: true },
-      });
-      return quote ? [{ id: quote.userId, role: 'CUSTOMER' }] : [];
-    },
-    buildMessage: (action) => {
-      const { movingType, quoteId } = action.metadata as any;
-      return {
-        title: `어제 <span class="text-primary-400 font-bold">${movingType}</span> 이사는 어떠셨나요? 기사님에 대한 <span class="text-primary-400 font-bold">리뷰</span>를 남겨주세요.`,
-        content: '기사님에 대한 리뷰를 남겨주세요.',
-        actionUrl: `/quotes/${quoteId}/review`,
-      };
-    },
-  },
-  REVIEW_SUBMITTED: {
-    type: NotificationType.REVIEW_REQUEST,
-    getReceivers: async (action) => {
-      const review = await prisma.review.findUnique({
-        where: { id: action.entityId },
-        select: { moverId: true },
-      });
-      return review ? [{ id: review.moverId, role: 'MOVER' }] : [];
-    },
-    buildMessage: () => ({
-      title: '<span class="text-primary-400 font-bold">새 리뷰</span>가 등록되었어요.',
-      content: '고객이 리뷰를 남겼어요. 지금 확인해보세요!',
-      actionUrl: `/mover/reviews`,
-    }),
-  },
-  MOVING_DAY_TOMORROW: {
-    type: NotificationType.MOVING_DAY,
-    getReceivers: async (action) => {
-      const estimate = await prisma.estimate.findUnique({
-        where: { id: action.entityId },
-        select: {
-          moverId: true,
-          quote: { select: { userId: true } },
-        },
-      });
-      if (!estimate) return [];
-      return [
-        { id: estimate.moverId, role: 'MOVER' },
-        { id: estimate.quote.userId, role: 'CUSTOMER' },
-      ];
-    },
-    buildMessage: (action: Action) => {
-      const { quoteId, movingType } = action.metadata as any;
-      return {
-        title: `내일은 <span class="text-primary-400 font-bold">${movingType}</span> 이사 예정일이에요.`,
-        content: '이사 준비를 미리 확인해보세요.',
-        actionUrl: `/quotes/${quoteId}`,
-      };
-    },
-  },
-  MOVING_DAY_TODAY: {
-    type: NotificationType.MOVING_DAY,
+    type: NotificationType.DESIGNATED_ESTIMATE_STATUS_UPDATED,
     getReceivers: async (action: Action) => {
       const estimate = await prisma.estimate.findUnique({
         where: { id: action.entityId },
-        select: {
-          moverId: true,
-          quote: { select: { userId: true } },
-        },
+        select: { estimateRequest: { select: { customerId: true } } },
       });
       if (!estimate) return [];
       return [
-        { id: estimate.moverId, role: 'MOVER' },
-        { id: estimate.quote.userId, role: 'CUSTOMER' },
+        { id: estimate.estimateRequest.customerId, userType: "CUSTOMER" },
       ];
     },
-    buildMessage: (action: Action) => {
-      const { quoteId, movingType } = action.metadata as any;
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moverName = "", moveType = "" } =
+        (action.metadata as IActionMetadata) || {};
       return {
-        title: `오늘은 <span class="text-primary-400 font-bold">${movingType}</span> 이사 예정일이에요.`,
-        content: '이사가 안전하게 진행되길 바래요.',
-        actionUrl: `/quotes/${quoteId}`,
+        title: `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">${moveType} 지정 견적</span>이 도착했어요.`,
+        content: "요청한 지정 견적에 대한 새로운 견적이 도착했습니다.",
+        path: `/estimateRequests/${action.entityId}`,
+      };
+    },
+  },
+
+  DESIGNATED_ESTIMATE_ACCEPTED: {
+    type: NotificationType.DESIGNATED_ESTIMATE_STATUS_UPDATED,
+    getReceivers: async (action: Action) => {
+      let moverId: string | undefined;
+      let customerId: string | undefined;
+      if (action.entityType === "DESIGNATED_ESTIMATE") {
+        const estimate = await prisma.estimate.findUnique({
+          where: { id: action.entityId },
+          select: {
+            moverId: true,
+            estimateRequestId: true,
+            estimateRequest: { select: { customerId: true } },
+          },
+        });
+        if (estimate) {
+          moverId = estimate.moverId;
+          customerId = estimate.estimateRequest.customerId;
+        }
+      } else if (action.entityType === "DESIGNATED_ESTIMATE_REQUEST") {
+        const estimateRequest = await prisma.estimateRequest.findUnique({
+          where: { id: action.entityId },
+          select: { customerId: true },
+        });
+        customerId = estimateRequest?.customerId;
+      }
+      const receivers: { id: string; userType: "MOVER" | "CUSTOMER" }[] = [];
+      if (moverId) receivers.push({ id: moverId, userType: "MOVER" });
+      if (customerId) receivers.push({ id: customerId, userType: "CUSTOMER" });
+      return receivers;
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const {
+        moverName = "",
+        customerName = "",
+        moveType = "",
+        estimateRequestId = "",
+        estimateId = "",
+      } = (action.metadata as IActionMetadata) || {};
+      return {
+        title:
+          userType === "CUSTOMER"
+            ? `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">${moveType} 지정 견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
+            : `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">${moveType} 지정 견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
+        content: "내 견적 관리 > 확정 견적에서 확인할 수 있어요.",
+        path:
+          userType === "CUSTOMER"
+            ? `/estimateRequests/${estimateRequestId}`
+            : `/estimate/${estimateId}`,
+      };
+    },
+  },
+
+  DESIGNATED_ESTIMATE_REJECTED: {
+    type: NotificationType.DESIGNATED_ESTIMATE_STATUS_UPDATED,
+    getReceivers: async (action: Action) => {
+      const estimate = await prisma.estimate.findUnique({
+        where: { id: action.entityId },
+        select: { moverId: true },
+      });
+      if (!estimate) return [];
+      return [{ id: estimate.moverId, userType: "MOVER" }];
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { customerName = "", moveType = "" } =
+        (action.metadata as IActionMetadata) || {};
+      return {
+        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">${moveType} 지정 견적</span>이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
+        content: "반려된 견적 상세를 확인하세요.",
+        path: `/estimate/${action.entityId}`,
+      };
+    },
+  },
+
+  REVIEW_SUBMITTED: {
+    type: NotificationType.REVIEW_EVENT,
+    getReceivers: async (action: Action) => {
+      const review = await prisma.review.findUnique({
+        where: { id: action.entityId },
+        select: { moverId: true, estimateRequestId: true },
+      });
+      if (!review) return [];
+      return [{ id: review.moverId, userType: "MOVER" }];
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moverId = "" } = (action.metadata as IActionMetadata) || {};
+      return {
+        title: "리뷰가 등록되었어요.",
+        content: "리뷰가 등록되었어요.",
+        path: `/moverMypage/${moverId}`,
+      };
+    },
+  },
+
+  FAVORITE_ADDED: {
+    type: NotificationType.FAVORITE_EVENT,
+    getReceivers: async (action: Action) => {
+      const favorite = await prisma.favorite.findUnique({
+        where: { id: action.entityId },
+        select: { customerId: true },
+      });
+      if (!favorite) return [];
+      return [{ id: favorite.customerId, userType: "CUSTOMER" }];
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moverId = "" } = (action.metadata as IActionMetadata) || {};
+      return {
+        title: "찜이 추가되었어요.",
+        content: "찜이 추가되었어요.",
+        path: `/moverMypage/${moverId}`,
+      };
+    },
+  },
+
+  FAVORITE_REMOVED: {
+    type: NotificationType.FAVORITE_EVENT,
+    getReceivers: async (action: Action) => {
+      const favorite = await prisma.favorite.findUnique({
+        where: { id: action.entityId },
+        select: { customerId: true },
+      });
+      if (!favorite) return [];
+      return [{ id: favorite.customerId, userType: "CUSTOMER" }];
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moverId = "" } = (action.metadata as IActionMetadata) || {};
+      return {
+        title: "찜이 제거되었어요.",
+        content: "찜이 제거되었어요.",
+        path: `/moverMypage/${moverId}`,
+      };
+    },
+  },
+
+  MOVE_DAY_REMINDER_TOMORROW: {
+    type: NotificationType.MOVE_DAY_REMINDER,
+    getReceivers: async (action: Action) => {
+      let moverId: string | undefined;
+      let customerId: string | undefined;
+      if (action.entityType === "DESIGNATED_ESTIMATE") {
+        const estimate = await prisma.estimate.findUnique({
+          where: { id: action.entityId },
+          select: {
+            moverId: true,
+            estimateRequestId: true,
+            estimateRequest: { select: { customerId: true } },
+          },
+        });
+        if (estimate) {
+          moverId = estimate.moverId;
+          customerId = estimate.estimateRequest.customerId;
+        }
+      } else if (action.entityType === "DESIGNATED_ESTIMATE_REQUEST") {
+        const estimateRequest = await prisma.estimateRequest.findUnique({
+          where: { id: action.entityId },
+          select: { customerId: true },
+        });
+        customerId = estimateRequest?.customerId;
+      }
+      const receivers: { id: string; userType: "MOVER" | "CUSTOMER" }[] = [];
+      if (moverId) receivers.push({ id: moverId, userType: "MOVER" });
+      if (customerId) receivers.push({ id: customerId, userType: "CUSTOMER" });
+      return receivers;
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moveType = "", estimateId = "" } =
+        (action.metadata as IActionMetadata) || {};
+      return {
+        title: `내일은 <span class="font-bold">${moveType}</span>의 이사 예정일이에요.`,
+        content: "이사 준비를 미리 확인해보세요.",
+        path: `/estimateRequests/${estimateId}`,
+      };
+    },
+  },
+
+  MOVE_DAY_REMINDER_TODAY: {
+    type: NotificationType.MOVE_DAY_REMINDER,
+    getReceivers: async (action: Action) => {
+      let moverId: string | undefined;
+      let customerId: string | undefined;
+      if (action.entityType === "DESIGNATED_ESTIMATE") {
+        const estimate = await prisma.estimate.findUnique({
+          where: { id: action.entityId },
+          select: {
+            moverId: true,
+            estimateRequestId: true,
+            estimateRequest: { select: { customerId: true } },
+          },
+        });
+        if (estimate) {
+          moverId = estimate.moverId;
+          customerId = estimate.estimateRequest.customerId;
+        }
+      } else if (action.entityType === "DESIGNATED_ESTIMATE_REQUEST") {
+        const estimateRequest = await prisma.estimateRequest.findUnique({
+          where: { id: action.entityId },
+          select: { customerId: true },
+        });
+        customerId = estimateRequest?.customerId;
+      }
+      const receivers: { id: string; userType: "MOVER" | "CUSTOMER" }[] = [];
+      if (moverId) receivers.push({ id: moverId, userType: "MOVER" });
+      if (customerId) receivers.push({ id: customerId, userType: "CUSTOMER" });
+      return receivers;
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moveType = "", estimateId = "" } =
+        (action.metadata as IActionMetadata) || {};
+      return {
+        title: `오늘은 <span class="font-bold">${moveType}</span>의 이사 예정일이에요.`,
+        content: "이사 준비를 미리 확인해보세요.",
+        path: `/estimateRequests/${estimateId}`,
+      };
+    },
+  },
+
+  MOVE_DAY_REVIEW_REQUEST: {
+    type: NotificationType.MOVE_DAY_REMINDER,
+    getReceivers: async (action: Action) => {
+      let customerId: string | undefined;
+      if (action.entityType === "DESIGNATED_ESTIMATE") {
+        const estimate = await prisma.estimate.findUnique({
+          where: { id: action.entityId },
+          select: { estimateRequest: { select: { customerId: true } } },
+        });
+        customerId = estimate?.estimateRequest.customerId;
+      }
+      return customerId ? [{ id: customerId, userType: "CUSTOMER" }] : [];
+    },
+    buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
+      const { moverName = "" } = (action.metadata as IActionMetadata) || {};
+      return {
+        title: `이사는 어떠셨나요? <span class="text-primary-400 font-bold">${moverName}</span> 기사님에 대한 <span class="font-bold">리뷰</span>를 남겨주세요.`,
+        content: "기사님에 대한 리뷰를 남겨주세요.",
+        path: `/reviews/writable`, //TODO: 페이지 이동후 해당 모달 열리게  `/reviews/writable/${action.entityId}` 로 변경
       };
     },
   },

--- a/src/utils/emitNotificationSSE.ts
+++ b/src/utils/emitNotificationSSE.ts
@@ -1,20 +1,23 @@
 import { Notification } from "@prisma/client";
 import { Response } from "express";
+import prisma from "../db/prisma/prisma";
 
-type NotificationEvent = {
+// NotificationEvent 타입에 hasUnread 추가
+export type NotificationEvent = {
   notification: Notification;
   unreadCount: number;
+  hasUnread: boolean;
 };
 
 // 유저별 SSE 연결 저장소
-const sseClients = new Map<number, Response>();
+const sseClients = new Map<string, Response>();
 
 /**
  * SSE 연결을 등록합니다.
  * @param userId 사용자 ID
  * @param res SSE Response 객체
  */
-export function registerSSE(userId: number, res: Response) {
+export function registerSSE(userId: string, res: Response) {
   res.writeHead(200, {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
@@ -34,14 +37,29 @@ export function registerSSE(userId: number, res: Response) {
 /**
  * 해당 사용자에게 알림 SSE를 전송합니다.
  * @param userId 사용자 ID
- * @param payload 전송할 알림 데이터
+ * @param notification 알림 데이터
  */
-export function emitNotificationSSE(
-  userId: number,
-  payload: NotificationEvent
+export async function emitNotificationSSE(
+  userId: string,
+  notification: Notification
 ) {
   const client = sseClients.get(userId);
   if (!client) return;
+
+  // 안읽은 알림 개수와 hasUnread 동시 계산
+  const unreadCount = await prisma.notification.count({
+    where: {
+      userId,
+      isRead: false,
+    },
+  });
+  const hasUnread = unreadCount > 0;
+
+  const payload: NotificationEvent = {
+    notification,
+    unreadCount,
+    hasUnread,
+  };
 
   client.write(`event: notification\n`);
   client.write(`data: ${JSON.stringify(payload)}\n\n`);


### PR DESCRIPTION
## ✨ 작업 개요

- 스키마 대공사에 따라 변경 사항에 맞게 타입 변경.

## ✅ 주요 작업 내용

- 유저타입 number -> string 변경.
- 바뀐 액션 타입과 알림 타입으로 매핑 변경.
- 알림 타입별 알림 리시버와 알림 메시지 변경.
- 스웨거 코드 추가 및 변경 사항에 맞게 수정.

## 🔄 관련 이슈

Closes #155 - 스키마 대공사에 따른 변경.

## 📎 참고 자료 (선택)

- API 명세서: [Notion 링크](https://admitted-turkey-c17.notion.site/API-2155da6dc98c813891ead8eb7218d631?source=copy_link)
- 프로젝트 분석 [Notion 링크](https://admitted-turkey-c17.notion.site/BE-2245da6dc98c80e681a1f21c8bf66842?source=copy_link)

## 📝 비고
- 아직 알림의 path가 완벽하다고는 못하겠습니다. 
- 상상으로만 매칭을 해놔서 URL 정리 후에 리팩토링을 거쳐 완벽하게 진행 될 것 같습니다.
