### PR TITLE
Feat:기사님 리뷰 통계 API 엔드포인트 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,7 @@
 import dotenv from "dotenv";
+// 환경변수 로드 (가장 먼저 실행)
+dotenv.config();
+
 import express from "express";
 import cors from "cors";
 import { errorHandler, notFoundHandler } from "./middlewares/errorMiddleware";
@@ -11,9 +14,6 @@ import authIndexRoutes from "./routes/authIndex.routes";
 import notificationIndexRoutes from "./routes/notificationIndex.routes";
 import businessRoutes from "./routes/index.routes";
 import passport from "./config/passport";
-
-// 환경변수 로드
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 5050;

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -94,7 +94,7 @@ const reviewController = {
         return;
       }
       const page = Number(req.query.page) || 1;
-      const pageSize = Number(req.query.pageSize) || 5;
+      const pageSize = Number(req.query.pageSize) || 10;
 
       const reviews = await reviewService.getReceivedReviews(moverId, {
         page,
@@ -105,6 +105,31 @@ const reviewController = {
         success: true,
         message: "기사님 리뷰 목록입니다.",
         data: reviews,
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  // 5. 기사님 리뷰 통계 조회
+  getMoverReviewStats: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    try {
+      const moverId = req.params.moverId;
+      if (!moverId) {
+        res.status(400).json({ message: "기사님 ID가 필요합니다." });
+        return;
+      }
+
+      const stats = await reviewService.getMoverReviewStats(moverId);
+
+      res.json({
+        success: true,
+        message: "기사님 리뷰 통계입니다.",
+        data: stats,
       });
     } catch (error) {
       next(error);

--- a/src/repositories/review.repository.ts
+++ b/src/repositories/review.repository.ts
@@ -138,6 +138,44 @@ const reviewRepository = {
 
     return { items, total, page, pageSize };
   },
+
+  // 5. 기사님 리뷰 통계 조회
+  getMoverReviewStats: async (moverId: string) => {
+    // 모든 리뷰 조회
+    const reviews = await prisma.review.findMany({
+      where: {
+        moverId,
+        deletedAt: null,
+      },
+      select: {
+        rating: true,
+      },
+    });
+
+    if (reviews.length === 0) {
+      return {
+        averageRating: 0,
+        totalReviewCount: 0,
+        ratingDistribution: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+      };
+    }
+
+    // 평균 평점 계산
+    const totalRating = reviews.reduce((sum, review) => sum + review.rating, 0);
+    const averageRating = totalRating / reviews.length;
+
+    // 평점 분포 계산
+    const ratingDistribution = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+    reviews.forEach((review) => {
+      ratingDistribution[review.rating as keyof typeof ratingDistribution]++;
+    });
+
+    return {
+      averageRating,
+      totalReviewCount: reviews.length,
+      ratingDistribution,
+    };
+  },
 };
 
 export default reviewRepository;

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -70,6 +70,7 @@ const getMoverProfile = async (userId: string) => {
   const profile = await prisma.user.findUnique({
     where: { id: userId },
     select: {
+      id: true,
       name: true,
       nickname: true,
       moverImage: true,

--- a/src/routes/review.route.ts
+++ b/src/routes/review.route.ts
@@ -197,4 +197,30 @@ reviewRouter.get(
  */
 reviewRouter.get("/mover/:moverId", reviewController.getReceivedReviews);
 
+/**
+ * GET /reviews/mover/:moverId/stats
+ * @summary 기사님 리뷰 통계 조회
+ * @description 기사님이 받은 모든 리뷰의 평균 평점과 평점 분포를 조회합니다.
+ * @tags Review
+ * @param {string} moverId.path.required - 기사님 ID
+ * @returns {object} 200 - 기사님 리뷰 통계 조회 성공
+ * @example response - 200 - 성공 예시
+ * {
+ *   "success": true,
+ *   "message": "기사님 리뷰 통계입니다.",
+ *   "data": {
+ *     "averageRating": 4.2,
+ *     "totalReviewCount": 145,
+ *     "ratingDistribution": {
+ *       "5": 80,
+ *       "4": 45,
+ *       "3": 15,
+ *       "2": 3,
+ *       "1": 2
+ *     }
+ *   }
+ * }
+ */
+reviewRouter.get("/mover/:moverId/stats", reviewController.getMoverReviewStats);
+
 export default reviewRouter;

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -113,6 +113,10 @@ const reviewService = {
 
     return { items: mappedItems, total, page, pageSize };
   },
+
+  getMoverReviewStats: async (moverId: string) => {
+    return reviewRepository.getMoverReviewStats(moverId);
+  },
 };
 
 export default reviewService;


### PR DESCRIPTION
## ✨ 작업 개요

- 기사님 마이페이지의 리뷰 통계를 위한 새로운 API 엔드포인트 구현
- 기존 리뷰 목록 API와 별도로 전체 리뷰의 평균 평점과 분포도를 계산하는 통계 API 추가

## ✅ 주요 작업 내용

- GET /reviews/mover/:moverId/stats 엔드포인트 구현
- 기사님이 받은 모든 리뷰의 통계 정보 제공
- getMoverReviewStats 컨트롤러 함수 추가
- 

## 🔄 관련 이슈

Closes #160

## 📎 참고 자료 (선택)

- API 명세서: [링크]

## 🧪 테스트 방법 (선택)

- [ ] GET /reviews/mover/{moverId}/stats API 호출 시 정상 응답 확인
- [ ]  프론트엔드에서 API 연동 테스트

## 📝 비고

- (추가 예정 기능, 보완 필요 등)
