### PR TITLE
[#191] refactor : 토큰 반환 로직 쿠키로만 하도록 수정

### DIFF
--- a/src/constants/token.constants.ts
+++ b/src/constants/token.constants.ts
@@ -8,11 +8,11 @@ export const TIME = {
 
 export const TOKEN_EXPIRES = {
   // 토큰 만료 시간
-  ACCESS_TOKEN: "30m", // 30분
+  ACCESS_TOKEN: "10m", // 10분
   REFRESH_TOKEN: "2w", // 2주
 
   // 쿠키 만료 시간
-  ACCESS_TOKEN_COOKIE: 30 * TIME.MINUTE, //  30분
+  ACCESS_TOKEN_COOKIE: 10 * TIME.MINUTE, //  10분
   REFRESH_TOKEN_COOKIE: 2 * TIME.WEEK, //  2주
 } as const;
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -11,8 +11,11 @@ const FRONTEND_URL =
     ? process.env.FRONTEND_URL
     : "http://localhost:3000";
 
-export const authCookieOptions = (maxAgeSeconds: number): TCookieOptions => ({
-  httpOnly: true,
+export const authCookieOptions = (
+  maxAgeSeconds: number,
+  httpOnly?: boolean
+): TCookieOptions => ({
+  httpOnly,
   sameSite: process.env.NODE_ENV === "production" ? "none" : "lax", // 개발환경에서는 lax 사용
   secure: process.env.NODE_ENV === "production", // 개발환경에서는 false
   path: "/",
@@ -34,9 +37,15 @@ const postSignin = async (req: Request, res: Response) => {
     } = await authService.signin(email, password, userType);
 
     res.cookie(
+      "accessToken",
+      accessToken,
+      authCookieOptions(TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE, false)
+    );
+
+    res.cookie(
       "refreshToken",
       refreshToken,
-      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE, true)
     );
 
     res.status(200).json({
@@ -47,7 +56,6 @@ const postSignin = async (req: Request, res: Response) => {
         userName,
         userType: userTypeResponse,
       },
-      accessToken,
     });
   } catch (error: any) {
     console.error("로그인 에러:", error);
@@ -80,9 +88,15 @@ const postSignup = async (req: Request, res: Response) => {
     });
 
     res.cookie(
+      "accessToken",
+      accessToken,
+      authCookieOptions(TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE, false)
+    );
+
+    res.cookie(
       "refreshToken",
       refreshToken,
-      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE, true)
     );
 
     res.status(200).json({
@@ -93,7 +107,6 @@ const postSignup = async (req: Request, res: Response) => {
         name: userName,
         userType: userTypeResponse,
       },
-      accessToken,
     });
   } catch (error: any) {
     handleError(res, error);
@@ -134,19 +147,24 @@ const postRefresh = async (req: Request, res: Response) => {
       userId,
     });
 
+    res.cookie(
+      "accessToken",
+      accessToken,
+      authCookieOptions(TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE, false)
+    );
+
     // 리프레쉬 쿠키까지 재발급 된다면 저장
     if (refreshToken) {
       res.cookie(
         "refreshToken",
         refreshToken,
-        authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+        authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE, true)
       );
     }
 
     res.status(200).json({
       success: true,
       message: "토큰 갱신 성공",
-      accessToken,
     });
   } catch (error: any) {
     handleError(res, error);
@@ -158,20 +176,16 @@ const getGoogleCallback = async (req: Request, res: Response) => {
   const { accessToken, refreshToken, userType } = req.user as any;
 
   try {
-    res.cookie("accessToken", accessToken, {
-      httpOnly: false,
-      sameSite: "none",
-      secure: true,
-      path: "/",
-      maxAge: TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE * 1000,
-      domain:
-        process.env.NODE_ENV === "production" ? ".gomoving.site" : undefined,
-    });
+    res.cookie(
+      "accessToken",
+      accessToken,
+      authCookieOptions(TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE, false)
+    );
 
     res.cookie(
       "refreshToken",
       refreshToken,
-      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE, true)
     );
 
     res.redirect(`${FRONTEND_URL}/`);
@@ -194,20 +208,16 @@ const getKakaoCallback = async (req: Request, res: Response) => {
   const { accessToken, refreshToken, userType } = req.user as any;
 
   try {
-    res.cookie("accessToken", accessToken, {
-      httpOnly: false,
-      sameSite: "none",
-      secure: true,
-      path: "/",
-      maxAge: TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE * 1000,
-      domain:
-        process.env.NODE_ENV === "production" ? ".gomoving.site" : undefined,
-    });
+    res.cookie(
+      "accessToken",
+      accessToken,
+      authCookieOptions(TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE, false)
+    );
 
     res.cookie(
       "refreshToken",
       refreshToken,
-      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE, true)
     );
 
     res.redirect(`${FRONTEND_URL}/`);
@@ -230,19 +240,16 @@ const getNaverCallback = async (req: Request, res: Response) => {
   const { accessToken, refreshToken, userType } = req.user as any;
 
   try {
-    res.cookie("accessToken", accessToken, {
-      httpOnly: false,
-      sameSite: "none",
-      secure: true,
-      path: "/",
-      maxAge: TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE * 1000,
-      domain:
-        process.env.NODE_ENV === "production" ? ".gomoving.site" : undefined,
-    });
+    res.cookie(
+      "accessToken",
+      accessToken,
+      authCookieOptions(TOKEN_EXPIRES.ACCESS_TOKEN_COOKIE, false)
+    );
+
     res.cookie(
       "refreshToken",
       refreshToken,
-      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
+      authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE, true)
     );
 
     res.redirect(`${FRONTEND_URL}/`);

--- a/src/types/cookie.types.ts
+++ b/src/types/cookie.types.ts
@@ -1,7 +1,7 @@
 export type TCookieOptions = {
-  httpOnly: boolean;
-  sameSite: "none" | "lax" | "strict";
-  secure: boolean;
+  httpOnly?: boolean;
+  sameSite?: "none" | "lax" | "strict";
+  secure?: boolean;
   path: string;
   maxAge: number;
   domain: string | undefined;


### PR DESCRIPTION
## ✨ 작업 개요
토큰 반환 로직 쿠키로만 하도록 수정

## ✅ 주요 작업 내용
- body로 액세스 토큰을 반환하던 부분들을 모두 쿠키로 전송 하도록 수정, 이제 클라이언트에서 수동 저장이 아닌
곧바로 httpOnly 속성을 false로 설정해 넘겨 로직을 단순화
- 탈취의 위험은 증가하지만 개발 편의성과 토큰의 사용이 더 중요하다고 판단함, 약간의 보완 정책으로 액세스 토큰의 만료시간을
10분으로 설정해 주기적으로 재발급 하도록 설정함

## 🔄 관련 이슈
#190 

## 📝 비고
- 추가적인 리팩터링 후 이슈 닫겠습니다
