### PR TITLE
repactor: 유저 흐름에 맞는 필요 옵션 추가

### DIFF
--- a/src/controllers/estimateRequest.controller.ts
+++ b/src/controllers/estimateRequest.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import EstimateRequestService from "../services/estimateRequest.service";
 import { convertRegionToKorean } from "../utils/addressUtils";
-import { isBeforeKoreaToday, isKoreaToday, formatDateForAPI } from "../utils/dateUtils";
+import { validateMoveDate, formatDateForAPI } from "../utils/dateUtils";
 import {
   TCreateEstimateRequest,
   TUpdateEstimateRequest,
@@ -45,24 +45,11 @@ class EstimateRequestController {
   }
 
   private validateMoveDate(movingDate: string): void {
-    try {
-      const moveDate = new Date(movingDate);
-      if (isNaN(moveDate.getTime())) {
-        throw new Error("올바른 날짜 형식이 아닙니다. (YYYY-MM-DD 형식으로 입력해주세요)");
-      }
+    const moveDate = new Date(movingDate);
+    const validation = validateMoveDate(moveDate);
 
-      if (isBeforeKoreaToday(moveDate)) {
-        throw new Error("이사일은 오늘 이후로 설정해주세요.");
-      }
-
-      if (isKoreaToday(moveDate)) {
-        throw new Error("당일 이사는 불가능합니다. 내일 이후로 설정해주세요.");
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error("날짜 검증 중 오류가 발생했습니다.");
+    if (!validation.isValid) {
+      throw new Error(validation.errorMessage);
     }
   }
 

--- a/src/services/moverSchedule.service.ts
+++ b/src/services/moverSchedule.service.ts
@@ -1,94 +1,7 @@
 import moverScheduleRepository from "../repositories/moverSchedule.repository";
-import {
-  TMoverScheduleResponse,
-  TMoverScheduleWithDetails,
-  MoveTypeMapping,
-  StatusMapping,
-} from "../types/moverSchedule";
+import { TMoverScheduleResponse, TMoverScheduleWithDetails } from "../types/moverSchedule";
 import { ServiceError, ServiceValidationError, RepositoryError } from "../types/errors.types";
-import { convertRegionToKorean } from "../utils/addressUtils";
-
-// 상수 정의
-const VALIDATION = {
-  MIN_YEAR: 1900,
-  MIN_MONTH: 1,
-  MAX_MONTH: 12,
-} as const;
-
-const MOVE_TYPE_MAPPING: MoveTypeMapping = {
-  SMALL: "소형이사",
-  HOME: "가정이사",
-  OFFICE: "사무실이사",
-} as const;
-
-const STATUS_MAPPING: StatusMapping = {
-  APPROVED: "confirmed",
-  PENDING: "pending",
-} as const;
-
-// 유틸리티 함수들
-const validateInput = (moverId: string, year: number, month: number): void => {
-  if (!moverId || typeof moverId !== "string") {
-    throw new ServiceValidationError("잘못된 기사 ID입니다");
-  }
-
-  if (!year || !month || year < VALIDATION.MIN_YEAR || month < VALIDATION.MIN_MONTH || month > VALIDATION.MAX_MONTH) {
-    throw new ServiceValidationError("잘못된 년도 또는 월입니다");
-  }
-};
-
-const formatAddressForTranslation = (address: {
-  city: string;
-  district: string;
-  detail: string | null;
-  region: string;
-}): string => {
-  const parts: string[] = [];
-
-  // 리전 (시/도) - region이 있으면 region을 사용, 없으면 city 사용
-  if (address.region) {
-    parts.push(convertRegionToKorean(address.region));
-  } else if (address.city) {
-    parts.push(address.city);
-  }
-
-  // 구/군
-  if (address.district) {
-    parts.push(address.district);
-  }
-
-  // 상세주소
-  if (address.detail) {
-    parts.push(address.detail);
-  }
-
-  return parts.join(" ");
-};
-
-const transformToScheduleResponse = (detail: TMoverScheduleWithDetails): TMoverScheduleResponse => {
-  return {
-    id: detail.estimateRequestId,
-    customerName: detail.customer.name,
-    movingType: MOVE_TYPE_MAPPING[detail.moveType] || "소형이사",
-    status: (STATUS_MAPPING as any)[detail.requestStatus] || "pending",
-    fromAddress: formatAddressForTranslation(detail.fromAddress),
-    toAddress: formatAddressForTranslation(detail.toAddress),
-    moveDate: detail.moveDate.toISOString().split("T")[0], // YYYY-MM-DD 형식
-  };
-};
-
-const handleServiceError = (error: unknown): never => {
-  if (error instanceof ServiceValidationError) {
-    throw error;
-  }
-
-  if (error instanceof RepositoryError) {
-    throw new ServiceError("월별 스케줄 조회 중 오류가 발생했습니다");
-  }
-
-  console.error("moverScheduleService.getMonthlySchedules 에러:", error);
-  throw new ServiceError("월별 스케줄 조회 중 예상치 못한 오류가 발생했습니다");
-};
+import { validateScheduleInput, transformToScheduleResponse, handleScheduleError } from "../utils/scheduleUtils";
 
 // 메인 서비스 객체
 const moverScheduleService = {
@@ -97,12 +10,20 @@ const moverScheduleService = {
    */
   getMonthlySchedules: async (moverId: string, year: number, month: number): Promise<TMoverScheduleResponse[]> => {
     try {
-      validateInput(moverId, year, month);
+      validateScheduleInput(moverId, year, month);
 
       const scheduleDetails = await moverScheduleRepository.getMonthlySchedules(moverId, year, month);
       return scheduleDetails.map(transformToScheduleResponse);
     } catch (error) {
-      return handleServiceError(error);
+      if (error instanceof ServiceValidationError) {
+        throw error;
+      }
+
+      if (error instanceof RepositoryError) {
+        throw new ServiceError("월별 스케줄 조회 중 오류가 발생했습니다");
+      }
+
+      return handleScheduleError(error, "월별 스케줄 조회 중 예상치 못한 오류가 발생했습니다");
     }
   },
 };

--- a/src/types/moverSchedule.ts
+++ b/src/types/moverSchedule.ts
@@ -1,4 +1,8 @@
-// 기사님 스케줄 조회 필터링 타입
+// 기사님 스케줄 관련 타입 정의
+
+/**
+ * 스케줄 조회 필터링 옵션 타입
+ */
 export type TMoverScheduleFilterOptions = {
   moverId: string;
   startDate?: Date;
@@ -6,18 +10,22 @@ export type TMoverScheduleFilterOptions = {
   sortBy?: "moveDate" | "createdAt";
 };
 
-// 스케줄 응답 타입 (프론트엔드 Schedule 인터페이스와 매핑)
+/**
+ * 스케줄 응답 타입 (프론트엔드 Schedule 인터페이스와 매핑)
+ */
 export type TMoverScheduleResponse = {
   id: string;
   customerName: string;
-  movingType: "소형이사" | "가정이사" | "원룸이사" | "사무실이사";
-  status: "confirmed" | "pending";
+  movingType: "small" | "home" | "office";
+  status: "confirmed" | "pending" | "completed";
   fromAddress: string;
   toAddress: string;
   moveDate: string; // YYYY-MM-DD 형식
 };
 
-// 기사님 스케줄 상세 정보 (내부 처리용)
+/**
+ * 기사님 스케줄 상세 정보 (내부 처리용)
+ */
 export type TMoverScheduleWithDetails = {
   estimateId: string;
   estimateRequestId: string;
@@ -28,15 +36,15 @@ export type TMoverScheduleWithDetails = {
   customer: {
     id: string;
     name: string;
-    customerImage: string | null;
-    nickname: string | null;
+    customerImage: string | undefined;
+    nickname: string | undefined;
   };
   fromAddress: {
     id: string;
     zoneCode: string;
     city: string;
     district: string;
-    detail: string | null;
+    detail: string | undefined;
     region: string;
   };
   toAddress: {
@@ -44,22 +52,124 @@ export type TMoverScheduleWithDetails = {
     zoneCode: string;
     city: string;
     district: string;
-    detail: string | null;
+    detail: string | undefined;
     region: string;
   };
   createdAt: Date;
   updatedAt: Date;
 };
 
-// 이사 타입 변환 유틸리티 타입
+/**
+ * 이사 타입 변환 유틸리티 타입
+ */
 export type MoveTypeMapping = {
-  SMALL: "소형이사";
-  HOME: "가정이사";
-  OFFICE: "사무실이사";
+  SMALL: "small";
+  HOME: "home";
+  OFFICE: "office";
 };
 
-// 상태 변환 유틸리티 타입
+/**
+ * 상태 변환 유틸리티 타입
+ */
 export type StatusMapping = {
   APPROVED: "confirmed";
   PENDING: "pending";
+  COMPLETED: "completed";
 };
+
+/**
+ * API 응답 타입
+ */
+export interface ScheduleApiResponse {
+  success: boolean;
+  message: string;
+  data: TMoverScheduleResponse[];
+}
+
+/**
+ * API 에러 응답 타입
+ */
+export interface ApiErrorResponse {
+  success: false;
+  message: string;
+}
+
+/**
+ * 주소 정보 타입
+ */
+export interface AddressInfo {
+  id: string;
+  zoneCode: string;
+  city: string;
+  district: string;
+  detail: string | undefined;
+  region: string;
+}
+
+/**
+ * 고객 정보 타입
+ */
+export interface CustomerInfo {
+  id: string;
+  name: string;
+  customerImage: string | undefined;
+  nickname: string | undefined;
+}
+
+/**
+ * 서비스 에러 타입
+ */
+export interface ServiceErrorType {
+  message: string;
+  code?: string;
+}
+
+/**
+ * 유효성 검사 결과 타입
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+/**
+ * 주소 포맷팅 입력 타입
+ */
+export interface AddressFormatInput {
+  city: string;
+  district: string;
+  detail: string | undefined;
+  region: string;
+}
+
+/**
+ * 스케줄 변환 입력 타입
+ */
+export interface ScheduleTransformInput {
+  estimateRequestId: string;
+  customer: {
+    name: string;
+  };
+  moveType: "SMALL" | "HOME" | "OFFICE";
+  requestStatus: string;
+  fromAddress: AddressFormatInput;
+  toAddress: AddressFormatInput;
+  moveDate: Date;
+}
+
+/**
+ * 유효성 검사 입력 타입
+ */
+export interface ValidationInput {
+  moverId: string;
+  year: number;
+  month: number;
+}
+
+/**
+ * 에러 처리 입력 타입
+ */
+export interface ErrorHandlingInput {
+  error: unknown;
+  defaultMessage: string;
+}

--- a/src/utils/addressUtils.ts
+++ b/src/utils/addressUtils.ts
@@ -50,14 +50,14 @@ const ENGLISH_TO_KOREAN: { [key: string]: string } = {
   ULSAN: "울산",
   SEJONG: "세종",
   GYEONGGI: "경기",
-  GANGWON: "강원특별자치도",
+  GANGWON: "강원",
   CHUNGBUK: "충북",
   CHUNGNAM: "충남",
-  JEONBUK: "전북특별자치도",
+  JEONBUK: "전북",
   JEONNAM: "전남",
   GYEONGBUK: "경북",
   GYEONGNAM: "경남",
-  JEJU: "제주특별자치도",
+  JEJU: "제주",
 };
 
 /**

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -47,6 +47,61 @@ export const isAfterKoreaToday = (date: Date): boolean => {
 };
 
 /**
+ * 주어진 날짜가 한국 시간 기준 오늘 이후인지 확인합니다 (과거 및 당일 제외).
+ * @param date 확인할 날짜
+ * @returns 오늘 이후이면 true, 과거 또는 당일이면 false
+ */
+export const isValidFutureDate = (date: Date): boolean => {
+  const koreaToday = getKoreaToday();
+  const inputDate = new Date(date);
+  inputDate.setHours(0, 0, 0, 0);
+  return inputDate > koreaToday;
+};
+
+/**
+ * 주어진 날짜가 유효한 이사일인지 확인합니다 (과거 및 당일 제외).
+ * @param date 확인할 날짜
+ * @returns 유효한 미래 날짜이면 true, 아니면 false
+ */
+export const isValidMoveDate = (date: Date): boolean => {
+  return isValidFutureDate(date);
+};
+
+/**
+ * 주어진 날짜에 대한 이사일 유효성 검사 결과를 반환합니다.
+ * @param date 확인할 날짜
+ * @returns { isValid: boolean, errorMessage?: string }
+ */
+export const validateMoveDate = (date: Date): { isValid: boolean; errorMessage?: string } => {
+  const koreaToday = getKoreaToday();
+  const inputDate = new Date(date);
+  inputDate.setHours(0, 0, 0, 0);
+
+  if (isNaN(inputDate.getTime())) {
+    return {
+      isValid: false,
+      errorMessage: "올바른 날짜 형식이 아닙니다. (YYYY-MM-DD 형식으로 입력해주세요)",
+    };
+  }
+
+  if (inputDate < koreaToday) {
+    return {
+      isValid: false,
+      errorMessage: "이사일은 오늘 이후로 설정해주세요.",
+    };
+  }
+
+  if (inputDate.getTime() === koreaToday.getTime()) {
+    return {
+      isValid: false,
+      errorMessage: "당일 이사는 불가능합니다. 내일 이후로 설정해주세요.",
+    };
+  }
+
+  return { isValid: true };
+};
+
+/**
  * DateTime을 YYYY-MM-DD 형식의 날짜만 반환
  * @param dateTime - DateTime 객체 또는 문자열
  * @returns YYYY-MM-DD 형식의 날짜 문자열

--- a/src/utils/scheduleUtils.ts
+++ b/src/utils/scheduleUtils.ts
@@ -1,0 +1,119 @@
+// 백엔드 스케줄 관련 유틸리티 함수들
+import {
+  TMoverScheduleWithDetails,
+  TMoverScheduleResponse,
+  MoveTypeMapping,
+  StatusMapping,
+  AddressFormatInput,
+  ScheduleTransformInput,
+  ValidationInput,
+  ErrorHandlingInput,
+} from "../types/moverSchedule";
+import { convertRegionToKorean } from "./addressUtils";
+
+// 상수 정의
+export const moveTypeMapping: MoveTypeMapping = {
+  SMALL: "small",
+  HOME: "home",
+  OFFICE: "office",
+} as const;
+
+export const statusMapping: StatusMapping = {
+  APPROVED: "confirmed",
+  PENDING: "pending",
+  COMPLETED: "completed",
+} as const;
+
+export const validation = {
+  minYear: 1900,
+  minMonth: 1,
+  maxMonth: 12,
+} as const;
+
+/**
+ * 입력값 유효성 검사
+ */
+export const validateScheduleInput = (moverId: string, year: number, month: number): void => {
+  if (!moverId || typeof moverId !== "string") {
+    throw new Error("잘못된 기사 ID입니다");
+  }
+
+  if (!year || !month || year < validation.minYear || month < validation.minMonth || month > validation.maxMonth) {
+    throw new Error("잘못된 년도 또는 월입니다");
+  }
+};
+
+/**
+ * 주소 포맷팅 함수
+ */
+export const formatAddressForTranslation = (address: AddressFormatInput): string => {
+  const parts: string[] = [];
+
+  // 리전 (시/도) - region이 있으면 region을 사용, 없으면 city 사용
+  if (address.region) {
+    parts.push(convertRegionToKorean(address.region));
+  } else if (address.city) {
+    parts.push(address.city);
+  }
+
+  // 구/군
+  if (address.district) {
+    parts.push(address.district);
+  }
+
+  // 상세주소
+  if (address.detail) {
+    parts.push(address.detail);
+  }
+
+  let result = parts.join(" ");
+
+  // Korea 제거
+  result = result.replace(/,?\s*Korea\s*$/, "");
+
+  // Seoul을 한국어로 변환
+  result = result.replace(/\bSeoul\b/g, "서울");
+
+  return result;
+};
+
+/**
+ * 스케줄 상세 정보를 응답 형식으로 변환
+ */
+export const transformToScheduleResponse = (detail: TMoverScheduleWithDetails): TMoverScheduleResponse => {
+  return {
+    id: detail.estimateRequestId,
+    customerName: detail.customer.name,
+    movingType: moveTypeMapping[detail.moveType] || "small",
+    status: statusMapping[detail.requestStatus as keyof StatusMapping] || "pending",
+    fromAddress: formatAddressForTranslation(detail.fromAddress),
+    toAddress: formatAddressForTranslation(detail.toAddress),
+    moveDate: detail.moveDate.toISOString().split("T")[0], // YYYY-MM-DD 형식
+  };
+};
+
+/**
+ * 백엔드 이사 유형을 프론트엔드 형식으로 변환
+ */
+export const mapBackendMoveType = (backendType: string): string => {
+  return moveTypeMapping[backendType as keyof typeof moveTypeMapping] || "small";
+};
+
+/**
+ * 백엔드 상태를 프론트엔드 형식으로 변환
+ */
+export const mapBackendStatus = (backendStatus: string): string => {
+  return statusMapping[backendStatus as keyof typeof statusMapping] || "pending";
+};
+
+/**
+ * 에러 처리 헬퍼
+ */
+export const handleScheduleError = (error: unknown, defaultMessage: string): never => {
+  if (error instanceof Error) {
+    throw error;
+  }
+
+  console.error("스케줄 서비스 에러:", error);
+  throw new Error(defaultMessage);
+};


### PR DESCRIPTION
## ✨ 작업 개요

- 유저 흐름에 맞는 필요 옵션 추가

## ✅ 주요 작업 내용
견적 요청 
- 당일 이사 불가능하게 수정
- 수정 삭제 시 기사님이 보낸 견적이 있는지 확인하는 필드 추가
- 견적 확정 후 이사일이 지나지 않아도 또 다른 견적 요청을 할 수 있는 문제 처리
- 주소 일관되게 매핑되도록 수정

일정 관리
- 동적 데이터 번역 이상하게 나오는 문제 해결

## 🔄 관련 이슈

## 📎 참고 자료 (선택)

## 🧪 테스트 방법 (선택)

- [ ] 쿼리 파라미터 전달 시 필터링 정상 작동

## 📝 비고
테스트 코드 추후 작성 예정 
