### PR TITLE
[#146]repactor: 견적요청 리팩토링

### DIFF
--- a/src/controllers/estimateRequest.controller.ts
+++ b/src/controllers/estimateRequest.controller.ts
@@ -1,53 +1,184 @@
 import { Request, Response } from "express";
-import { MoveType, RequestStatus, EstimateRequest } from "@prisma/client";
 import EstimateRequestService from "../services/estimateRequest.service";
-import { TCreateEstimateRequest, TUpdateEstimateRequest } from "../types/estimateRequest.types";
-import { getKoreaToday, isBeforeKoreaToday } from "../utils/dateUtils";
+import { convertRegionToKorean } from "../utils/addressUtils";
+import {
+  TCreateEstimateRequest,
+  TUpdateEstimateRequest,
+  IDatabaseEstimateRequest,
+  IEstimateRequestResponse,
+  IAddressInfo,
+  IUserTypeResult,
+  ICreateValidationData,
+  IUpdateValidationData,
+  IValidationResult,
+} from "../types/estimateRequest.types";
 
 const estimateRequestService = new EstimateRequestService();
 
 class EstimateRequestController {
-  async createEstimateRequest(req: Request, res: Response) {
+  private getUserId(req: Request): string {
+    if (!req.user || !req.user.userId) {
+      throw new Error("인증이 필요합니다.");
+    }
+    return req.user.userId;
+  }
+
+  private validateUser(userId: string): void {
+    if (!userId || typeof userId !== "string" || userId.trim().length === 0) {
+      throw new Error("인증이 필요합니다.");
+    }
+  }
+
+  private async validateCustomerAccess(userId: string): Promise<void> {
+    const { isCustomer }: IUserTypeResult = await estimateRequestService.checkUserType(userId);
+    if (!isCustomer) {
+      throw new Error("기사님은 견적 요청을 생성할 수 없습니다. 일반 고객으로 로그인해주세요.");
+    }
+  }
+
+  private validateMoveDate(movingDate: string): void {
     try {
-      const userId = (req as any).user?.userId as string;
-      if (!userId) {
-        return res.status(401).json({ success: false, message: "인증이 필요합니다." });
+      const moveDate = new Date(movingDate);
+      if (isNaN(moveDate.getTime())) {
+        throw new Error("올바른 날짜 형식이 아닙니다. (YYYY-MM-DD 형식으로 입력해주세요)");
       }
 
-      // 유저 유형 확인 - 기사님은 견적 요청을 생성할 수 없음
-      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
-      if (!isCustomer) {
-        return res.status(403).json({
-          success: false,
-          message: "기사님은 견적 요청을 생성할 수 없습니다. 일반 고객으로 로그인해주세요.",
-        });
+      const today = new Date();
+      const koreaTime = new Date(today.toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+      koreaTime.setHours(0, 0, 0, 0);
+
+      if (moveDate < koreaTime) {
+        throw new Error("이사일은 오늘 이후로 설정해주세요.");
       }
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("날짜 검증 중 오류가 발생했습니다.");
+    }
+  }
+
+  private validateAddresses(departure: IAddressInfo, arrival: IAddressInfo): void {
+    const isSameRoadAddress = (departure?.roadAddress || "").trim() === (arrival?.roadAddress || "").trim();
+    const isSameDetailAddress = (departure?.detailAddress || "").trim() === (arrival?.detailAddress || "").trim();
+
+    if (isSameRoadAddress && isSameDetailAddress) {
+      throw new Error("출발지와 도착지는 달라야 합니다.");
+    }
+  }
+
+  private validateCreateEstimateRequest(data: ICreateValidationData): IValidationResult {
+    const errors: string[] = [];
+
+    if (!["small", "home", "office"].includes(data.movingType.toLowerCase())) {
+      errors.push("이사 종류는 small, home, office 중 하나여야 합니다.");
+    }
+
+    try {
+      this.validateMoveDate(data.movingDate);
+    } catch (error) {
+      if (error instanceof Error) {
+        errors.push(error.message);
+      }
+    }
+
+    try {
+      this.validateAddresses(data.departure, data.arrival);
+    } catch (error) {
+      if (error instanceof Error) {
+        errors.push(error.message);
+      }
+    }
+
+    if (!data.departure?.roadAddress?.trim()) {
+      errors.push("출발지 주소는 필수입니다.");
+    }
+
+    if (!data.arrival?.roadAddress?.trim()) {
+      errors.push("도착지 주소는 필수입니다.");
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  private validateUpdateEstimateRequest(data: IUpdateValidationData): IValidationResult {
+    const errors: string[] = [];
+
+    if (data.movingType && !["small", "home", "office"].includes(data.movingType.toLowerCase())) {
+      errors.push("이사 종류는 small, home, office 중 하나여야 합니다.");
+    }
+
+    if (data.movingDate) {
+      try {
+        this.validateMoveDate(data.movingDate);
+      } catch (error) {
+        if (error instanceof Error) {
+          errors.push(error.message);
+        }
+      }
+    }
+
+    if (data.departure && data.arrival) {
+      try {
+        this.validateAddresses(data.departure, data.arrival);
+      } catch (error) {
+        if (error instanceof Error) {
+          errors.push(error.message);
+        }
+      }
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  private formatEstimateRequestResponse(request: IDatabaseEstimateRequest): IEstimateRequestResponse {
+    return {
+      id: request.id,
+      userId: request.customerId,
+      movingType: request.moveType,
+      departureAddress: request.fromAddress
+        ? `${convertRegionToKorean(request.fromAddress.region)} ${request.fromAddress.city} ${request.fromAddress.district}`
+        : "",
+      arrivalAddress: request.toAddress
+        ? `${convertRegionToKorean(request.toAddress.region)} ${request.toAddress.city} ${request.toAddress.district}`
+        : "",
+      departureDetailAddress: request.fromAddress?.detail || undefined,
+      arrivalDetailAddress: request.toAddress?.detail || undefined,
+      departurePostalCode: request.fromAddress?.postalCode || undefined,
+      arrivalPostalCode: request.toAddress?.postalCode || undefined,
+      movingDate: request.moveDate.toISOString().split("T")[0],
+      status: request.status,
+      createdAt: request.createdAt.toISOString(),
+      updatedAt: request.updatedAt.toISOString(),
+    };
+  }
+
+  async createEstimateRequest(req: Request, res: Response) {
+    try {
+      const userId = this.getUserId(req);
+      this.validateUser(userId);
+      await this.validateCustomerAccess(userId);
 
       const hasPending = await estimateRequestService.hasPendingRequest(userId);
       if (hasPending) {
         return res.status(409).json({ success: false, message: "이미 진행중인 견적 요청이 있습니다." });
       }
 
-      // 프론트엔드 요청 구조에 맞게 파라미터 받기
       const { movingType, movingDate, departure, arrival, description } = req.body;
 
-      // 이사일이 과거인지 확인 (한국 시간 기준)
-      const moveDate = new Date(movingDate);
+      const validation = this.validateCreateEstimateRequest({
+        movingType,
+        movingDate,
+        departure,
+        arrival,
+        description,
+      });
 
-      if (isBeforeKoreaToday(moveDate)) {
+      if (!validation.isValid) {
         return res.status(400).json({
           success: false,
-          message: "이사일은 오늘 이후로 설정해주세요.",
+          message: validation.errors[0],
         });
-      }
-
-      // 출발지와 도착지 주소가 완전히 같은지 검사
-      const safeEq = (a: any, b: any) => (a || "").toString().trim() === (b || "").toString().trim();
-      if (
-        safeEq(departure?.roadAddress, arrival?.roadAddress) &&
-        safeEq(departure?.detailAddress, arrival?.detailAddress)
-      ) {
-        return res.status(400).json({ success: false, message: "출발지와 도착지는 달라야 합니다." });
       }
 
       const params: TCreateEstimateRequest = {
@@ -59,129 +190,87 @@ class EstimateRequestController {
         description,
       };
 
-      const result = await estimateRequestService.createEstimateRequest(params);
-      return res.status(201).json({ success: true, message: "견적 요청이 성공적으로 생성되었습니다.", data: result });
+      await estimateRequestService.createEstimateRequest(params);
+
+      const createdRequest = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
+
+      return res.status(201).json({
+        success: true,
+        message: "견적 요청이 성공적으로 생성되었습니다.",
+        data: createdRequest ? this.formatEstimateRequestResponse(createdRequest) : null,
+      });
     } catch (error) {
       console.error("견적 요청 생성 에러:", error);
-      return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
+      const message = error instanceof Error ? error.message : "서버 내부 오류가 발생했습니다.";
+      const status = error instanceof Error && error.message.includes("인증") ? 401 : 500;
+      return res.status(status).json({ success: false, message });
     }
   }
 
   async getActiveEstimateRequest(req: Request, res: Response) {
     try {
-      const userId = (req as any).user?.userId as string;
-      if (!userId) {
-        return res.status(401).json({ success: false, message: "인증이 필요합니다." });
-      }
-
-      // 유저 유형 확인 - 기사님은 견적 요청을 조회할 수 없음
-      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
-      if (!isCustomer) {
-        return res.status(403).json({
-          success: false,
-          message: "기사님은 견적 요청을 조회할 수 없습니다. 일반 고객으로 로그인해주세요.",
-        });
-      }
+      const userId = this.getUserId(req);
+      this.validateUser(userId);
+      await this.validateCustomerAccess(userId);
 
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       const hasActive = !!active;
 
-      if (hasActive) {
-        // 견적 요청이 만료되었는지 확인
-        const isExpired = await estimateRequestService.isRequestExpired(active.id);
-        if (isExpired && active.status === RequestStatus.PENDING) {
-          // 만료된 PENDING 상태의 견적 요청을 EXPIRED로 변경
-          await estimateRequestService.expireOverdueRequests();
-          return res.status(200).json({ success: true, hasActive: false });
-        }
-
-        // 프론트엔드 응답 구조에 맞게 변환
-        const responseData = {
-          id: active.id,
-          userId: active.customerId,
-          movingType: active.moveType,
-          departureAddress: active.fromAddress
-            ? `${active.fromAddress.region} ${active.fromAddress.city} ${active.fromAddress.district}`
-            : "",
-          arrivalAddress: active.toAddress
-            ? `${active.toAddress.region} ${active.toAddress.city} ${active.toAddress.district}`
-            : "",
-          departureDetailAddress: active.fromAddress?.detail || null,
-          arrivalDetailAddress: active.toAddress?.detail || null,
-          movingDate: active.moveDate.toISOString().split("T")[0], // YYYY-MM-DD 형식
-          status: active.status,
-          createdAt: active.createdAt.toISOString(),
-          updatedAt: active.updatedAt.toISOString(),
-        };
-
+      if (hasActive && active) {
+        const responseData = this.formatEstimateRequestResponse(active);
         return res.status(200).json({ success: true, hasActive, data: responseData });
       } else {
         return res.status(200).json({ success: true, hasActive });
       }
     } catch (error) {
       console.error("활성 견적 요청 조회 에러:", error);
-      return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
+      const message = error instanceof Error ? error.message : "서버 내부 오류가 발생했습니다.";
+      const status = error instanceof Error && error.message.includes("인증") ? 401 : 500;
+      return res.status(status).json({ success: false, message });
     }
   }
 
   async updateActiveEstimateRequest(req: Request, res: Response) {
     try {
-      const userId = (req as any).user?.userId as string;
-      if (!userId) {
-        return res.status(401).json({ success: false, message: "인증이 필요합니다." });
-      }
+      const userId = this.getUserId(req);
+      this.validateUser(userId);
+      await this.validateCustomerAccess(userId);
 
-      // 유저 유형 확인 - 기사님은 견적 요청을 수정할 수 없음
-      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
-      if (!isCustomer) {
-        return res.status(403).json({
+      const isPending = await estimateRequestService.hasPendingRequest(userId);
+      if (!isPending) {
+        return res.status(409).json({
           success: false,
-          message: "기사님은 견적 요청을 수정할 수 없습니다. 일반 고객으로 로그인해주세요.",
+          message: "진행중(PENDING) 상태에서만 수정할 수 있습니다.",
         });
       }
 
-      const isPending = await estimateRequestService.isActiveRequestPending(userId);
-      if (!isPending) {
-        return res.status(409).json({ success: false, message: "진행중(PENDING) 상태에서만 수정할 수 있습니다." });
-      }
-
-      // 활성 견적 요청 찾기
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       if (!active) {
         return res.status(404).json({ success: false, message: "활성 견적 요청이 없습니다." });
       }
 
-      // 견적 요청이 만료되었는지 확인
-      const isExpired = await estimateRequestService.isRequestExpired(active.id);
-      if (isExpired) {
+      if (active.status !== "PENDING") {
         return res.status(409).json({
           success: false,
-          message: "이사일이 지나 만료된 견적 요청은 수정할 수 없습니다.",
+          message: "진행중(PENDING) 상태에서만 수정할 수 있습니다.",
         });
       }
 
-      // 프론트엔드 요청 구조에 맞게 파라미터 받기
       const { movingType, movingDate, departure, arrival, description } = req.body;
 
-      // 이사일이 과거인지 확인 (수정 시에만, 한국 시간 기준)
-      if (movingDate) {
-        const moveDate = new Date(movingDate);
+      const validation = this.validateUpdateEstimateRequest({
+        movingType,
+        movingDate,
+        departure,
+        arrival,
+        description,
+      });
 
-        if (isBeforeKoreaToday(moveDate)) {
-          return res.status(400).json({
-            success: false,
-            message: "이사일은 오늘 이후로 설정해주세요.",
-          });
-        }
-      }
-
-      // 출발지와 도착지 주소가 완전히 같은지 검사
-      const safeEq = (a: any, b: any) => (a || "").toString().trim() === (b || "").toString().trim();
-      if (
-        safeEq(departure?.roadAddress, arrival?.roadAddress) &&
-        safeEq(departure?.detailAddress, arrival?.detailAddress)
-      ) {
-        return res.status(400).json({ success: false, message: "출발지와 도착지는 달라야 합니다." });
+      if (!validation.isValid) {
+        return res.status(400).json({
+          success: false,
+          message: validation.errors[0],
+        });
       }
 
       const updateData: TUpdateEstimateRequest = {
@@ -192,36 +281,37 @@ class EstimateRequestController {
         description,
       };
 
-      const updated = await estimateRequestService.updateActiveEstimateRequest(active.id, updateData);
-      return res.status(200).json({ success: true, message: "견적 요청이 성공적으로 수정되었습니다.", data: updated });
+      await estimateRequestService.updateActiveEstimateRequest(active.id, updateData);
+
+      const updatedRequest = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
+
+      return res.status(200).json({
+        success: true,
+        message: "견적 요청이 성공적으로 수정되었습니다.",
+        data: updatedRequest ? this.formatEstimateRequestResponse(updatedRequest) : null,
+      });
     } catch (error) {
       console.error("견적 요청 수정 에러:", error);
-      return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
+      const message = error instanceof Error ? error.message : "서버 내부 오류가 발생했습니다.";
+      const status = error instanceof Error && error.message.includes("인증") ? 401 : 500;
+      return res.status(status).json({ success: false, message });
     }
   }
 
   async cancelActiveEstimateRequest(req: Request, res: Response) {
     try {
-      const userId = (req as any).user?.userId as string;
-      if (!userId) {
-        return res.status(401).json({ success: false, message: "인증이 필요합니다." });
-      }
+      const userId = this.getUserId(req);
+      this.validateUser(userId);
+      await this.validateCustomerAccess(userId);
 
-      // 유저 유형 확인 - 기사님은 견적 요청을 취소할 수 없음
-      const { isCustomer, isMover } = await estimateRequestService.checkUserType(userId);
-      if (!isCustomer) {
-        return res.status(403).json({
+      const isPending = await estimateRequestService.hasPendingRequest(userId);
+      if (!isPending) {
+        return res.status(409).json({
           success: false,
-          message: "기사님은 견적 요청을 취소할 수 없습니다. 일반 고객으로 로그인해주세요.",
+          message: "진행중(PENDING) 상태에서만 취소할 수 있습니다.",
         });
       }
 
-      const isPending = await estimateRequestService.isActiveRequestPending(userId);
-      if (!isPending) {
-        return res.status(409).json({ success: false, message: "진행중(PENDING) 상태에서만 취소할 수 있습니다." });
-      }
-
-      // 기사님이 견적을 제출했는지 확인 (PROPOSED 상태)
       const hasEstimate = await estimateRequestService.hasEstimateFromMover(userId);
       if (hasEstimate) {
         return res.status(409).json({
@@ -230,27 +320,25 @@ class EstimateRequestController {
         });
       }
 
-      // 활성 견적 요청 찾기
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       if (!active) {
         return res.status(404).json({ success: false, message: "활성 견적 요청이 없습니다." });
       }
 
-      // 견적 요청이 만료되었는지 확인
-      const isExpired = await estimateRequestService.isRequestExpired(active.id);
-      if (isExpired) {
+      if (active.status !== "PENDING" || hasEstimate) {
         return res.status(409).json({
           success: false,
-          message: "이사일이 지나 만료된 견적 요청은 취소할 수 없습니다.",
+          message: "진행중(PENDING) 상태에서만 취소할 수 있습니다.",
         });
       }
 
-      // 취소 처리
       await estimateRequestService.cancelActiveEstimateRequest(active.id);
       return res.status(200).json({ success: true, message: "견적 요청이 취소되었습니다." });
     } catch (error) {
       console.error("견적 요청 취소 에러:", error);
-      return res.status(500).json({ success: false, message: "서버 내부 오류가 발생했습니다." });
+      const message = error instanceof Error ? error.message : "서버 내부 오류가 발생했습니다.";
+      const status = error instanceof Error && error.message.includes("인증") ? 401 : 500;
+      return res.status(status).json({ success: false, message });
     }
   }
 }

--- a/src/controllers/estimateRequest.controller.ts
+++ b/src/controllers/estimateRequest.controller.ts
@@ -244,6 +244,14 @@ class EstimateRequestController {
         });
       }
 
+      const hasEstimateFromMover = await estimateRequestService.hasEstimateFromMover(userId);
+      if (hasEstimateFromMover) {
+        return res.status(409).json({
+          success: false,
+          message: "기사님이 견적을 제출한 경우 수정할 수 없습니다. 견적을 확인한 후 결정해주세요.",
+        });
+      }
+
       const active = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
       if (!active) {
         return res.status(404).json({ success: false, message: "활성 견적 요청이 없습니다." });

--- a/src/db/prisma/migrations/20250726072213_remove_address_unique_constraint/migration.sql
+++ b/src/db/prisma/migrations/20250726072213_remove_address_unique_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "addresses_postalCode_city_district_detail_key";

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -188,7 +188,7 @@ model Address {
   requestsTo    EstimateRequest[] @relation("RequestTo") // 도착지로 사용된 견적 요청들
   userAddresses UserAddress[] // 사용자별 주소 연결
 
-  @@unique([postalCode, city, district, detail]) // 중복 주소 등록 방지
+  // @@unique([postalCode, city, district, detail]) // 중복 주소 등록 방지 - 제거: 같은 주소라도 다른 사용자 요청일 수 있음
   @@index([region])
   @@index([city])
   @@index([district])

--- a/src/repositories/estimateRequest.repository.ts
+++ b/src/repositories/estimateRequest.repository.ts
@@ -1,22 +1,19 @@
+import { PrismaClient, RequestStatus, EstimateRequest, UserType, MoveType, RegionType } from "@prisma/client";
 import {
-  PrismaClient,
-  MoveType,
-  RequestStatus,
-  EstimateRequest,
-  UserType,
-} from "@prisma/client";
-import { getKoreaToday } from "../utils/dateUtils";
+  IParsedAddressData,
+  IDatabaseEstimateRequest,
+  TCreateEstimateRequestData,
+  TUpdateEstimateRequestData,
+  IUserTypeResult,
+} from "../types/estimateRequest.types";
 
 const prisma = new PrismaClient();
 
-const createEstimateRequest = async (
-  data: any,
-  userId: string
-): Promise<EstimateRequest> => {
+const createEstimateRequest = async (data: TCreateEstimateRequestData, userId: string): Promise<EstimateRequest> => {
   return await prisma.estimateRequest.create({
     data: {
       customerId: userId,
-      moveType: data.moveType,
+      moveType: data.moveType as MoveType,
       moveDate: new Date(data.moveDate),
       fromAddressId: data.fromAddressId,
       toAddressId: data.toAddressId,
@@ -25,10 +22,9 @@ const createEstimateRequest = async (
     },
   });
 };
-const getActiveEstimateRequestByUserId = async (
-  userId: string
-): Promise<any | null> => {
-  return await prisma.estimateRequest.findFirst({
+
+const getActiveEstimateRequestByUserId = async (userId: string): Promise<IDatabaseEstimateRequest | null> => {
+  const request = await prisma.estimateRequest.findFirst({
     where: {
       customerId: userId,
       status: RequestStatus.PENDING,
@@ -46,6 +42,7 @@ const getActiveEstimateRequestByUserId = async (
       status: true,
       createdAt: true,
       updatedAt: true,
+      deletedAt: true,
       fromAddress: {
         select: {
           postalCode: true,
@@ -53,6 +50,7 @@ const getActiveEstimateRequestByUserId = async (
           district: true,
           detail: true,
           region: true,
+          deletedAt: true,
         },
       },
       toAddress: {
@@ -62,15 +60,30 @@ const getActiveEstimateRequestByUserId = async (
           district: true,
           detail: true,
           region: true,
+          deletedAt: true,
         },
       },
     },
   });
+
+  if (request) {
+    if (request.fromAddress && request.fromAddress.deletedAt) {
+      (request as any).fromAddress = undefined;
+    }
+    if (request.toAddress && request.toAddress.deletedAt) {
+      (request as any).toAddress = undefined;
+    }
+  }
+
+  return request;
 };
 
-const getEstimateRequestById = async (id: string): Promise<any | null> => {
+const getEstimateRequestById = async (id: string): Promise<IDatabaseEstimateRequest | null> => {
   return await prisma.estimateRequest.findUnique({
-    where: { id },
+    where: {
+      id,
+      deletedAt: null,
+    },
     select: {
       id: true,
       customerId: true,
@@ -82,49 +95,112 @@ const getEstimateRequestById = async (id: string): Promise<any | null> => {
       status: true,
       createdAt: true,
       updatedAt: true,
+      deletedAt: true,
+      fromAddress: {
+        select: {
+          postalCode: true,
+          city: true,
+          district: true,
+          detail: true,
+          region: true,
+          deletedAt: true,
+        },
+      },
+      toAddress: {
+        select: {
+          postalCode: true,
+          city: true,
+          district: true,
+          detail: true,
+          region: true,
+          deletedAt: true,
+        },
+      },
     },
   });
 };
-const updateEstimateRequest = async (
-  id: string,
-  updateData: any
-): Promise<EstimateRequest> => {
-  return await prisma.estimateRequest.update({
-    where: { id },
-    data: updateData,
-  });
-};
-const cancelEstimateRequest = async (id: string): Promise<EstimateRequest> => {
-  // 한국 시간 기준으로 삭제한 날짜만 저장 (시간은 00:00:00)
-  const koreaToday = getKoreaToday();
+
+const updateEstimateRequest = async (id: string, updateData: TUpdateEstimateRequestData): Promise<EstimateRequest> => {
+  const prismaUpdateData: {
+    moveType?: MoveType;
+    moveDate?: Date;
+    fromAddressId?: string;
+    toAddressId?: string;
+    description?: string;
+  } = {};
+
+  if (updateData.moveType) {
+    prismaUpdateData.moveType = updateData.moveType as MoveType;
+  }
+  if (updateData.moveDate) {
+    prismaUpdateData.moveDate = updateData.moveDate;
+  }
+  if (updateData.fromAddressId) {
+    prismaUpdateData.fromAddressId = updateData.fromAddressId;
+  }
+  if (updateData.toAddressId) {
+    prismaUpdateData.toAddressId = updateData.toAddressId;
+  }
+  if (updateData.description !== undefined) {
+    prismaUpdateData.description = updateData.description;
+  }
 
   return await prisma.estimateRequest.update({
     where: { id },
-    data: { status: RequestStatus.CANCELLED, deletedAt: koreaToday },
+    data: prismaUpdateData,
   });
 };
+
+const cancelEstimateRequest = async (id: string): Promise<EstimateRequest> => {
+  const today = new Date();
+  const todayDateOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  return await prisma.$transaction(async (tx) => {
+    const request = await tx.estimateRequest.findUnique({
+      where: { id },
+      select: { fromAddressId: true, toAddressId: true },
+    });
+
+    if (!request) {
+      throw new Error("견적 요청을 찾을 수 없습니다.");
+    }
+
+    const cancelledRequest = await tx.estimateRequest.update({
+      where: { id },
+      data: {
+        status: RequestStatus.CANCELLED,
+        deletedAt: todayDateOnly,
+      },
+    });
+
+    await Promise.all([
+      tx.address.update({
+        where: { id: request.fromAddressId },
+        data: { deletedAt: todayDateOnly },
+      }),
+      tx.address.update({
+        where: { id: request.toAddressId },
+        data: { deletedAt: todayDateOnly },
+      }),
+    ]);
+
+    return cancelledRequest;
+  });
+};
+
 const hasPendingRequest = async (userId: string): Promise<boolean> => {
-  const req = await prisma.estimateRequest.findFirst({
+  const request = await prisma.estimateRequest.findFirst({
     where: {
       customerId: userId,
       status: RequestStatus.PENDING,
       deletedAt: null,
     },
   });
-  return !!req;
+  return !!request;
 };
-const isActiveRequestPending = async (userId: string): Promise<boolean> => {
-  const req = await prisma.estimateRequest.findFirst({
-    where: {
-      customerId: userId,
-      status: RequestStatus.PENDING,
-      deletedAt: null,
-    },
-  });
-  return !!req;
-};
+
 const hasEstimateFromMover = async (userId: string): Promise<boolean> => {
-  const req = await prisma.estimateRequest.findFirst({
+  const request = await prisma.estimateRequest.findFirst({
     where: {
       customerId: userId,
       status: RequestStatus.PENDING,
@@ -132,41 +208,48 @@ const hasEstimateFromMover = async (userId: string): Promise<boolean> => {
     },
     select: { id: true },
   });
-  if (!req) return false;
+
+  if (!request) return false;
+
   const estimate = await prisma.estimate.findFirst({
-    where: { estimateRequestId: req.id, deletedAt: null },
+    where: {
+      estimateRequestId: request.id,
+      deletedAt: null,
+    },
   });
   return !!estimate;
 };
-const findOrCreateAddress = async ({
-  city,
-  district,
-  detail,
-  region,
-}: {
-  city: string;
-  district: string;
-  detail?: string;
-  region: string;
-}) => {
-  // region enum 변환
-  // Prisma의 $Enums.RegionType을 import하지 않고, prisma.address의 타입 추론을 활용
-  let address = await prisma.address.findFirst({
-    where: { city, district, detail, region: region as any },
+
+const findOrCreateAddress = async (addressData: IParsedAddressData): Promise<{ id: string }> => {
+  const createData = {
+    postalCode: addressData.postalCode,
+    city: addressData.city,
+    district: addressData.district,
+    region: addressData.region as RegionType,
+    detail:
+      addressData.detail === null || addressData.detail === undefined || addressData.detail === ""
+        ? null
+        : addressData.detail,
+  };
+
+  const address = await prisma.address.create({
+    data: createData,
   });
-  if (!address) {
-    // 우편번호는 나중에 업데이트하거나 빈 문자열로 설정
-    address = await prisma.address.create({
-      data: { city, district, detail, region: region as any, postalCode: "" },
-    });
-  }
-  return address;
+
+  return { id: address.id };
 };
 
-// 유저의 유형을 확인하는 메서드
-const checkUserType = async (
-  userId: string
-): Promise<{ isCustomer: boolean; isMover: boolean }> => {
+const softDeleteAddress = async (addressId: string): Promise<void> => {
+  const today = new Date();
+  const todayDateOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  await prisma.address.update({
+    where: { id: addressId },
+    data: { deletedAt: todayDateOnly },
+  });
+};
+
+const checkUserType = async (userId: string): Promise<IUserTypeResult> => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { userType: true, isCustomer: true, isMover: true },
@@ -176,48 +259,10 @@ const checkUserType = async (
     throw new Error("사용자를 찾을 수 없습니다.");
   }
 
-  const isCustomer =
-    user.userType.includes(UserType.CUSTOMER) || user.isCustomer === true;
-  const isMover =
-    user.userType.includes(UserType.MOVER) || user.isMover === true;
+  const isCustomer = user.userType.includes(UserType.CUSTOMER) || user.isCustomer === true;
+  const isMover = user.userType.includes(UserType.MOVER) || user.isMover === true;
 
   return { isCustomer, isMover };
-};
-
-// 이사일이 지난 견적 요청을 만료 처리하는 메서드
-const expireOverdueRequests = async (today: Date): Promise<void> => {
-  await prisma.estimateRequest.updateMany({
-    where: {
-      moveDate: {
-        lt: today, // 이사일이 오늘보다 이전
-      },
-      status: RequestStatus.PENDING, // PENDING 상태인 것만
-      deletedAt: null,
-    },
-    data: {
-      status: RequestStatus.EXPIRED,
-      updatedAt: new Date(),
-    },
-  });
-};
-
-// 견적 요청이 만료되었는지 확인하는 메서드
-const isRequestExpired = async (
-  estimateRequestId: string
-): Promise<boolean> => {
-  const request = await prisma.estimateRequest.findUnique({
-    where: { id: estimateRequestId },
-    select: { moveDate: true, status: true },
-  });
-
-  if (!request) {
-    return false;
-  }
-
-  const koreaToday = getKoreaToday();
-  return (
-    request.moveDate < koreaToday || request.status === RequestStatus.EXPIRED
-  );
 };
 
 export default {
@@ -227,10 +272,8 @@ export default {
   updateEstimateRequest,
   cancelEstimateRequest,
   hasPendingRequest,
-  isActiveRequestPending,
   hasEstimateFromMover,
   findOrCreateAddress,
+  softDeleteAddress,
   checkUserType,
-  expireOverdueRequests,
-  isRequestExpired,
 };

--- a/src/routes/estimateRequest.routes.ts
+++ b/src/routes/estimateRequest.routes.ts
@@ -6,288 +6,389 @@ const router = Router();
 const estimateRequestController = new EstimateRequestController();
 
 /**
- * POST / (이사 견적 요청 생성)
- * @summary 이사 견적 요청 생성
- * @description 한 사용자는 PENDING 상태의 견적 요청이 1개만 존재할 수 있습니다. 기존 요청이 CANCELLED, EXPIRED, COMPLETED 상태일 때만 새로 생성할 수 있습니다. 기사님은 견적 요청을 생성할 수 없습니다.
+ * Address information
+ * @typedef {object} AddressInfo
+ * @property {string} roadAddress.required - 도로명주소
+ * @property {string} detailAddress - 상세주소
+ * @property {string} zonecode - 우편번호 (카카오 API 응답용)
+ * @property {string} jibunAddress - 지번주소
+ * @property {string} extraAddress - 참고항목
+ */
+
+/**
+ * Create estimate request
+ * @typedef {object} CreateEstimateRequest
+ * @property {string} movingType.required - 이사 종류 - enum:small,home,office
+ * @property {string} movingDate.required - 이사 날짜 (YYYY-MM-DD)
+ * @property {boolean} isDateConfirmed - 날짜 확정 여부
+ * @property {AddressInfo} departure.required - 출발지 주소
+ * @property {AddressInfo} arrival.required - 도착지 주소
+ * @property {string} description - 추가 설명
+ */
+
+/**
+ * Update estimate request
+ * @typedef {object} UpdateEstimateRequest
+ * @property {string} movingType - 이사 종류 - enum:small,home,office
+ * @property {string} movingDate - 이사 날짜 (YYYY-MM-DD)
+ * @property {AddressInfo} departure - 출발지 주소
+ * @property {AddressInfo} arrival - 도착지 주소
+ * @property {string} description - 추가 설명
+ */
+
+/**
+ * Estimate request response
+ * @typedef {object} EstimateRequestResponse
+ * @property {string} id - 견적 요청 ID
+ * @property {string} userId - 사용자 ID
+ * @property {string} movingType - 이사 종류 - enum:SMALL,HOME,OFFICE
+ * @property {string} departureAddress - 출발지 주소 (한글 지역명 포함)
+ * @property {string} arrivalAddress - 도착지 주소 (한글 지역명 포함)
+ * @property {string} departureDetailAddress - 출발지 상세주소
+ * @property {string} arrivalDetailAddress - 도착지 상세주소
+ * @property {string} departurePostalCode - 출발지 우편번호
+ * @property {string} arrivalPostalCode - 도착지 우편번호
+ * @property {string} movingDate - 이사 날짜
+ * @property {string} status - 견적 요청 상태 - enum:PENDING,CANCELLED,COMPLETED
+ * @property {string} createdAt - 생성일시
+ * @property {string} updatedAt - 수정일시
+ */
+
+/**
+ * Success response with data
+ * @typedef {object} SuccessResponse
+ * @property {boolean} success - 성공 여부
+ * @property {string} message - 응답 메시지
+ * @property {EstimateRequestResponse} data - 견적 요청 데이터
+ */
+
+/**
+ * Active response
+ * @typedef {object} ActiveResponse
+ * @property {boolean} success - 성공 여부
+ * @property {boolean} hasActive - 활성 견적 요청 존재 여부
+ * @property {EstimateRequestResponse} data - 견적 요청 데이터 (hasActive가 true인 경우)
+ */
+
+/**
+ * Error response
+ * @typedef {object} ErrorResponse
+ * @property {boolean} success - 성공 여부
+ * @property {string} message - 에러 메시지
+ */
+
+/**
+ * Cancel response
+ * @typedef {object} CancelResponse
+ * @property {boolean} success - 성공 여부
+ * @property {string} message - 응답 메시지
+ */
+
+// 견적 요청 생성
+/**
+ * POST /estimateRequests/create
+ * @summary 견적 요청 생성
+ * @description 고객이 이사 견적을 요청합니다. 한 사용자는 PENDING 상태의 견적 요청이 1개만 존재할 수 있습니다. 기사님은 견적 요청을 생성할 수 없습니다. 주소는 자동으로 파싱되어 데이터베이스에 저장되며, zonecode 필드는 postalCode로 자동 변환됩니다.
  * @tags EstimateRequest
- * @security BearerAuth
- * @param {object} request.body.required - 견적 요청 정보
- * @param {string} request.body.movingType.required - 이사 종류 (small, home, office)
- * @param {string} request.body.movingDate.required - 이사 날짜 (YYYY-MM-DD 형식, 오늘 이후만 가능)
- * @param {object} request.body.departure.required - 출발지 주소 정보
- * @param {string} request.body.departure.roadAddress.required - 출발지 도로명주소 (예: "서울특별시 강남구 테헤란로 123")
- * @param {string} request.body.departure.detailAddress - 출발지 상세주소 (예: "456호")
- * @param {object} request.body.arrival.required - 도착지 주소 정보
- * @param {string} request.body.arrival.roadAddress.required - 도착지 도로명주소 (예: "경기도 성남시 분당구 판교로 456")
- * @param {string} request.body.arrival.detailAddress - 도착지 상세주소 (예: "789호")
- * @param {string} request.body.description - 추가 설명
- * @returns {object} 201 - 견적 요청 생성 성공
- * @returns {object} 400 - 잘못된 요청 (이사일이 과거, 출발지/도착지 동일 등)
- * @returns {object} 403 - 기사님은 견적 요청을 생성할 수 없음
- * @returns {object} 409 - 이미 진행중인 견적 요청 존재
- * @returns {object} 401 - 인증 실패
- * @returns {object} 500 - 서버 내부 오류
- * @example request - 요청 예시
+ * @param {CreateEstimateRequest} request.body.required - 견적 요청 정보
+ * @return {SuccessResponse} 201 - 견적 요청 생성 성공
+ * @return {ErrorResponse} 400 - 잘못된 요청 (이사일이 과거, 출발지와 도착지 동일, 잘못된 이사 종류, 주소 누락)
+ * @return {ErrorResponse} 401 - 인증 실패
+ * @return {ErrorResponse} 403 - 기사님은 견적 요청을 생성할 수 없음
+ * @return {ErrorResponse} 409 - 이미 진행중인 견적 요청 존재
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ * @example request - 가정 이사 견적 요청 예시
  * {
  *   "movingType": "home",
- *   "movingDate": "2024-07-01",
+ *   "movingDate": "2025-07-28",
+ *   "isDateConfirmed": true,
  *   "departure": {
- *     "roadAddress": "서울특별시 강남구 테헤란로 123",
- *     "detailAddress": "456호"
+ *     "roadAddress": "부산 연제구 월드컵대로91번가길 15",
+ *     "detailAddress": "501호",
+ *     "zonecode": "47597",
+ *     "jibunAddress": "부산 연제구 연산동 715-1",
+ *     "extraAddress": "연산동"
  *   },
  *   "arrival": {
- *     "roadAddress": "경기도 성남시 분당구 판교로 456",
- *     "detailAddress": "789호"
+ *     "roadAddress": "경남 고성군 고성읍 송학로 206",
+ *     "detailAddress": "402호",
+ *     "zonecode": "52940",
+ *     "jibunAddress": "경남 고성군 고성읍 송학리 235-2",
+ *     "extraAddress": "송학리"
  *   },
- *   "description": "엘리베이터 있음, 반려동물 동반"
+ *   "description": "가정 이사입니다. 신중하게 견적 부탁드립니다."
  * }
- * @example response - 201 - 성공 예시
+ * @example response - 201 - 견적 요청 생성 성공 응답 예시
  * {
  *   "success": true,
  *   "message": "견적 요청이 성공적으로 생성되었습니다.",
  *   "data": {
- *     "id": "abc123",
+ *     "id": "cmdjyt7ei0004irvgm050kzxz",
+ *     "userId": "cmdjvqbym0000a4whmdgza4i0",
  *     "movingType": "HOME",
- *     "movingDate": "2024-07-01",
- *     "departureAddress": "서울특별시 강남구 테헤란로 123",
- *     "arrivalAddress": "경기도 성남시 분당구 판교로 456",
- *     "departureDetailAddress": "456호",
- *     "arrivalDetailAddress": "789호",
- *     "description": "엘리베이터 있음, 반려동물 동반"
+ *     "departureAddress": "부산 연제구 월드컵대로91번가길",
+ *     "arrivalAddress": "경남 고성군 고성읍",
+ *     "departureDetailAddress": "15 501호",
+ *     "arrivalDetailAddress": "송학로 206 402호",
+ *     "departurePostalCode": "47597",
+ *     "arrivalPostalCode": "52940",
+ *     "movingDate": "2025-07-28",
+ *     "status": "PENDING",
+ *     "createdAt": "2025-07-26T08:05:07.387Z",
+ *     "updatedAt": "2025-07-26T08:05:07.387Z"
  *   }
  * }
- * @example response - 400 - 이사일이 과거
+ * @example response - 400 - 이사일이 과거인 경우 응답 예시
  * {
  *   "success": false,
  *   "message": "이사일은 오늘 이후로 설정해주세요."
  * }
- * @example response - 400 - 출발지와 도착지 동일
+ * @example response - 400 - 출발지와 도착지 동일한 경우 응답 예시
  * {
  *   "success": false,
  *   "message": "출발지와 도착지는 달라야 합니다."
  * }
- * @example response - 403 - 기사님은 생성 불가
+ * @example response - 400 - 잘못된 이사 종류인 경우 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "이사 종류는 small, home, office 중 하나여야 합니다."
+ * }
+ * @example response - 400 - 주소 누락인 경우 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "출발지 주소는 필수입니다."
+ * }
+ * @example response - 401 - 인증 실패 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "인증이 필요합니다."
+ * }
+ * @example response - 403 - 기사님 접근 제한 응답 예시
  * {
  *   "success": false,
  *   "message": "기사님은 견적 요청을 생성할 수 없습니다. 일반 고객으로 로그인해주세요."
  * }
- * @example response - 409 - 이미 진행중인 견적 요청이 있습니다.
+ * @example response - 409 - 이미 진행중인 견적 요청 존재 응답 예시
  * {
  *   "success": false,
  *   "message": "이미 진행중인 견적 요청이 있습니다."
  * }
- * @example response - 401 - 인증 실패
- * {
- *   "success": false,
- *   "message": "인증이 필요합니다."
- * }
- * @example response - 500 - 서버 내부 오류
+ * @example response - 500 - 서버 내부 오류 응답 예시
  * {
  *   "success": false,
  *   "message": "서버 내부 오류가 발생했습니다."
  * }
  */
-router.post("/", verifyAccessToken, estimateRequestController.createEstimateRequest);
+router.post("/create", verifyAccessToken, (req, res) => estimateRequestController.createEstimateRequest(req, res));
 
+// 활성 견적 요청 조회
 /**
- * GET /active (활성 견적 요청 조회)
+ * GET /estimateRequests/active
  * @summary 활성 견적 요청 조회
- * @description 현재 사용자의 활성 상태(PENDING) 견적 요청이 있는지 확인하고, 만료된 요청은 자동으로 EXPIRED로 변경합니다. 기사님은 견적 요청을 조회할 수 없습니다.
+ * @description 현재 사용자의 활성 상태(PENDING) 견적 요청을 조회합니다. 기사님은 견적 요청을 조회할 수 없습니다. 지역명은 한글로 표시되며, 주소가 soft delete된 경우 undefined로 처리됩니다.
  * @tags EstimateRequest
- * @security BearerAuth
- * @returns {object} 200 - 활성 견적 요청 조회 성공
- * @returns {object} 403 - 기사님은 견적 요청을 조회할 수 없음
- * @returns {object} 401 - 인증 실패
- * @returns {object} 500 - 서버 내부 오류
- * @example response - 200 - 활성 견적 요청 있음
+ * @return {ActiveResponse} 200 - 활성 견적 요청 조회 성공
+ * @return {ErrorResponse} 401 - 인증 실패
+ * @return {ErrorResponse} 403 - 기사님은 견적 요청을 조회할 수 없음
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ * @example response - 200 - 활성 견적 요청 있음 응답 예시
  * {
  *   "success": true,
  *   "hasActive": true,
  *   "data": {
- *     "id": "abc123",
- *     "userId": "user123",
+ *     "id": "cmdjyt7ei0004irvgm050kzxz",
+ *     "userId": "cmdjvqbym0000a4whmdgza4i0",
  *     "movingType": "HOME",
- *     "departureAddress": "서울특별시 강남구 테헤란로 123",
- *     "arrivalAddress": "경기도 성남시 분당구 판교로 456",
- *     "departureDetailAddress": "456호",
- *     "arrivalDetailAddress": "789호",
- *     "movingDate": "2024-07-01",
+ *     "departureAddress": "부산 연제구 월드컵대로91번가길",
+ *     "arrivalAddress": "경남 고성군 고성읍",
+ *     "departureDetailAddress": "15 501호",
+ *     "arrivalDetailAddress": "송학로 206 402호",
+ *     "departurePostalCode": "47597",
+ *     "arrivalPostalCode": "52940",
+ *     "movingDate": "2025-07-28",
  *     "status": "PENDING",
- *     "createdAt": "2024-01-15T10:30:00.000Z",
- *     "updatedAt": "2024-01-15T10:30:00.000Z"
+ *     "createdAt": "2025-07-26T08:05:07.387Z",
+ *     "updatedAt": "2025-07-26T08:05:07.387Z"
  *   }
  * }
- * @example response - 200 - 활성 견적 요청 없음
+ * @example response - 200 - 활성 견적 요청 없음 응답 예시
  * {
  *   "success": true,
  *   "hasActive": false
  * }
- * @example response - 403 - 기사님은 조회 불가
+ * @example response - 401 - 인증 실패 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "인증이 필요합니다."
+ * }
+ * @example response - 403 - 기사님 접근 제한 응답 예시
  * {
  *   "success": false,
  *   "message": "기사님은 견적 요청을 조회할 수 없습니다. 일반 고객으로 로그인해주세요."
  * }
- * @example response - 401 - 인증 실패
- * {
- *   "success": false,
- *   "message": "인증이 필요합니다."
- * }
- * @example response - 500 - 서버 내부 오류
+ * @example response - 500 - 서버 내부 오류 응답 예시
  * {
  *   "success": false,
  *   "message": "서버 내부 오류가 발생했습니다."
  * }
  */
-router.get("/active", verifyAccessToken, estimateRequestController.getActiveEstimateRequest);
+router.get("/active", verifyAccessToken, (req, res) => estimateRequestController.getActiveEstimateRequest(req, res));
 
+// 견적 요청 수정
 /**
- * PATCH /active (활성 견적 요청 수정)
- * @summary 활성 견적 요청 수정
- * @description PENDING 상태이면서 만료되지 않은 견적 요청만 수정 가능. 기사님은 수정할 수 없음.
+ * PATCH /estimateRequests/active
+ * @summary 견적 요청 수정
+ * @description PENDING 상태의 견적 요청을 수정합니다. 기사님은 견적 요청을 수정할 수 없습니다. 주소 수정 시 기존 주소는 soft delete되고 새 주소가 생성됩니다. 부분 수정이 가능하며, 필요한 필드만 전송하면 됩니다.
  * @tags EstimateRequest
- * @security BearerAuth
- * @param {object} request.body.required - 수정할 견적 요청 정보
- * @param {string} request.body.movingType.required - 이사 종류 (small, home, office)
- * @param {string} request.body.movingDate.required - 이사 날짜 (YYYY-MM-DD 형식, 오늘 이후만 가능)
- * @param {object} request.body.departure.required - 출발지 주소 정보
- * @param {string} request.body.departure.roadAddress.required - 출발지 도로명주소 (예: "서울특별시 강남구 테헤란로 123")
- * @param {string} request.body.departure.detailAddress - 출발지 상세주소 (예: "456호")
- * @param {object} request.body.arrival.required - 도착지 주소 정보
- * @param {string} request.body.arrival.roadAddress.required - 도착지 도로명주소 (예: "경기도 성남시 분당구 판교로 456")
- * @param {string} request.body.arrival.detailAddress - 도착지 상세주소 (예: "789호")
- * @param {string} request.body.description - 추가 설명
- * @returns {object} 200 - 견적 요청 수정 성공
- * @returns {object} 400 - 잘못된 요청 (이사일이 과거, 출발지/도착지 동일 등)
- * @returns {object} 403 - 기사님은 견적 요청을 수정할 수 없음
- * @returns {object} 404 - 활성 견적 요청 없음
- * @returns {object} 409 - 진행중(PENDING) 상태가 아님/만료된 요청 등
- * @returns {object} 401 - 인증 실패
- * @returns {object} 500 - 서버 내부 오류
- * @example request - 요청 예시
+ * @param {UpdateEstimateRequest} request.body.required - 수정할 견적 요청 정보
+ * @return {SuccessResponse} 200 - 견적 요청 수정 성공
+ * @return {ErrorResponse} 400 - 잘못된 요청 (이사일이 과거, 출발지와 도착지 동일, 잘못된 이사 종류)
+ * @return {ErrorResponse} 401 - 인증 실패
+ * @return {ErrorResponse} 403 - 기사님은 견적 요청을 수정할 수 없음
+ * @return {ErrorResponse} 404 - 활성 견적 요청 없음
+ * @return {ErrorResponse} 409 - 진행중(PENDING) 상태가 아님
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ * @example request - 이사 종류 변경 예시
  * {
- *   "movingType": "office",
- *   "movingDate": "2024-07-10",
+ *   "movingType": "home",
+ *   "description": "가정 이사로 변경했습니다."
+ * }
+ * @example request - 이사일 변경 예시
+ * {
+ *   "movingDate": "2026-10-20"
+ * }
+ * @example request - 주소 변경 예시
+ * {
  *   "departure": {
- *     "roadAddress": "서울특별시 강남구 테헤란로 123",
- *     "detailAddress": "456호"
+ *     "roadAddress": "서울 강남구 테헤란로 123",
+ *     "detailAddress": "456호",
+ *     "zonecode": "06123",
+ *     "jibunAddress": "서울 강남구 역삼동 123-45",
+ *     "extraAddress": "역삼동"
  *   },
  *   "arrival": {
- *     "roadAddress": "경기도 성남시 분당구 판교로 456",
- *     "detailAddress": "789호"
- *   },
- *   "description": "짐이 많음, 사다리차 필요"
+ *     "roadAddress": "경기 성남시 분당구 판교로 456",
+ *     "detailAddress": "789호",
+ *     "zonecode": "13561",
+ *     "jibunAddress": "경기 성남시 분당구 정자동 456-78",
+ *     "extraAddress": "정자동"
+ *   }
  * }
- * @example response - 200 - 성공 예시
+ * @example response - 200 - 견적 요청 수정 성공 응답 예시
  * {
  *   "success": true,
  *   "message": "견적 요청이 성공적으로 수정되었습니다.",
  *   "data": {
- *     "id": "abc123",
+ *     "id": "cmdjyt7ei0004irvgm050kzxz",
+ *     "userId": "cmdjvqbym0000a4whmdgza4i0",
  *     "movingType": "OFFICE",
- *     "movingDate": "2024-07-10",
- *     "departureAddress": "서울특별시 강남구 테헤란로 123",
- *     "arrivalAddress": "경기도 성남시 분당구 판교로 456",
- *     "departureDetailAddress": "456호",
- *     "arrivalDetailAddress": "789호",
- *     "description": "짐이 많음, 사다리차 필요"
+ *     "departureAddress": "서울 강남구 테헤란로",
+ *     "arrivalAddress": "경기 성남시 분당구 판교로",
+ *     "departureDetailAddress": "123 456호",
+ *     "arrivalDetailAddress": "456 789호",
+ *     "departurePostalCode": "06123",
+ *     "arrivalPostalCode": "13561",
+ *     "movingDate": "2026-10-20",
+ *     "status": "PENDING",
+ *     "createdAt": "2025-07-26T08:05:07.387Z",
+ *     "updatedAt": "2025-07-26T11:30:00.000Z"
  *   }
  * }
- * @example response - 400 - 이사일이 과거
+ * @example response - 400 - 이사일이 과거인 경우 응답 예시
  * {
  *   "success": false,
  *   "message": "이사일은 오늘 이후로 설정해주세요."
  * }
- * @example response - 400 - 출발지와 도착지 동일
+ * @example response - 400 - 출발지와 도착지 동일한 경우 응답 예시
  * {
  *   "success": false,
  *   "message": "출발지와 도착지는 달라야 합니다."
  * }
- * @example response - 403 - 기사님은 수정 불가
+ * @example response - 400 - 잘못된 이사 종류인 경우 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "이사 종류는 small, home, office 중 하나여야 합니다."
+ * }
+ * @example response - 401 - 인증 실패 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "인증이 필요합니다."
+ * }
+ * @example response - 403 - 기사님 접근 제한 응답 예시
  * {
  *   "success": false,
  *   "message": "기사님은 견적 요청을 수정할 수 없습니다. 일반 고객으로 로그인해주세요."
  * }
- * @example response - 409 - 진행중(PENDING) 상태가 아님
+ * @example response - 404 - 활성 견적 요청 없음 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "활성 견적 요청이 없습니다."
+ * }
+ * @example response - 409 - 진행중(PENDING) 상태가 아님 응답 예시
  * {
  *   "success": false,
  *   "message": "진행중(PENDING) 상태에서만 수정할 수 있습니다."
  * }
- * @example response - 409 - 만료된 요청
- * {
- *   "success": false,
- *   "message": "이사일이 지나 만료된 견적 요청은 수정할 수 없습니다."
- * }
- * @example response - 404 - 활성 견적 요청 없음
- * {
- *   "success": false,
- *   "message": "활성 견적 요청이 없습니다."
- * }
- * @example response - 401 - 인증 실패
- * {
- *   "success": false,
- *   "message": "인증이 필요합니다."
- * }
- * @example response - 500 - 서버 내부 오류
+ * @example response - 500 - 서버 내부 오류 응답 예시
  * {
  *   "success": false,
  *   "message": "서버 내부 오류가 발생했습니다."
  * }
  */
-router.patch("/active", verifyAccessToken, estimateRequestController.updateActiveEstimateRequest);
+router.patch("/active", verifyAccessToken, (req, res) =>
+  estimateRequestController.updateActiveEstimateRequest(req, res),
+);
 
+// 견적 요청 취소
 /**
- * DELETE /active (활성 견적 요청 취소)
- * @summary 활성 견적 요청 취소
- * @description PENDING 상태이면서 만료되지 않은 견적 요청만 취소 가능. 기사님이 견적을 제출한 경우 취소할 수 없습니다. 기사님은 견적 요청을 취소할 수 없습니다. 취소 시 상태는 CANCELLED로 변경됩니다.
+ * DELETE /estimateRequests/active
+ * @summary 견적 요청 취소
+ * @description PENDING 상태의 견적 요청을 취소합니다. 기사님이 견적을 제출한 경우 취소할 수 없습니다. 기사님은 견적 요청을 취소할 수 없습니다. 취소 시 견적 요청과 관련 주소들의 deletedAt에 오늘 날짜가 기록됩니다.
  * @tags EstimateRequest
- * @security BearerAuth
- * @returns {object} 200 - 견적 요청 취소 성공
- * @returns {object} 403 - 기사님은 견적 요청을 취소할 수 없음
- * @returns {object} 404 - 활성 견적 요청 없음
- * @returns {object} 409 - 진행중(PENDING) 상태가 아님/기사 견적 제출됨/만료된 요청 등
- * @returns {object} 401 - 인증 실패
- * @returns {object} 500 - 서버 내부 오류
- * @example response - 200 - 취소 성공
+ * @return {CancelResponse} 200 - 견적 요청 취소 성공
+ * @return {ErrorResponse} 401 - 인증 실패
+ * @return {ErrorResponse} 403 - 기사님은 견적 요청을 취소할 수 없음
+ * @return {ErrorResponse} 404 - 활성 견적 요청 없음
+ * @return {ErrorResponse} 409 - 진행중(PENDING) 상태가 아님 또는 기사 견적 제출됨
+ * @return {ErrorResponse} 500 - 서버 내부 오류
+ * @example response - 200 - 견적 요청 취소 성공 응답 예시
  * {
  *   "success": true,
  *   "message": "견적 요청이 취소되었습니다."
  * }
- * @example response - 403 - 기사님은 취소 불가
- * {
- *   "success": false,
- *   "message": "기사님은 견적 요청을 취소할 수 없습니다. 일반 고객으로 로그인해주세요."
- * }
- * @example response - 409 - 진행중(PENDING) 상태가 아님
- * {
- *   "success": false,
- *   "message": "진행중(PENDING) 상태에서만 취소할 수 있습니다."
- * }
- * @example response - 409 - 기사 견적 제출됨
- * {
- *   "success": false,
- *   "message": "기사님이 견적을 제출한 경우 취소할 수 없습니다. 견적을 확인한 후 결정해주세요."
- * }
- * @example response - 409 - 만료된 요청
- * {
- *   "success": false,
- *   "message": "이사일이 지나 만료된 견적 요청은 취소할 수 없습니다."
- * }
- * @example response - 404 - 활성 견적 요청 없음
- * {
- *   "success": false,
- *   "message": "활성 견적 요청이 없습니다."
- * }
- * @example response - 401 - 인증 실패
+ * @example response - 401 - 인증 실패 응답 예시
  * {
  *   "success": false,
  *   "message": "인증이 필요합니다."
  * }
- * @example response - 500 - 서버 내부 오류
+ * @example response - 403 - 기사님 접근 제한 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "기사님은 견적 요청을 취소할 수 없습니다. 일반 고객으로 로그인해주세요."
+ * }
+ * @example response - 404 - 활성 견적 요청 없음 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "활성 견적 요청이 없습니다."
+ * }
+ * @example response - 409 - 진행중(PENDING) 상태가 아님 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "진행중(PENDING) 상태에서만 취소할 수 있습니다."
+ * }
+ * @example response - 409 - 기사 견적 제출됨 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "기사님이 견적을 제출한 경우 취소할 수 없습니다. 견적을 확인한 후 결정해주세요."
+ * }
+ * @example response - 500 - 서버 내부 오류 응답 예시
  * {
  *   "success": false,
  *   "message": "서버 내부 오류가 발생했습니다."
  * }
  */
-router.delete("/active", verifyAccessToken, estimateRequestController.cancelActiveEstimateRequest);
+router.delete("/active", verifyAccessToken, (req, res) =>
+  estimateRequestController.cancelActiveEstimateRequest(req, res),
+);
 
 export default router;

--- a/src/routes/estimateRequest.routes.ts
+++ b/src/routes/estimateRequest.routes.ts
@@ -246,7 +246,7 @@ router.get("/active", verifyAccessToken, (req, res) => estimateRequestController
  * @return {ErrorResponse} 401 - 인증 실패
  * @return {ErrorResponse} 403 - 기사님은 견적 요청을 수정할 수 없음
  * @return {ErrorResponse} 404 - 활성 견적 요청 없음
- * @return {ErrorResponse} 409 - 진행중(PENDING) 상태가 아님
+ * @return {ErrorResponse} 409 - 진행중(PENDING) 상태가 아님 또는 기사 견적 제출됨
  * @return {ErrorResponse} 500 - 서버 내부 오류
  * @example request - 이사 종류 변경 예시
  * {
@@ -328,6 +328,11 @@ router.get("/active", verifyAccessToken, (req, res) => estimateRequestController
  * {
  *   "success": false,
  *   "message": "진행중(PENDING) 상태에서만 수정할 수 있습니다."
+ * }
+ * @example response - 409 - 기사 견적 제출됨 응답 예시
+ * {
+ *   "success": false,
+ *   "message": "기사님이 견적을 제출한 경우 수정할 수 없습니다. 견적을 확인한 후 결정해주세요."
  * }
  * @example response - 500 - 서버 내부 오류 응답 예시
  * {

--- a/src/routes/index.routes.ts
+++ b/src/routes/index.routes.ts
@@ -29,7 +29,7 @@ businessRoutes.get("/health", (req, res) => {
 // 일반 비즈니스 로직 라우터
 businessRoutes.use("/movers", moverRouter);
 businessRoutes.use("/reviews", reviewRouter);
-businessRoutes.use("/estimate-requests", estimateRequestRouter);
+businessRoutes.use("/estimateRequests", estimateRequestRouter);
 businessRoutes.use("/customer-quotes", customerEstimateRequestRouter);
 businessRoutes.use("/mover-estimates", moverEstimateRouter);
 businessRoutes.use("/favorites", favoriteRouter);

--- a/src/services/estimateRequest.service.ts
+++ b/src/services/estimateRequest.service.ts
@@ -1,10 +1,17 @@
 import estimateRequestRepository from "../repositories/estimateRequest.repository";
-import { TCreateEstimateRequest, TUpdateEstimateRequest } from "../types/estimateRequest.types";
-import { getKoreaToday } from "../utils/dateUtils";
+import {
+  TCreateEstimateRequest,
+  TUpdateEstimateRequest,
+  IParsedAddressData,
+  IDatabaseEstimateRequest,
+  IUserTypeResult,
+  IAddressInfoForService,
+} from "../types/estimateRequest.types";
+import { parseAddress } from "../utils/addressUtils";
+import { EstimateRequest } from "@prisma/client";
 
 class EstimateRequestService {
-  // 유저의 유형을 확인하는 메서드
-  async checkUserType(userId: string): Promise<{ isCustomer: boolean; isMover: boolean }> {
+  async checkUserType(userId: string): Promise<IUserTypeResult> {
     return await estimateRequestRepository.checkUserType(userId);
   }
 
@@ -12,120 +19,28 @@ class EstimateRequestService {
     return await estimateRequestRepository.hasPendingRequest(userId);
   }
 
-  async isActiveRequestPending(userId: string): Promise<boolean> {
-    return await estimateRequestRepository.isActiveRequestPending(userId);
-  }
-
   async hasEstimateFromMover(userId: string): Promise<boolean> {
     return await estimateRequestRepository.hasEstimateFromMover(userId);
   }
 
-  // 이사일이 지난 견적 요청을 만료 처리하는 메서드
-  async expireOverdueRequests(): Promise<void> {
-    const koreaToday = getKoreaToday();
-    await estimateRequestRepository.expireOverdueRequests(koreaToday);
-  }
-
-  // 견적 요청이 만료되었는지 확인하는 메서드
-  async isRequestExpired(estimateRequestId: string): Promise<boolean> {
-    return await estimateRequestRepository.isRequestExpired(estimateRequestId);
-  }
-
-  async getActiveEstimateRequestByUserId(userId: string) {
+  async getActiveEstimateRequestByUserId(userId: string): Promise<IDatabaseEstimateRequest | null> {
     return await estimateRequestRepository.getActiveEstimateRequestByUserId(userId);
   }
 
-  async createEstimateRequest(params: TCreateEstimateRequest) {
+  private async processAddress(addressInfo: IAddressInfoForService): Promise<{ id: string }> {
+    const addressData: IParsedAddressData = parseAddress({
+      roadAddress: addressInfo.roadAddress,
+      detailAddress: addressInfo.detailAddress,
+      postalCode: addressInfo.zonecode || addressInfo.postalCode,
+    });
+    return await estimateRequestRepository.findOrCreateAddress(addressData);
+  }
+
+  async createEstimateRequest(params: TCreateEstimateRequest): Promise<EstimateRequest> {
     const { userId, movingType, movingDate, departure, arrival, description } = params;
 
-    // 주소 파싱 함수
-    const parseAddress = (addressObj: any) => {
-      const roadAddress = addressObj.roadAddress;
-      console.log("파싱할 주소:", roadAddress); // 디버깅용
+    const [fromAddress, toAddress] = await Promise.all([this.processAddress(departure), this.processAddress(arrival)]);
 
-      // 카카오 주소 API에서 오는 형태: "서울특별시 강남구 테헤란로 123"
-      // 또는 "경기도 성남시 분당구 경부고속도로 409"
-
-      // 주소를 공백으로 분리
-      const parts = roadAddress.split(" ");
-      console.log("분리된 주소 부분들:", parts); // 디버깅용
-
-      // 첫 번째 부분이 시/도인지 확인
-      const firstPart = parts[0];
-      console.log("첫 번째 부분:", firstPart); // 디버깅용
-
-      // 시/도 매핑이 가능한지 확인
-      const mappedRegion = this.mapRegionToEnum(firstPart);
-      console.log("매핑된 지역:", mappedRegion); // 디버깅용
-
-      // 매핑이 성공한 경우 (첫 번째 부분이 시/도인 경우)
-      if (mappedRegion !== "SEOUL" || firstPart === "서울" || firstPart === "서울특별시") {
-        if (parts.length >= 4) {
-          // "서울특별시 강남구 역삼동 테헤란로 123" 형태
-          const region = parts[0]; // 서울특별시
-          const city = parts[1]; // 강남구
-          const district = parts[2]; // 역삼동
-          const detail = parts.slice(3).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
-
-          console.log("파싱 결과 (4개 이상):", { region, city, district, detail }); // 디버깅용
-
-          return {
-            city,
-            district,
-            detail,
-            region: this.mapRegionToEnum(region),
-          };
-        } else if (parts.length === 3) {
-          // "서울특별시 강남구 테헤란로 123" 형태
-          const region = parts[0]; // 서울특별시
-          const city = parts[1]; // 강남구
-          const district = ""; // 빈 문자열
-          const detail = parts.slice(2).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
-
-          console.log("파싱 결과 (3개):", { region, city, district, detail }); // 디버깅용
-
-          return {
-            city,
-            district,
-            detail,
-            region: this.mapRegionToEnum(region),
-          };
-        } else if (parts.length === 2) {
-          // "강원특별자치도 홍천군" 형태 - city에 다 넣지 말고 detail에 넣기
-          const region = parts[0]; // 강원특별자치도
-          const city = ""; // 빈 문자열로 설정
-          const detail = parts[1] + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 홍천군 1
-
-          console.log("파싱 결과 (2개):", { region, city, district: "", detail }); // 디버깅용
-
-          return {
-            city,
-            district: "",
-            detail,
-            region: this.mapRegionToEnum(region),
-          };
-        }
-      }
-
-      // 매핑되지 않는 경우 기본값
-      console.log("매핑되지 않는 주소 형태, 기본값 사용");
-      return {
-        city: roadAddress,
-        district: "",
-        detail: addressObj.detailAddress || "",
-        region: "SEOUL" as any,
-      };
-    };
-
-    // 출발지 주소 생성 또는 검색
-    const fromAddressData = parseAddress(departure);
-    const fromAddress = await estimateRequestRepository.findOrCreateAddress(fromAddressData);
-
-    // 도착지 주소 생성 또는 검색
-    const toAddressData = parseAddress(arrival);
-    const toAddress = await estimateRequestRepository.findOrCreateAddress(toAddressData);
-
-    // EstimateRequest 생성
     return await estimateRequestRepository.createEstimateRequest(
       {
         moveType: movingType.toUpperCase(),
@@ -138,202 +53,73 @@ class EstimateRequestService {
     );
   }
 
-  async updateActiveEstimateRequest(id: string, updateData: TUpdateEstimateRequest) {
-    const updatePayload: any = {};
+  async updateActiveEstimateRequest(id: string, updateData: TUpdateEstimateRequest): Promise<EstimateRequest> {
+    const updatePayload: {
+      moveType?: string;
+      moveDate?: Date;
+      fromAddressId?: string;
+      toAddressId?: string;
+      description?: string;
+    } = {};
 
-    // moveType 업데이트
     if (updateData.movingType) {
       updatePayload.moveType = updateData.movingType.toUpperCase();
     }
-
-    // moveDate 업데이트
     if (updateData.movingDate) {
       updatePayload.moveDate = new Date(updateData.movingDate);
     }
-
-    // description 업데이트
     if (updateData.description !== undefined) {
       updatePayload.description = updateData.description;
     }
 
-    // 주소 업데이트가 있는 경우
     if (updateData.departure || updateData.arrival) {
       const currentRequest = await estimateRequestRepository.getEstimateRequestById(id);
       if (!currentRequest) {
         throw new Error("견적 요청을 찾을 수 없습니다.");
       }
 
-      // 주소 파싱 함수
-      const parseAddress = (addressObj: any) => {
-        const roadAddress = addressObj.roadAddress;
-        console.log("업데이트 파싱할 주소:", roadAddress); // 디버깅용
+      const oldFromAddressId = currentRequest.fromAddressId;
+      const oldToAddressId = currentRequest.toAddressId;
 
-        // 카카오 주소 API에서 오는 형태: "서울특별시 강남구 테헤란로 123"
-        // 또는 "경기도 성남시 분당구 경부고속도로 409"
+      const addressPromises: Promise<{ id: string }>[] = [];
 
-        // 주소를 공백으로 분리
-        const parts = roadAddress.split(" ");
-        console.log("업데이트 분리된 주소 부분들:", parts); // 디버깅용
-
-        // 첫 번째 부분이 시/도인지 확인
-        const firstPart = parts[0];
-        console.log("업데이트 첫 번째 부분:", firstPart); // 디버깅용
-
-        // 시/도 매핑이 가능한지 확인
-        const mappedRegion = this.mapRegionToEnum(firstPart);
-        console.log("업데이트 매핑된 지역:", mappedRegion); // 디버깅용
-
-        // 매핑이 성공한 경우 (첫 번째 부분이 시/도인 경우)
-        if (mappedRegion !== "SEOUL" || firstPart === "서울" || firstPart === "서울특별시") {
-          if (parts.length >= 4) {
-            // "서울특별시 강남구 역삼동 테헤란로 123" 형태
-            const region = parts[0]; // 서울특별시
-            const city = parts[1]; // 강남구
-            const district = parts[2]; // 역삼동
-            const detail = parts.slice(3).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
-
-            console.log("업데이트 파싱 결과 (4개 이상):", { region, city, district, detail }); // 디버깅용
-
-            return {
-              city,
-              district,
-              detail,
-              region: this.mapRegionToEnum(region),
-            };
-          } else if (parts.length === 3) {
-            // "서울특별시 강남구 테헤란로 123" 형태
-            const region = parts[0]; // 서울특별시
-            const city = parts[1]; // 강남구
-            const district = ""; // 빈 문자열
-            const detail = parts.slice(2).join(" ") + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 테헤란로 123 21
-
-            console.log("업데이트 파싱 결과 (3개):", { region, city, district, detail }); // 디버깅용
-
-            return {
-              city,
-              district,
-              detail,
-              region: this.mapRegionToEnum(region),
-            };
-          } else if (parts.length === 2) {
-            // "강원특별자치도 홍천군" 형태 - city에 다 넣지 말고 detail에 넣기
-            const region = parts[0]; // 강원특별자치도
-            const city = ""; // 빈 문자열로 설정
-            const detail = parts[1] + (addressObj.detailAddress ? ` ${addressObj.detailAddress}` : ""); // 홍천군 1
-
-            console.log("업데이트 파싱 결과 (2개):", { region, city, district: "", detail }); // 디버깅용
-
-            return {
-              city,
-              district: "",
-              detail,
-              region: this.mapRegionToEnum(region),
-            };
-          }
-        }
-
-        // 매핑되지 않는 경우 기본값
-        console.log("업데이트 매핑되지 않는 주소 형태, 기본값 사용");
-        return {
-          city: roadAddress,
-          district: "",
-          detail: addressObj.detailAddress || "",
-          region: "SEOUL" as any,
-        };
-      };
-
-      // 출발지 주소 업데이트
       if (updateData.departure) {
-        const fromAddressData = parseAddress(updateData.departure);
-        const fromAddress = await estimateRequestRepository.findOrCreateAddress(fromAddressData);
-        updatePayload.fromAddressId = fromAddress.id;
+        addressPromises.push(this.processAddress(updateData.departure));
+      }
+      if (updateData.arrival) {
+        addressPromises.push(this.processAddress(updateData.arrival));
       }
 
-      // 도착지 주소 업데이트
-      if (updateData.arrival) {
-        const toAddressData = parseAddress(updateData.arrival);
-        const toAddress = await estimateRequestRepository.findOrCreateAddress(toAddressData);
-        updatePayload.toAddressId = toAddress.id;
+      const processedAddresses = await Promise.all(addressPromises);
+
+      if (updateData.departure) {
+        updatePayload.fromAddressId = processedAddresses[0].id;
       }
+      if (updateData.arrival) {
+        updatePayload.toAddressId = processedAddresses[updateData.departure ? 1 : 0].id;
+      }
+
+      const updatedRequest = await estimateRequestRepository.updateEstimateRequest(id, updatePayload);
+
+      const deletePromises: Promise<void>[] = [];
+
+      if (updateData.departure && oldFromAddressId) {
+        deletePromises.push(estimateRequestRepository.softDeleteAddress(oldFromAddressId));
+      }
+      if (updateData.arrival && oldToAddressId) {
+        deletePromises.push(estimateRequestRepository.softDeleteAddress(oldToAddressId));
+      }
+
+      await Promise.all(deletePromises);
+
+      return updatedRequest;
     }
 
     return await estimateRequestRepository.updateEstimateRequest(id, updatePayload);
   }
 
-  async cancelActiveEstimateRequest(id: string) {
+  async cancelActiveEstimateRequest(id: string): Promise<EstimateRequest> {
     return await estimateRequestRepository.cancelEstimateRequest(id);
-  }
-
-  // 한국 지역명을 enum으로 매핑
-  private mapRegionToEnum(region: string): string {
-    console.log("매핑할 지역명:", region); // 디버깅용
-
-    const regionMap: { [key: string]: string } = {
-      // 한국어 지역명
-      서울특별시: "SEOUL",
-      서울: "SEOUL",
-      부산광역시: "BUSAN",
-      부산: "BUSAN",
-      대구광역시: "DAEGU",
-      대구: "DAEGU",
-      인천광역시: "INCHEON",
-      인천: "INCHEON",
-      광주광역시: "GWANGJU",
-      광주: "GWANGJU",
-      대전광역시: "DAEJEON",
-      대전: "DAEJEON",
-      울산광역시: "ULSAN",
-      울산: "ULSAN",
-      세종특별자치시: "SEJONG",
-      세종: "SEJONG",
-      경기도: "GYEONGGI",
-      경기: "GYEONGGI",
-      강원도: "GANGWON",
-      강원: "GANGWON",
-      강원특별자치도: "GANGWON",
-      충청북도: "CHUNGBUK",
-      충북: "CHUNGBUK",
-      충청남도: "CHUNGNAM",
-      충남: "CHUNGNAM",
-      전라북도: "JEONBUK",
-      전북: "JEONBUK",
-      전라남도: "JEONNAM",
-      전남: "JEONNAM",
-      경상북도: "GYEONGBUK",
-      경북: "GYEONGBUK",
-      경상남도: "GYEONGNAM",
-      경남: "GYEONGNAM",
-      제주특별자치도: "JEJU",
-      제주: "JEJU",
-
-      // 영어 지역명 (카카오 주소 API에서 오는 경우)
-      SEOUL: "SEOUL",
-      BUSAN: "BUSAN",
-      DAEGU: "DAEGU",
-      INCHEON: "INCHEON",
-      GWANGJU: "GWANGJU",
-      DAEJEON: "DAEJEON",
-      ULSAN: "ULSAN",
-      SEJONG: "SEJONG",
-      GYEONGGI: "GYEONGGI",
-      GANGWON: "GANGWON",
-      CHUNGBUK: "CHUNGBUK",
-      CHUNGNAM: "CHUNGNAM",
-      JEONBUK: "JEONBUK",
-      JEONNAM: "JEONNAM",
-      GYEONGBUK: "GYEONGBUK",
-      GYEONGNAM: "GYEONGNAM",
-      JEJU: "JEJU",
-    };
-
-    const mappedRegion = regionMap[region];
-    if (!mappedRegion) {
-      console.warn(`매핑되지 않은 지역명: "${region}", 기본값 SEOUL 사용`);
-    } else {
-      console.log(`지역명 매핑: "${region}" -> "${mappedRegion}"`);
-    }
-
-    return mappedRegion || "SEOUL";
   }
 }
 

--- a/src/types/estimateRequest.types.ts
+++ b/src/types/estimateRequest.types.ts
@@ -1,40 +1,137 @@
+// 주소 정보 인터페이스 (API 요청용)
+export interface IAddressInfo {
+  roadAddress: string; // 도로명주소 (예: "서울특별시 강남구 테헤란로 123")
+  detailAddress?: string; // 상세주소 (예: "456호")
+  postalCode?: string; // 우편번호 (예: "06123")
+  zonecode?: string; // 우편번호 (카카오 API 응답용)
+  jibunAddress?: string; // 지번주소 (예: "서울특별시 강남구 역삼동 123-45")
+  extraAddress?: string; // 참고항목 (예: "역삼동")
+}
+
+// 견적 요청 생성 타입
 export type TCreateEstimateRequest = {
   userId: string;
   movingType: string;
   movingDate: string;
-  departure: {
-    roadAddress: string;
-    detailAddress?: string;
-    zonecode: string;
-    jibunAddress: string;
-    extraAddress: string;
-  };
-  arrival: {
-    roadAddress: string;
-    detailAddress?: string;
-    zonecode: string;
-    jibunAddress: string;
-    extraAddress: string;
-  };
+  departure: IAddressInfo;
+  arrival: IAddressInfo;
   description?: string;
 };
 
+// 견적 요청 수정 타입
 export type TUpdateEstimateRequest = {
   movingType?: string;
   movingDate?: string;
-  departure?: {
-    roadAddress: string;
-    detailAddress?: string;
-    zonecode: string;
-    jibunAddress: string;
-    extraAddress: string;
-  };
-  arrival?: {
-    roadAddress: string;
-    detailAddress?: string;
-    zonecode: string;
-    jibunAddress: string;
-    extraAddress: string;
-  };
+  departure?: IAddressInfo;
+  arrival?: IAddressInfo;
   description?: string;
 };
+
+// 파싱된 주소 데이터 (내부 처리용)
+export interface IParsedAddressData {
+  postalCode: string; // 우편번호
+  region: string; // 1단계: 광역시/도 (예: "서울특별시", "경기도")
+  city: string; // 2단계: 시/군/구 (예: "강남구", "수원시", "창원시")
+  district: string; // 3단계: 동/읍/면 (예: "역삼동", "삼척읍", "정자동")
+  detail: string | null; // 4단계: 상세주소 (예: "테헤란로 123", "옆집")
+}
+
+// 견적 요청 응답 인터페이스
+export interface IEstimateRequestResponse {
+  id: string;
+  userId: string;
+  movingType: string;
+  departureAddress: string;
+  arrivalAddress: string;
+  departureDetailAddress?: string;
+  arrivalDetailAddress?: string;
+  departurePostalCode?: string;
+  arrivalPostalCode?: string;
+  movingDate: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 데이터베이스 주소 인터페이스
+export interface IDatabaseAddress {
+  postalCode: string;
+  city: string;
+  district: string;
+  detail: string | null;
+  region: string;
+  deletedAt: Date | null;
+}
+
+// 데이터베이스 견적 요청 인터페이스
+export interface IDatabaseEstimateRequest {
+  id: string;
+  customerId: string;
+  moveType: string;
+  moveDate: Date;
+  fromAddressId: string;
+  toAddressId: string;
+  description: string | null;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date | null;
+  fromAddress?: IDatabaseAddress | null;
+  toAddress?: IDatabaseAddress | null;
+}
+
+// 견적 요청 생성 데이터 타입
+export type TCreateEstimateRequestData = {
+  moveType: string;
+  moveDate: string;
+  fromAddressId: string;
+  toAddressId: string;
+  description?: string;
+};
+
+// 견적 요청 수정 데이터 타입
+export type TUpdateEstimateRequestData = {
+  moveType?: string;
+  moveDate?: Date;
+  fromAddressId?: string;
+  toAddressId?: string;
+  description?: string;
+};
+
+// 사용자 타입 확인 결과 인터페이스
+export interface IUserTypeResult {
+  isCustomer: boolean;
+  isMover: boolean;
+}
+
+// 서비스에서 사용하는 타입들
+export interface IAddressInfoForService {
+  roadAddress: string;
+  detailAddress?: string;
+  postalCode?: string;
+  zonecode?: string;
+  jibunAddress?: string;
+  extraAddress?: string;
+}
+
+// 컨트롤러에서 사용하는 타입들
+export interface ICreateValidationData {
+  movingType: string;
+  movingDate: string;
+  departure: IAddressInfo;
+  arrival: IAddressInfo;
+  description?: string;
+}
+
+export interface IUpdateValidationData {
+  movingType?: string;
+  movingDate?: string;
+  departure?: IAddressInfo;
+  arrival?: IAddressInfo;
+  description?: string;
+}
+
+export interface IValidationResult {
+  isValid: boolean;
+  errors: string[];
+}

--- a/src/utils/addressUtils.ts
+++ b/src/utils/addressUtils.ts
@@ -1,0 +1,104 @@
+import { IParsedAddressData } from "../types/estimateRequest.types";
+
+// 지역명 매핑
+const REGION_MAP: { [key: string]: string } = {
+  서울특별시: "SEOUL",
+  서울: "SEOUL",
+  부산광역시: "BUSAN",
+  부산: "BUSAN",
+  대구광역시: "DAEGU",
+  대구: "DAEGU",
+  인천광역시: "INCHEON",
+  인천: "INCHEON",
+  광주광역시: "GWANGJU",
+  광주: "GWANGJU",
+  대전광역시: "DAEJEON",
+  대전: "DAEJEON",
+  울산광역시: "ULSAN",
+  울산: "ULSAN",
+  세종특별자치시: "SEJONG",
+  세종: "SEJONG",
+  경기도: "GYEONGGI",
+  경기: "GYEONGGI",
+  강원도: "GANGWON",
+  강원: "GANGWON",
+  충청북도: "CHUNGBUK",
+  충북: "CHUNGBUK",
+  충청남도: "CHUNGNAM",
+  충남: "CHUNGNAM",
+  전라북도: "JEONBUK",
+  전북: "JEONBUK",
+  전라남도: "JEONNAM",
+  전남: "JEONNAM",
+  경상북도: "GYEONGBUK",
+  경북: "GYEONGBUK",
+  경상남도: "GYEONGNAM",
+  경남: "GYEONGNAM",
+  제주특별자치도: "JEJU",
+  제주: "JEJU",
+};
+
+const ENGLISH_TO_KOREAN: { [key: string]: string } = {
+  SEOUL: "서울",
+  BUSAN: "부산",
+  DAEGU: "대구",
+  INCHEON: "인천",
+  GWANGJU: "광주",
+  DAEJEON: "대전",
+  ULSAN: "울산",
+  SEJONG: "세종",
+  GYEONGGI: "경기",
+  GANGWON: "강원",
+  CHUNGBUK: "충북",
+  CHUNGNAM: "충남",
+  JEONBUK: "전북",
+  JEONNAM: "전남",
+  GYEONGBUK: "경북",
+  GYEONGNAM: "경남",
+  JEJU: "제주",
+};
+
+/**
+ * 지역명을 enum으로 매핑
+ */
+const mapRegionToEnum = (region: string): string => {
+  return REGION_MAP[region] || "SEOUL";
+};
+
+/**
+ * 영어 지역명을 한글로 변환
+ */
+export const convertRegionToKorean = (englishRegion: string): string => {
+  return ENGLISH_TO_KOREAN[englishRegion] || englishRegion;
+};
+
+/**
+ * 주소를 파싱
+ */
+export const parseAddress = (addressObj: {
+  roadAddress: string;
+  detailAddress?: string;
+  postalCode?: string;
+  zonecode?: string;
+}): IParsedAddressData => {
+  const postalCode = addressObj.zonecode || addressObj.postalCode || "";
+  const addressParts = addressObj.roadAddress.split(" ");
+
+  if (addressParts.length < 3) {
+    throw new Error("올바른 주소 형식이 아닙니다.");
+  }
+
+  const [region, city, district, ...detailParts] = addressParts;
+
+  if (addressObj.detailAddress) {
+    detailParts.push(addressObj.detailAddress);
+  }
+
+  return {
+    postalCode,
+    region: mapRegionToEnum(region),
+    city,
+    district,
+    detail: detailParts.join(" ").trim() || null,
+  };
+};

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,11 +1,13 @@
+// 한국 시간대 상수
+const KOREA_TIMEZONE = "Asia/Seoul";
+
 /**
- * 한국 시간(KST) 기준으로 오늘 날짜의 시작(00:00:00)을 반환합니다.
- * @returns 한국 시간 기준 오늘 날짜의 시작
+ * 한국 시간 기준으로 오늘 날짜를 가져옵니다.
+ * @returns 한국 시간 기준 오늘 날짜 (시간은 00:00:00으로 설정)
  */
-export const getKoreaToday = (): Date => {
+const getKoreaToday = (): Date => {
   const today = new Date();
-  // 한국 시간(KST) 기준으로 오늘 날짜 계산
-  const koreaTime = new Date(today.toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+  const koreaTime = new Date(today.toLocaleString("en-US", { timeZone: KOREA_TIMEZONE }));
   koreaTime.setHours(0, 0, 0, 0);
   return koreaTime;
 };

--- a/src/utils/estimateRequestUtils.ts
+++ b/src/utils/estimateRequestUtils.ts
@@ -1,0 +1,204 @@
+import { IAddressInfo } from "../types/estimateRequest.types";
+import { isBeforeKoreaToday } from "./dateUtils";
+
+/**
+ * 주소 정보 검증 결과 인터페이스
+ */
+export interface IAddressValidationResult {
+  isValid: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * 날짜 검증 결과 인터페이스
+ */
+export interface IDateValidationResult {
+  isValid: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * 견적 요청 검증 결과 인터페이스
+ */
+export interface IEstimateRequestValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+/**
+ * 두 문자열을 안전하게 비교합니다.
+ * @param a 첫 번째 문자열
+ * @param b 두 번째 문자열
+ * @returns 동일하면 true, 아니면 false
+ */
+const safeStringEquals = (a: string | undefined, b: string | undefined): boolean => {
+  return (a || "").toString().trim() === (b || "").toString().trim();
+};
+
+/**
+ * 이사일이 유효한지 검증합니다.
+ * @param movingDate 이사일 (YYYY-MM-DD 형식)
+ * @returns 검증 결과
+ */
+export const validateMovingDate = (movingDate: string): IDateValidationResult => {
+  try {
+    const moveDate = new Date(movingDate);
+
+    if (isNaN(moveDate.getTime())) {
+      return {
+        isValid: false,
+        errorMessage: "올바른 날짜 형식이 아닙니다. (YYYY-MM-DD 형식으로 입력해주세요)",
+      };
+    }
+
+    if (isBeforeKoreaToday(moveDate)) {
+      return {
+        isValid: false,
+        errorMessage: "이사일은 오늘 이후로 설정해주세요.",
+      };
+    }
+
+    return { isValid: true };
+  } catch (error) {
+    return {
+      isValid: false,
+      errorMessage: "날짜 검증 중 오류가 발생했습니다.",
+    };
+  }
+};
+
+/**
+ * 출발지와 도착지 주소가 동일한지 검증합니다.
+ * @param departure 출발지 주소
+ * @param arrival 도착지 주소
+ * @returns 검증 결과
+ */
+export const validateAddresses = (departure: IAddressInfo, arrival: IAddressInfo): IAddressValidationResult => {
+  const isSameRoadAddress = safeStringEquals(departure?.roadAddress, arrival?.roadAddress);
+  const isSameDetailAddress = safeStringEquals(departure?.detailAddress, arrival?.detailAddress);
+
+  if (isSameRoadAddress && isSameDetailAddress) {
+    return {
+      isValid: false,
+      errorMessage: "출발지와 도착지는 달라야 합니다.",
+    };
+  }
+
+  return { isValid: true };
+};
+
+/**
+ * 견적 요청 생성 데이터를 검증합니다.
+ * @param data 견적 요청 데이터
+ * @returns 검증 결과
+ */
+export const validateCreateEstimateRequest = (data: {
+  movingType: string;
+  movingDate: string;
+  departure: IAddressInfo;
+  arrival: IAddressInfo;
+  description?: string;
+}): IEstimateRequestValidationResult => {
+  const errors: string[] = [];
+
+  // 이사 종류 검증
+  if (!data.movingType || !["small", "home", "office"].includes(data.movingType.toLowerCase())) {
+    errors.push("이사 종류는 small, home, office 중 하나여야 합니다.");
+  }
+
+  // 이사일 검증
+  const dateValidation = validateMovingDate(data.movingDate);
+  if (!dateValidation.isValid) {
+    errors.push(dateValidation.errorMessage!);
+  }
+
+  // 주소 검증
+  const addressValidation = validateAddresses(data.departure, data.arrival);
+  if (!addressValidation.isValid) {
+    errors.push(addressValidation.errorMessage!);
+  }
+
+  // 출발지 주소 검증
+  if (!data.departure?.roadAddress?.trim()) {
+    errors.push("출발지 주소는 필수입니다.");
+  }
+
+  // 도착지 주소 검증
+  if (!data.arrival?.roadAddress?.trim()) {
+    errors.push("도착지 주소는 필수입니다.");
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * 견적 요청 수정 데이터를 검증합니다.
+ * @param data 견적 요청 수정 데이터
+ * @returns 검증 결과
+ */
+export const validateUpdateEstimateRequest = (data: {
+  movingType?: string;
+  movingDate?: string;
+  departure?: IAddressInfo;
+  arrival?: IAddressInfo;
+  description?: string;
+}): IEstimateRequestValidationResult => {
+  const errors: string[] = [];
+
+  // 이사 종류 검증 (제공된 경우에만)
+  if (data.movingType && !["small", "home", "office"].includes(data.movingType.toLowerCase())) {
+    errors.push("이사 종류는 small, home, office 중 하나여야 합니다.");
+  }
+
+  // 이사일 검증 (제공된 경우에만)
+  if (data.movingDate) {
+    const dateValidation = validateMovingDate(data.movingDate);
+    if (!dateValidation.isValid) {
+      errors.push(dateValidation.errorMessage!);
+    }
+  }
+
+  // 주소 검증 (둘 다 제공된 경우에만)
+  if (data.departure && data.arrival) {
+    const addressValidation = validateAddresses(data.departure, data.arrival);
+    if (!addressValidation.isValid) {
+      errors.push(addressValidation.errorMessage!);
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * 사용자 ID가 유효한지 검증합니다.
+ * @param userId 사용자 ID
+ * @returns 검증 결과
+ */
+export const validateUserId = (userId: string): boolean => {
+  return !!userId && typeof userId === "string" && userId.trim().length > 0;
+};
+
+/**
+ * 견적 요청 상태가 수정 가능한지 확인합니다.
+ * @param status 현재 견적 요청 상태
+ * @returns 수정 가능하면 true, 아니면 false
+ */
+export const isStatusModifiable = (status: string): boolean => {
+  return status === "PENDING";
+};
+
+/**
+ * 견적 요청 상태가 취소 가능한지 확인합니다.
+ * @param status 현재 견적 요청 상태
+ * @param hasEstimateFromMover 기사님이 견적을 제출했는지 여부
+ * @returns 취소 가능하면 true, 아니면 false
+ */
+export const isStatusCancellable = (status: string, hasEstimateFromMover: boolean): boolean => {
+  return status === "PENDING" && !hasEstimateFromMover;
+};

--- a/src/utils/swagger-auto.ts
+++ b/src/utils/swagger-auto.ts
@@ -4,28 +4,138 @@ import { Express } from "express";
 const swaggerOptions = {
   info: {
     version: "1.0.0",
-    title: "Moving API",
-    description: "Moving 프로젝트 백엔드 API 문서 (자동 생성)",
+    title: "Moving Backend API",
+    description: `
+      무빙. 이삿짐 서비스의 백엔드 API 서버입니다.
+      
+      ## 주요 기능
+      - **견적 요청 관리**: 생성, 조회, 수정, 취소
+      - **견적 제출**: 기사님이 고객에게 견적 제출
+      - **사용자 관리**: 회원가입, 로그인, 프로필 관리
+      - **기사님 관리**: 기사님 정보 조회, 찜하기 기능
+      - **알림 시스템**: 실시간 SSE 알림 및 푸시 알림
+      - **리뷰 시스템**: 이사 완료 후 리뷰 작성
+      - **권한 관리**: 고객/기사님 역할 기반 접근 제어
+
+      ## 인증
+      모든 API는 JWT 토큰 인증이 필요합니다.
+      Authorization 헤더에 Bearer 토큰을 포함하여 요청하세요.
+      
+      ### 토큰 관리
+      - 액세스 토큰: API 요청 시 사용 (짧은 유효기간)
+      - 리프레시 토큰: 액세스 토큰 갱신용 (긴 유효기간)
+      - HTTP-only 쿠키로 자동 관리
+
+      ## API 그룹별 설명
+
+      ### 🔐 인증 API (Auth)
+      - 회원가입, 로그인, 로그아웃
+      - 소셜 로그인 (구글, 카카오, 네이버)
+      - 토큰 갱신
+
+      ### 👤 사용자 API (User)
+      - 사용자 정보 조회 및 수정
+      - 프로필 관리 (일반 고객/기사님)
+      - 이미지 업로드 (Presigned URL)
+
+      ### 📋 견적 요청 API (EstimateRequest)
+      - 견적 요청 생성, 조회, 수정, 취소
+      - 주소 자동 파싱 및 데이터베이스 저장
+      - Soft Delete를 통한 데이터 보존
+
+      ### 💰 견적 제출 API (MoverEstimate)
+      - 기사님이 고객에게 견적 제출
+      - 지역별/지정 견적 조회
+      - 견적 상태 관리 및 업데이트
+
+      ### 🚛 기사님 API (Mover)
+      - 기사님 목록 조회 및 상세 정보
+      - 찜한 기사님 관리
+      - 지정 견적 요청
+
+      ### ❤️ 찜하기 API (Favorites)
+      - 기사님 찜하기 추가/제거
+      - 찜하기 상태 확인
+
+      ### 📢 알림 API (Notification)
+      - 실시간 SSE 알림 구독
+      - 알림 목록 조회 및 읽음 처리
+      - 전체 알림 읽음 처리
+
+      ### ⭐ 리뷰 API (Review)
+      - 이사 완료 후 리뷰 작성
+      - 리뷰 작성 가능한 견적 요청 조회
+      - 내가 쓴/받은 리뷰 목록
+
+      ### 📊 고객 견적 API (UserQuote)
+      - 진행중/완료된 견적 요청 조회
+      - 견적 상세 정보 확인
+      - 견적 확정 및 지정 견적 요청
+
+      ## 공통 기능
+
+      ### 주소 처리
+      - 프론트엔드에서 전송하는 zonecode는 자동으로 postalCode로 변환
+      - roadAddress에서 지역명, 시/군/구, 동/읍/면을 자동 추출
+      - 지역명은 영어 enum으로 변환 (예: "부산" → "BUSAN")
+      - API 응답에서는 지역명이 한글로 표시 (예: "BUSAN" → "부산")
+
+      ### 데이터 처리
+      - 주소 수정 시 기존 주소는 soft delete되고 새 주소가 생성
+      - 견적 요청 취소 시 관련 데이터들이 soft delete
+      - deletedAt 필드에는 날짜만 기록 (시간 제외)
+
+      ### 권한 관리
+      - **일반 고객**: 견적 요청 생성/조회/수정/취소, 기사님 조회, 찜하기, 리뷰 작성
+      - **기사님**: 견적 제출, 고객 견적 요청 조회, 프로필 관리
+      - **관리자**: 모든 기능 접근 가능
+
+      ### 에러 처리
+      - 일관된 에러 응답 형식
+      - 적절한 HTTP 상태 코드 사용
+      - 명확한 에러 메시지 제공
+
+      ### 보안
+      - JWT 토큰 기반 인증
+      - CORS 설정으로 허용된 도메인만 접근
+      - 입력값 검증 및 sanitization
+      `,
+    contact: {
+      name: "API Support",
+      email: "support@moving.com",
+    },
     license: {
-      name: "MIT",
+      name: "FS6기 1팀 ",
+      url: "https://github.com/WooGie911/Moving_BE",
     },
   },
+  servers: [
+    {
+      url: "http://localhost:5050",
+      description: "Development server",
+    },
+    {
+      url: "https://api.moving.com",
+      description: "Production server",
+    },
+  ],
   security: {
     BearerAuth: {
       type: "http",
       scheme: "bearer",
       bearerFormat: "JWT",
+      description: "JWT 토큰을 Bearer 형식으로 전송",
     },
   },
   baseDir: __dirname + "/../", // src 디렉토리
-  // 스캔할 파일들
+  // 스캔할 파일들 - 절대 경로로 수정
   filesPattern: [
-    "./routes/**/*.ts",
-    "./routes/**/*.js",
-    "./controllers/**/*.ts",
-    "./controllers/**/*.js",
-    "./app.ts",
-    "./app.js",
+    __dirname + "/../routes/**/*.ts",
+    __dirname + "/../routes/**/*.js",
+    __dirname + "/../controllers/**/*.ts",
+    __dirname + "/../controllers/**/*.js",
+    __dirname + "/../app.ts",
+    __dirname + "/../app.js",
   ],
   // Swagger UI 설정
   swaggerUIPath: "/api-docs",
@@ -35,6 +145,54 @@ const swaggerOptions = {
   exposeSwaggerUI: true,
   exposeApiDocs: true,
   apiDocsPath: "/api-docs.json",
+  // 태그 정의
+  tags: [
+    {
+      name: "EstimateRequest",
+      description: "견적 요청 관련 API - 고객이 이사 견적을 요청하고 관리하는 API",
+    },
+    {
+      name: "Auth",
+      description: "인증 관련 API - 회원가입, 로그인, 소셜 로그인, 토큰 관리",
+    },
+    {
+      name: "User",
+      description: "사용자 관련 API - 사용자 정보 조회, 프로필 관리, 이미지 업로드",
+    },
+    {
+      name: "Mover",
+      description: "기사님 관련 API - 기사님 목록 조회, 상세 정보, 지정 견적 요청",
+    },
+    {
+      name: "MoverEstimate",
+      description: "견적 제출 관련 API - 기사님이 고객에게 견적을 제출하고 관리하는 API",
+    },
+    {
+      name: "Favorites",
+      description: "찜하기 관련 API - 기사님 찜하기 추가/제거, 상태 확인",
+    },
+    {
+      name: "Notification",
+      description: "알림 관련 API - 실시간 SSE 알림, 알림 목록 조회 및 읽음 처리",
+    },
+    {
+      name: "Review",
+      description: "리뷰 관련 API - 이사 완료 후 리뷰 작성, 리뷰 목록 조회",
+    },
+    {
+      name: "UserQuote",
+      description: "고객 견적 관련 API - 진행중/완료된 견적 요청 조회, 견적 확정",
+    },
+    {
+      name: "Health",
+      description: "서버 상태 확인 API - 서버 상태 및 헬스 체크",
+    },
+  ],
+  // 외부 문서 링크
+  externalDocs: {
+    description: "협업 노션",
+    url: "https://www.notion.so/Part4-Team1-Moving-2155da6dc98c80fa89c2f08319b1ef83",
+  },
 };
 
 export const setupAutoSwagger = (app: Express) => {


### PR DESCRIPTION
## ✨ 작업 개요

-견적 요청 리팩토링 

## ✅ 주요 작업 내용
- 백엔드 프론트엔드 데이터 구조 일치하도록 수정
- 주소 파싱 로직 제작
- patch에서 기존 주소 삭제 후 새로 주소 넣도록 변경
- 코드 가독성 증가
- 중복 제거

## 🔄 관련 이슈

Closes #146

## 📎 참고 자료 (선택)

- API 명세서: swagger 참고

## 🧪 테스트 방법 (선택)
<img width="1596" height="184" alt="image" src="https://github.com/user-attachments/assets/b2d86034-4322-43b2-b1e3-efc89b099ce9" />


## 📝 비고
- 정상적으로 원하는데로 이제 db에 들어감
- 프론트 카카오 api에서는 우편번호를 zoneCode로 나오지만 스키마 필드는 postalCode로 매핑하는 로직이 있음 두 개를 맞추면 불필요한 로직을 줄일 수 있을 듯 -> 카카오는 건들 수 없으니 필드 네이밍 수정이 필요할듯..
- region만 왜 영어로 들어가야 하는가.. 
-