### PR TITLE
[#168] test : auth.service 유닛 테스트 작성

### DIFF
--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -1,20 +1,29 @@
 import bcrypt from "bcrypt";
 import authRepository from "../repositories/auth.repository";
-import { generateToken } from "../utils/generateToken";
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  generateToken,
+} from "../utils/generateToken";
 import authService from "./auth.service";
 import {
   AuthenticationError,
   DatabaseError,
+  NotFoundError,
   ServerError,
   ValidationError,
 } from "../types/commonError.types";
 import { TUserRole } from "../types/user.types";
 import { validateUserSignupInput } from "../utils/validators/userValidator";
+import * as authUtils from "../utils/authUtils";
 
 jest.mock("../repositories/auth.repository");
 jest.mock("bcrypt");
 jest.mock("../utils/generateToken");
 jest.mock("../utils/validators/userValidator");
+jest.mock("../utils/authUtils", () => ({
+  mergeUserTypes: jest.fn(),
+}));
 
 describe("authService.signup", () => {
   // Teardown
@@ -514,5 +523,244 @@ describe("authService.signin", () => {
     await expect(
       authService.signin("test@test.com", "1rhdiddl!", "CUSTOMER")
     ).rejects.toThrow(ServerError);
+  });
+});
+
+describe("authService.logout", () => {
+  // Teardown
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("로그아웃 성공", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      email: "test@test.com",
+      encryptedPassword: "$2b$10$hashedpassword",
+      customerImage: "https://cdn.com/image.png",
+      moverImage: null,
+      isCustomer: true,
+      isMover: false,
+      refreshToken: "mockRefreshToken",
+    };
+
+    const mockFindUserById = authRepository.findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue(mockUser);
+
+    // Exercise
+    const result = await authService.logout(mockUser.id.toString());
+
+    // Assertion
+    expect(result).toBeUndefined();
+    expect(mockFindUserById).toHaveBeenCalledWith(mockUser.id.toString());
+  });
+
+  test("로그아웃 실패 - 존재하지 않는 유저 라면 NotFoundError(404) 발생", async () => {
+    // Setup
+    const mockFindUserById = authRepository.findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue(null);
+
+    // Exercise
+    await expect(authService.logout("1")).rejects.toThrow(NotFoundError);
+  });
+
+  test("로그아웃 실패 - 이미 로그아웃된 유저 라면 AuthenticationError(401) 발생", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      email: "test@test.com",
+      encryptedPassword: "$2b$10$hashedpassword",
+      customerImage: "https://cdn.com/image.png",
+      moverImage: null,
+      isCustomer: true,
+      isMover: false,
+      refreshToken: null,
+    };
+
+    const mockFindUserById = authRepository.findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue(mockUser);
+
+    // Exercise
+    await expect(authService.logout("1")).rejects.toThrow(AuthenticationError);
+  });
+});
+
+describe("authService.refresh", () => {
+  // Teardown
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("토큰 갱신 성공 - refreshToken 재발급 없이 accessToken만 반환", async () => {
+    // Setup
+    const mockDecodedToken = {
+      userId: "1",
+      userType: "CUSTOMER" as TUserRole,
+      exp: Math.floor(Date.now() / 1000) + 6 * 24 * 60 * 60, // 만료까지 6일 → 재발급 안됨
+    };
+
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER"],
+      isCustomer: true,
+    };
+
+    const mockFindUserById = authRepository.findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue(mockUser);
+
+    const mockGenerateAccessToken = generateAccessToken as jest.Mock;
+    mockGenerateAccessToken.mockReturnValue("mockAccessToken");
+
+    // Exercise
+    const result = await authService.refresh(mockDecodedToken);
+
+    // Assertion
+    expect(result).toMatchObject({
+      accessToken: "mockAccessToken",
+      refreshToken: undefined,
+    });
+  });
+
+  test("토큰 갱신 성공 - refreshToken 만료 임박 시 둘 다 재발급", async () => {
+    // Setup
+    const mockDecodedToken = {
+      userId: "1",
+      userType: "CUSTOMER" as TUserRole,
+      exp: Math.floor(Date.now() / 1000) + 2 * 24 * 60 * 60, // 만료까지 2일 → 재발급 조건 충족
+    };
+
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER"],
+      isCustomer: true,
+    };
+
+    const mockFindUserById = authRepository.findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue(mockUser);
+
+    const mockGenerateAccessToken = generateAccessToken as jest.Mock;
+    mockGenerateAccessToken.mockReturnValue("mockAccessToken");
+
+    const mockGenerateRefreshToken = generateRefreshToken as jest.Mock;
+    mockGenerateRefreshToken.mockReturnValue("mockRefreshToken");
+
+    const mockUpdateUserToken = authRepository.updateUserToken as jest.Mock;
+    mockUpdateUserToken.mockResolvedValue(undefined);
+
+    // Exercise
+    const result = await authService.refresh(mockDecodedToken);
+
+    // Assertion
+    expect(result).toMatchObject({
+      accessToken: "mockAccessToken",
+      refreshToken: "mockRefreshToken",
+    });
+  });
+});
+
+describe("authService.oauthCrateOrUpdate", () => {
+  // Teardown
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("기존 소셜 유저가 있는 경우 - 업데이트 후 토큰 반환", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER"],
+      nickname: "길동이",
+      provider: "GOOGLE",
+      isCustomer: true,
+      isMover: false,
+    };
+
+    const mockUpdatedUser = {
+      ...mockUser,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+    };
+
+    // 기존 유저가 있는 경우
+    (authRepository.findUserByEmail as jest.Mock).mockResolvedValue(mockUser);
+    (authUtils.mergeUserTypes as jest.Mock).mockReturnValue([
+      "CUSTOMER",
+      "MOVER",
+    ]);
+    (authRepository.updateUser as jest.Mock).mockResolvedValue(mockUpdatedUser);
+    (generateToken as jest.Mock).mockReturnValue({
+      newAccessToken: "access_token",
+      newRefreshToken: "refresh_token",
+    });
+    (authRepository.updateUserToken as jest.Mock).mockResolvedValue(undefined);
+
+    // Exercise
+    const result = await authService.oauthCrateOrUpdate(
+      "GOOGLE",
+      "provider-id-123",
+      "test@example.com",
+      "홍길동",
+      "MOVER"
+    );
+
+    // Assert
+    expect(result).toMatchObject({
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      nickname: "길동이",
+      provider: "GOOGLE",
+      accessToken: "access_token",
+      refreshToken: "refresh_token",
+    });
+  });
+
+  test("기존 소셜 유저가 없는 경우 - 생성 후 토큰 반환", async () => {
+    // Setup
+    const mockCreatedUser = {
+      id: 2,
+      name: "이몽룡",
+      userType: ["CUSTOMER"],
+      nickname: "몽룡",
+      provider: "NAVER",
+    };
+
+    // 기존 유저가 null인 경우
+    (authRepository.findUserByEmail as jest.Mock).mockResolvedValue(null);
+    (authRepository.createSocialUser as jest.Mock).mockResolvedValue(
+      mockCreatedUser
+    );
+    (generateToken as jest.Mock).mockReturnValue({
+      newAccessToken: "access_token",
+      newRefreshToken: "refresh_token",
+    });
+
+    // Exercise
+    const result = await authService.oauthCrateOrUpdate(
+      "NAVER",
+      "provider-id-456",
+      "lee@example.com",
+      "이몽룡",
+      "CUSTOMER"
+    );
+
+    // Assert
+    expect(result).toMatchObject({
+      id: 2,
+      name: "이몽룡",
+      userType: ["CUSTOMER"],
+      nickname: "몽룡",
+      provider: "NAVER",
+      accessToken: "access_token",
+      refreshToken: "refresh_token",
+    });
   });
 });

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -1,0 +1,518 @@
+import bcrypt from "bcrypt";
+import authRepository from "../repositories/auth.repository";
+import { generateToken } from "../utils/generateToken";
+import authService from "./auth.service";
+import {
+  AuthenticationError,
+  DatabaseError,
+  ServerError,
+  ValidationError,
+} from "../types/commonError.types";
+import { TUserRole } from "../types/user.types";
+import { validateUserSignupInput } from "../utils/validators/userValidator";
+
+jest.mock("../repositories/auth.repository");
+jest.mock("bcrypt");
+jest.mock("../utils/generateToken");
+jest.mock("../utils/validators/userValidator");
+
+describe("authService.signup", () => {
+  // Teardown
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("CUSTOMER 회원가입 성공", async () => {
+    // Setup
+    // DB createUser 반환값 테스트용 객체
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      nickname: "홍길동",
+    };
+
+    // Exercise 테스트용 유저 객체 생성
+    const testUser = {
+      name: "홍길동",
+      email: "test@test.com",
+      phoneNumber: "01012345678",
+      password: "1rhdiddl!",
+      userType: "CUSTOMER" as TUserRole,
+    };
+
+    // email 중복 체크 로직 모킹
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null);
+
+    // 비밀번호 암호화 로직 모킹
+    const mockHash = bcrypt.hash as jest.Mock;
+    mockHash.mockResolvedValue("$2b$10$hashedpassword");
+
+    // 유저 생성 로직 모킹
+    const mockCreateUser = authRepository.createUser as jest.Mock;
+    mockCreateUser.mockResolvedValue(mockUser);
+
+    // 토큰 생성용 로직 모킹
+    const mockGenerateToken = generateToken as jest.Mock;
+    mockGenerateToken.mockReturnValue({
+      newAccessToken: "mockAccessToken",
+      newRefreshToken: "mockRefreshToken",
+    });
+
+    // Exercise
+    const result = await authService.signup(testUser);
+
+    // Assertion
+
+    // 회원가입 반환값 검사
+    expect(result).toMatchObject({
+      id: mockUser.id,
+      userName: testUser.name,
+      userType: "CUSTOMER",
+      accessToken: "mockAccessToken",
+      refreshToken: "mockRefreshToken",
+    });
+  });
+
+  test("MOVER 회원가입 성공", async () => {
+    // Setup
+    // DB createUser 반환값 테스트용 객체
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      nickname: "홍길동",
+    };
+
+    // Exercise 테스트용 유저 객체 생성
+    const testUser = {
+      name: "홍길동",
+      email: "test@test.com",
+      phoneNumber: "01012345678",
+      password: "1rhdiddl!",
+      userType: "MOVER" as TUserRole,
+    };
+
+    // email 중복 체크 로직 모킹
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null);
+
+    // 비밀번호 암호화 로직 모킹
+    const mockHash = bcrypt.hash as jest.Mock;
+    mockHash.mockResolvedValue("$2b$10$hashedpassword");
+
+    // 유저 생성 로직 모킹
+    const mockCreateUser = authRepository.createUser as jest.Mock;
+    mockCreateUser.mockResolvedValue(mockUser);
+
+    // 토큰 생성용 로직 모킹
+    const mockGenerateToken = generateToken as jest.Mock;
+    mockGenerateToken.mockReturnValue({
+      newAccessToken: "mockAccessToken",
+      newRefreshToken: "mockRefreshToken",
+    });
+
+    // Exercise
+    const result = await authService.signup(testUser);
+
+    // Assertion
+
+    // 회원가입 반환값 검사
+    expect(result).toMatchObject({
+      id: mockUser.id,
+      userName: testUser.name,
+      userType: "MOVER",
+      accessToken: "mockAccessToken",
+      refreshToken: "mockRefreshToken",
+    });
+  });
+
+  test("회원가입 실패 - 이메일 중복 ValidationError(422) 발생", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      nickname: "홍길동",
+    };
+
+    // 이메일이 중복 되는 경우 예외 처리 (ValidationError)
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(mockUser);
+
+    // Assertion
+    // 이메일이 중복 되는 경우 ValidationError 발생
+    await expect(
+      authService.signup({
+        name: "홍길동",
+        email: "test@test.com",
+        phoneNumber: "01012345678",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("회원가입 실패 - 잘못된 이메일 형식이면 ValidationError(422) 발생", async () => {
+    // 💡 validateUserSignupInput 직접 throw 시뮬레이션
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null); // 중복 아님
+
+    const mockValidateUserSignupInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSignupInput.mockImplementation(() => {
+      throw new ValidationError(
+        "올바른 이메일 형식이 아니거나 허용되지 않는 도메인입니다."
+      );
+    });
+
+    /**
+     * 이메일 유효성 검사
+     * - 기본 이메일 구문 검사
+     * - 허용된 TLD 검사
+     */
+    await expect(
+      authService.signup({
+        name: "홍길동",
+        email: "not-an-email",
+        phoneNumber: "01012345678",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("회원가입 실패 - 잘못된 비밀번호 형식이면 ValidationError(422) 발생", async () => {
+    // 💡 validateUserSignupInput 직접 throw 시뮬레이션
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null); // 중복 아님
+
+    const mockValidateUserSignupInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSignupInput.mockImplementation(() => {
+      throw new ValidationError("올바른 비밀번호 형식이 아닙니다.");
+    });
+
+    /**
+     * 비밀번호 유효성 검사
+     * - 최소 8자 이상
+     * - 영문, 숫자, 특수문자 각각 1개 이상 포함
+     */
+    await expect(
+      authService.signup({
+        name: "홍길동",
+        email: "test@test.com",
+        phoneNumber: "01012345678",
+        password: "2222",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("회원가입 실패 - 잘못된 이름 형식이면 ValidationError(422) 발생", async () => {
+    // 💡 validateUserSignupInput 직접 throw 시뮬레이션
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null); // 중복 아님
+
+    const mockValidateUserSignupInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSignupInput.mockImplementation(() => {
+      throw new ValidationError("올바른 이름 형식이 아닙니다.");
+    });
+
+    /**
+     * 이름 유효성 검사
+     * - 한글, 영문, 공백 허용
+     * 최소 2자이상
+     * 최대 10자 이하
+     */
+    await expect(
+      authService.signup({
+        name: "홍길동123",
+        email: "test@test.com",
+        phoneNumber: "01012345678",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("회원가입 실패 - 잘못된 전화번호 형식이면 ValidationError(422) 발생", async () => {
+    // 💡 validateUserSignupInput 직접 throw 시뮬레이션
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null); // 중복 아님
+
+    const mockValidateUserSignupInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSignupInput.mockImplementation(() => {
+      throw new ValidationError("올바른 전화번호 형식이 아닙니다.");
+    });
+
+    /**
+     * 전화번호 유효성 검사 (010xxxxxxxx)
+     */
+    await expect(
+      authService.signup({
+        name: "홍길동",
+        email: "test@test.com",
+        phoneNumber: "010123456789",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("회원가입 실패 - 유저 생성 실패시 DatabaseError(500) 발생", async () => {
+    // Setup
+
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null);
+
+    // 유저 생성이 null로 반환되는 경우 예외 처리 (DatabaseError)
+    const mockCreateUser = authRepository.createUser as jest.Mock;
+    mockCreateUser.mockResolvedValue(null);
+
+    // Assertion
+    await expect(
+      authService.signup({
+        name: "홍길동",
+        email: "test@test.com",
+        phoneNumber: "01012345678",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(DatabaseError);
+  });
+
+  test("회원가입 실패 - 토큰 생성 실패시 ServerError(500) 발생", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      nickname: "홍길동",
+    };
+
+    const mockFindUserByEmail = authRepository.findUserByEmail as jest.Mock;
+    mockFindUserByEmail.mockResolvedValue(null);
+
+    const mockCreateUser = authRepository.createUser as jest.Mock;
+    mockCreateUser.mockResolvedValue(mockUser);
+
+    // 토큰 생성이 null로 반환되는 경우 예외 처리 (ServerError)
+    const mockGenerateToken = generateToken as jest.Mock;
+    mockGenerateToken.mockReturnValue({
+      newAccessToken: null,
+      newRefreshToken: null,
+    });
+
+    // Assertion
+    await expect(
+      authService.signup({
+        name: "홍길동",
+        email: "test@test.com",
+        phoneNumber: "01012345678",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+    ).rejects.toThrow(ServerError);
+  });
+});
+
+describe("authService.signin", () => {
+  // Teardown
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("CUSTOMER 로그인 성공", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      email: "test@test.com",
+      encryptedPassword: "$2b$10$hashedpassword",
+      customerImage: "https://cdn.com/image.png",
+      moverImage: null,
+      isCustomer: true,
+      isMover: false,
+    };
+
+    // 로그인 검증용 로직 모킹
+    const mockFindUserByEmailAndPassword =
+      authRepository.findUserByEmailAndPassword as jest.Mock;
+
+    // 비밀번호 검증용 로직 모킹
+    const mockCompare = bcrypt.compare as jest.Mock;
+
+    // 토큰 생성용 로직 모킹
+    const mockGenerateToken = generateToken as jest.Mock;
+
+    // 토큰 업데이트용 로직 모킹
+    const mockUpdateUserToken = authRepository.updateUserToken as jest.Mock;
+
+    // Mock 함수의 반환값 설정
+    mockFindUserByEmailAndPassword.mockResolvedValue(mockUser);
+    mockCompare.mockResolvedValue(true);
+    mockGenerateToken.mockReturnValue({
+      newAccessToken: "mockAccessToken",
+      newRefreshToken: "mockRefreshToken",
+    });
+    mockUpdateUserToken.mockResolvedValue(undefined);
+
+    // Exercise
+    const result = await authService.signin(
+      "test@test.com",
+      "1rhdiddl!",
+      "CUSTOMER"
+    );
+
+    // Assertion
+    expect(result).toMatchObject({
+      id: mockUser.id,
+      userName: mockUser.name,
+      userType: "CUSTOMER",
+      accessToken: "mockAccessToken",
+      refreshToken: "mockRefreshToken",
+    });
+  });
+
+  test("MOVER 로그인 성공", async () => {
+    // Setup
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      email: "test@test.com",
+      encryptedPassword: "$2b$10$hashedpassword",
+      customerImage: "https://cdn.com/image.png",
+      moverImage: null,
+      isCustomer: false,
+      isMover: true,
+    };
+
+    // 로그인 검증용 로직 모킹
+    const mockFindUserByEmailAndPassword =
+      authRepository.findUserByEmailAndPassword as jest.Mock;
+
+    // 비밀번호 검증용 로직 모킹
+    const mockCompare = bcrypt.compare as jest.Mock;
+
+    // 토큰 생성용 로직 모킹
+    const mockGenerateToken = generateToken as jest.Mock;
+
+    // 토큰 업데이트용 로직 모킹
+    const mockUpdateUserToken = authRepository.updateUserToken as jest.Mock;
+
+    // Mock 함수의 반환값 설정
+    mockFindUserByEmailAndPassword.mockResolvedValue(mockUser);
+    mockCompare.mockResolvedValue(true);
+    mockGenerateToken.mockReturnValue({
+      newAccessToken: "mockAccessToken",
+      newRefreshToken: "mockRefreshToken",
+    });
+    mockUpdateUserToken.mockResolvedValue(undefined);
+
+    // Exercise
+    const result = await authService.signin(
+      "test@test.com",
+      "1rhdiddl!",
+      "MOVER"
+    );
+
+    // Assertion
+    expect(result).toMatchObject({
+      id: mockUser.id,
+      userName: mockUser.name,
+      userType: "MOVER",
+      accessToken: "mockAccessToken",
+      refreshToken: "mockRefreshToken",
+    });
+  });
+
+  test("로그인 실패 - 잘못된 이메일 형식이면 ValidationError(422) 발생", async () => {
+    // Setup
+    const mockValidateUserSigninInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSigninInput.mockImplementation(() => {
+      throw new ValidationError(
+        "올바른 이메일 형식이 아니거나 허용되지 않는 도메인입니다."
+      );
+    });
+
+    // Assertion
+    await expect(
+      authService.signin("not-an-email", "1rhdiddl!", "CUSTOMER")
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("로그인 실패 - 잘못된 비밀번호 형식이면 ValidationError(422) 발생", async () => {
+    // Setup
+    const mockValidateUserSigninInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSigninInput.mockImplementation(() => {
+      throw new ValidationError(
+        "비밀번호는 최소 8자 이상이며 영문, 숫자, 특수문자를 각각 포함해야 합니다."
+      );
+    });
+
+    // Assertion
+    await expect(
+      authService.signin("test@test.com", "2222", "CUSTOMER")
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("로그인 실패 - 존재하지 않는 유저 라면 AuthenticationError(401) 발생", async () => {
+    // Setup
+    const mockValidateUserSigninInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSigninInput.mockImplementation(() => {
+      throw new AuthenticationError("존재하지 않는 유저입니다.");
+    });
+
+    // Assertion
+    await expect(
+      authService.signin("test@test.com", "1rhdiddl!", "CUSTOMER")
+    ).rejects.toThrow(AuthenticationError);
+  });
+
+  test("로그인 실패 - 비밀번호 불일치 라면 AuthenticationError(401) 발생", async () => {
+    // Setup
+    const mockValidateUserSigninInput = validateUserSignupInput as jest.Mock;
+    mockValidateUserSigninInput.mockImplementation(() => {
+      throw new AuthenticationError("비밀번호가 일치하지 않습니다.");
+    });
+
+    // Assertion
+    await expect(
+      authService.signin("test@test.com", "1rhdiddl!", "CUSTOMER")
+    ).rejects.toThrow(AuthenticationError);
+  });
+
+  test("로그인 실패 - 토큰 생성 실패시 ServerError(500) 발생", async () => {
+    // Setup: 로그인 성공 조건 세팅
+    const mockUser = {
+      id: 1,
+      name: "홍길동",
+      userType: ["CUSTOMER", "MOVER"],
+      email: "test@test.com",
+      encryptedPassword: "$2b$10$hashedpassword",
+      customerImage: "https://cdn.com/image.png",
+      moverImage: null,
+      isCustomer: false,
+      isMover: true,
+    };
+
+    const mockFindUser = authRepository.findUserByEmailAndPassword as jest.Mock;
+    mockFindUser.mockResolvedValue(mockUser);
+
+    const mockCompare = bcrypt.compare as jest.Mock;
+    mockCompare.mockResolvedValue(true); // 비밀번호 일치
+
+    const mockGenerateToken = generateToken as jest.Mock;
+    mockGenerateToken.mockReturnValue({
+      newAccessToken: null,
+      newRefreshToken: null,
+    });
+
+    // Assertion
+    await expect(
+      authService.signin("test@test.com", "1rhdiddl!", "CUSTOMER")
+    ).rejects.toThrow(ServerError);
+  });
+});

--- a/src/utils/validators/userValidator.ts
+++ b/src/utils/validators/userValidator.ts
@@ -2,8 +2,15 @@
 
 import { ValidationError } from "../../types/commonError.types";
 import { TMoverProfileUpdateInput } from "../../types/user.types";
-import { VALIDATION_CONFIG, PROFILE_ERROR_MESSAGES } from "../../constants/profile.constants";
-import { validateRegion, validateMoveTypes, ensureNicknameUnique } from "./profileValidator";
+import {
+  VALIDATION_CONFIG,
+  PROFILE_ERROR_MESSAGES,
+} from "../../constants/profile.constants";
+import {
+  validateRegion,
+  validateMoveTypes,
+  ensureNicknameUnique,
+} from "./profileValidator";
 
 /**
  * 허용 TLD 리스트
@@ -159,16 +166,30 @@ export const validateMoverProfileUpdate = async (
   }
 
   // 5. 한줄 소개 길이 검사
-  if (updateData.shortIntro !== undefined && updateData.shortIntro.trim().length > 0) {
-    if (updateData.shortIntro.trim().length < VALIDATION_CONFIG.MIN_INTRODUCTION_LENGTH) {
+  if (
+    updateData.shortIntro !== undefined &&
+    updateData.shortIntro.trim().length > 0
+  ) {
+    if (
+      updateData.shortIntro.trim().length <
+      VALIDATION_CONFIG.MIN_INTRODUCTION_LENGTH
+    ) {
       throw new ValidationError(PROFILE_ERROR_MESSAGES.INTRODUCTION_REQUIRED);
     }
   }
 
   // 6. 상세 설명 길이 검사
-  if (updateData.detailIntro !== undefined && updateData.detailIntro.trim().length > 0) {
-    if (updateData.detailIntro.trim().length < VALIDATION_CONFIG.MIN_DETAIL_INTRODUCTION_LENGTH) {
-      throw new ValidationError(PROFILE_ERROR_MESSAGES.DETAIL_INTRODUCTION_REQUIRED);
+  if (
+    updateData.detailIntro !== undefined &&
+    updateData.detailIntro.trim().length > 0
+  ) {
+    if (
+      updateData.detailIntro.trim().length <
+      VALIDATION_CONFIG.MIN_DETAIL_INTRODUCTION_LENGTH
+    ) {
+      throw new ValidationError(
+        PROFILE_ERROR_MESSAGES.DETAIL_INTRODUCTION_REQUIRED
+      );
     }
   }
 };


### PR DESCRIPTION
## ✨ 작업 개요

- `authService` 전반에 대한 유닛 테스트 작성
- 회원가입, 로그인, 로그아웃, 토큰 갱신, 소셜 로그인 기능의 성공/실패 케이스를 포괄
- 예외 처리와 경계 조건 테스트를 통해 인증 도메인의 안정성과 커버리지 향상

## ✅ 주요 작업 내용

### 🧩 회원가입 (`authService.signup`)
- [x] CUSTOMER 회원가입 성공
- [x] MOVER 회원가입 성공
- [x] 이메일 중복 시 `ValidationError(422)` 발생
- [x] 이메일 형식 오류 시 `ValidationError(422)` 발생
- [x] 비밀번호 형식 오류 시 `ValidationError(422)` 발생
- [x] 이름 형식 오류 시 `ValidationError(422)` 발생
- [x] 전화번호 형식 오류 시 `ValidationError(422)` 발생
- [x] 유저 생성 실패 시 `DatabaseError(500)` 발생
- [x] 토큰 생성 실패 시 `ServerError(500)` 발생

### 🔐 로그인 (`authService.signin`)
- [x] CUSTOMER 로그인 성공
- [x] MOVER 로그인 성공
- [x] 이메일 형식 오류 시 `ValidationError(422)` 발생
- [x] 비밀번호 형식 오류 시 `ValidationError(422)` 발생
- [x] 존재하지 않는 유저인 경우 `AuthenticationError(401)` 발생
- [x] 비밀번호 불일치 시 `AuthenticationError(401)` 발생
- [x] 토큰 생성 실패 시 `ServerError(500)` 발생

### 🚪 로그아웃 (`authService.logout`)
- [x] 로그아웃 성공 (refreshToken 제거)
- [x] 존재하지 않는 유저일 경우 `NotFoundError(404)` 발생
- [x] 이미 로그아웃된 유저일 경우 `AuthenticationError(401)` 발생

### 🔁 토큰 재발급 (`authService.refresh`)
- [x] `accessToken`만 재발급 (refreshToken 만료까지 6일 이상 남은 경우)
- [x] `accessToken`, `refreshToken` 모두 재발급 (만료까지 3일 이하인 경우)

### 🌐 소셜 로그인 (`authService.oauthCrateOrUpdate`)
- [x] 기존 소셜 유저가 있는 경우 → `userType` 병합 및 토큰 재발급
- [x] 기존 유저가 없는 경우 → 신규 유저 생성 및 토큰 발급

## 🔄 관련 이슈

Closes #168
