### PR TITLE
[#149] fix : 견적-리턴값일부수정

### DIFF
--- a/src/repositories/moverEstimate.repository.ts
+++ b/src/repositories/moverEstimate.repository.ts
@@ -50,6 +50,24 @@ const estimateRequestSelectOptions = {
       region: true,
     },
   },
+  estimates: {
+    select: {
+      id: true,
+      moverId: true,
+      price: true,
+      comment: true,
+      status: true,
+      rejectReason: true,
+      isDesignated: true,
+      workingHours: true,
+      includesPackaging: true,
+      insuranceAmount: true,
+      validUntil: true,
+      createdAt: true,
+      updatedAt: true,
+      deletedAt: true,
+    },
+  },
 };
 
 // 공통 select 옵션 - Estimate용

--- a/src/types/moverEstimate.ts
+++ b/src/types/moverEstimate.ts
@@ -92,6 +92,22 @@ export type TEstimateRequestResponse = {
   customer: TCustomer;
   fromAddress: TAddress;
   toAddress: TAddress;
+  estimates?: {
+    id: string;
+    moverId: string;
+    price: number | null;
+    comment: string | null;
+    status: "PROPOSED" | "ACCEPTED" | "REJECTED" | "AUTO_REJECTED";
+    rejectReason: string | null;
+    isDesignated: boolean;
+    workingHours: string | null;
+    includesPackaging: boolean;
+    insuranceAmount: number | null;
+    validUntil: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+    deletedAt: Date | null;
+  }[];
 };
 
 // 견적서 응답 타입


### PR DESCRIPTION
## ✨ 작업 개요

- 견적:리턴값일부수정

## ✅ 주요 작업 내용

- 견적:리턴값일부수정 -> estimate 배열 추가
- 기사가 견적서 제출 시 이미 최대견적이면 버튼 비활성화를 위해 리턴값에 배열 추가

## 🔄 관련 이슈

Closes #149 

## 📎 참고 자료 (선택)

- API 명세서: [링크]

## 🧪 테스트 방법 (선택)

- [ ] 쿼리 파라미터 전달 시 필터링 정상 작동

## 📝 비고

- (추가 예정 기능, 보완 필요 등)
