### PR TITLE
[#210] 유저 플로우 테스트 이슈 수정

### DIFF
--- a/src/constants/profile.constants.ts
+++ b/src/constants/profile.constants.ts
@@ -41,6 +41,10 @@ export const PROFILE_ERROR_MESSAGES = {
   USER_SERVICES_REQUIRED: "이용할 서비스를 하나 이상 선택해주세요",
   SERVICE_REGIONS_REQUIRED: "서비스 가능 지역을 하나 이상 선택해주세요",
   SERVICE_TYPES_REQUIRED: "제공할 서비스를 하나 이상 선택해주세요",
+  NICKNAME_INVALID_FORMAT: "닉네임은 한글, 영어, 중국어, 숫자만 허용합니다",
+  NICKNAME_TOO_LONG: "닉네임은 15자 이하로 입력해주세요",
+  INTRODUCTION_TOO_LONG: "한줄 소개는 30자 이하로 입력해주세요",
+  DESCRIPTION_TOO_LONG: "상세 설명은 300자 이하로 입력해주세요",
   INVALID_SERVICE_ID: `유효하지 않은 서비스 ID입니다. ${Object.entries(
     SERVICE_INFO
   )
@@ -69,4 +73,7 @@ export const VALIDATION_CONFIG = {
   MIN_DESCRIPTION_LENGTH: 10,
   MIN_SERVICE_COUNT: 1,
   MIN_REGION_COUNT: 1,
+  MAX_NICKNAME_LENGTH: 15,
+  MAX_INTRODUCTION_LENGTH: 30,
+  MAX_DESCRIPTION_LENGTH: 300,
 } as const;

--- a/src/middlewares/verifyToken.ts
+++ b/src/middlewares/verifyToken.ts
@@ -10,7 +10,9 @@ export const verifyAccessToken = (
   const token = req.headers.authorization?.split(" ")[1];
 
   if (!token) {
-    return res.status(401).json({ message: "로그인이 필요합니다." });
+    return res
+      .status(401)
+      .json({ message: "로그인이 필요합니다. 다시 로그인해 주세요." });
   }
 
   try {
@@ -27,21 +29,22 @@ export const verifyAccessToken = (
     next();
   } catch (err: unknown) {
     if (err instanceof jwt.TokenExpiredError) {
-      return res
-        .status(401)
-        .json({ success: false, message: "토큰 만료 시간이 지났습니다." });
+      return res.status(401).json({
+        success: false,
+        message: "로그인 세션이 만료되었습니다. 다시 로그인해 주세요.",
+      });
     }
 
     if (err instanceof jwt.JsonWebTokenError) {
       return res.status(401).json({
         success: false,
-        message: "Access token이 변조되었거나 잘못된 형식입니다.",
+        message: "유효하지 않은 로그인 정보입니다. 다시 로그인해 주세요.",
       });
     }
 
     return res.status(401).json({
       success: false,
-      message: "Access token이 유효하지 않습니다.",
+      message: "인증에 실패했습니다. 다시 로그인해 주세요.",
     });
   }
 };

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -28,6 +28,7 @@ const getUserById = async (userId: string) => {
       moverImage: true,
       userType: true,
       refreshToken: true,
+      provider: true,
     },
   });
   return user;

--- a/src/services/user.service.test.ts
+++ b/src/services/user.service.test.ts
@@ -1,4 +1,3 @@
-import * as userRepository from "../repositories/user.repository";
 import { NotFoundError, ValidationError } from "../types/commonError.types";
 import { generateToken } from "../utils/generateToken";
 import { encryptPhoneNumber } from "../utils/phoneEncryption";
@@ -18,6 +17,7 @@ import {
 import { MoveType, RegionType } from "../types/user.types";
 import bcrypt from "bcrypt";
 import { validateMoverProfileUpdate } from "../utils/validators/userValidator";
+import userRepository from "../repositories/user.repository";
 
 jest.mock("../repositories/user.repository");
 jest.mock("../utils/generateToken");
@@ -51,6 +51,7 @@ describe("userService.userInfo", () => {
       moverImage: "test.jpg",
       userType: ["CUSTOMER", "MOVER"],
       refreshToken: "refreshToken",
+      provider: "LOCAL",
     };
 
     const expectedUser = {
@@ -61,6 +62,7 @@ describe("userService.userInfo", () => {
       nickname: "홍길동",
       customerImage: "test.jpg",
       userType: "CUSTOMER",
+      provider: "LOCAL",
     };
 
     const mockGetUserById = userRepository.getUserById as jest.Mock;
@@ -91,6 +93,7 @@ describe("userService.userInfo", () => {
       moverImage: "test.jpg",
       userType: ["CUSTOMER", "MOVER"],
       refreshToken: "refreshToken",
+      provider: "LOCAL",
     };
 
     const expectedUser = {
@@ -101,6 +104,7 @@ describe("userService.userInfo", () => {
       nickname: "홍길동",
       moverImage: "test.jpg",
       userType: "MOVER",
+      provider: "LOCAL",
     };
 
     const mockGetUserById = userRepository.getUserById as jest.Mock;
@@ -1473,9 +1477,9 @@ describe("userService.createMoverProfile", () => {
 
     (userRepository.getUserById as jest.Mock).mockResolvedValue(mockUser);
     (validateMoverProfileData as jest.Mock).mockResolvedValue(undefined);
-    (
-      userRepository.createMoverProfileRepository as jest.Mock
-    ).mockResolvedValue(expectedResult);
+    (userRepository.createMoverProfile as jest.Mock).mockResolvedValue(
+      expectedResult
+    );
     (generateToken as jest.Mock).mockReturnValue(mockTokens);
 
     // Exercise
@@ -1484,7 +1488,7 @@ describe("userService.createMoverProfile", () => {
     // Assertion
     expect(userRepository.getUserById).toHaveBeenCalledWith("1");
     expect(validateMoverProfileData).toHaveBeenCalledWith(profileData, "1");
-    expect(userRepository.createMoverProfileRepository).toHaveBeenCalledWith({
+    expect(userRepository.createMoverProfile).toHaveBeenCalledWith({
       userId: "1",
       nickname: "믿을만한김기사",
       moverImage: "https://example.com/mover.jpg",
@@ -1547,16 +1551,16 @@ describe("userService.createMoverProfile", () => {
 
     (userRepository.getUserById as jest.Mock).mockResolvedValue(mockUser);
     (validateMoverProfileData as jest.Mock).mockResolvedValue(undefined);
-    (
-      userRepository.createMoverProfileRepository as jest.Mock
-    ).mockResolvedValue(expectedResult);
+    (userRepository.createMoverProfile as jest.Mock).mockResolvedValue(
+      expectedResult
+    );
     (generateToken as jest.Mock).mockReturnValue(mockTokens);
 
     // Exercise
     const result = await createMoverProfile("1", profileData);
 
     // Assertion
-    expect(userRepository.createMoverProfileRepository).toHaveBeenCalledWith({
+    expect(userRepository.createMoverProfile).toHaveBeenCalledWith({
       userId: "1",
       nickname: "새로운기사",
       moverImage: undefined,

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -43,6 +43,7 @@ const userInfo = async (userId: string, userType: TUserRole) => {
       nickname: user.nickname,
       customerImage: user.customerImage || "",
       userType,
+      provider: user.provider,
     };
   } else if (userType === "MOVER") {
     return {
@@ -55,6 +56,7 @@ const userInfo = async (userId: string, userType: TUserRole) => {
       nickname: user.nickname,
       moverImage: user.moverImage || "",
       userType,
+      provider: user.provider,
     };
   }
 };

--- a/src/utils/validators/profileValidator.ts
+++ b/src/utils/validators/profileValidator.ts
@@ -1,13 +1,11 @@
-import { VALID_REGIONS } from "../../constants/regions.constants";
 import {
   PROFILE_ERROR_MESSAGES,
   VALIDATION_CONFIG,
 } from "../../constants/profile.constants";
-import { ValidationError, ForbiddenError } from "../../types/commonError.types";
+import { ValidationError } from "../../types/commonError.types";
 import {
   TCustomerProfileInput,
   TMoverProfileInput,
-  TUserProfileUpdateInput,
   MoveType,
   RegionType,
 } from "../../types/user.types";
@@ -46,19 +44,36 @@ export const validateRegion = (regions: RegionType[]): boolean => {
   return regions.every((region) => validRegions.includes(region));
 };
 
-// 닉네임 중복 확인 및 에러 처리
+// 닉네임 유효성 정규식 (한글, 영어, 중국어, 숫자만 허용) 15자 이하
+const NICKNAME_REGEX =
+  /^[\p{Script=Hangul}\p{Script=Han}\p{Script=Latin}0-9]{1,15}$/u;
+
+// 닉네임 중복 확인 및 유효성 검사
 export const ensureNicknameUnique = async (
   nickname: string,
   excludeUserId?: string
 ): Promise<void> => {
-  if (
-    !nickname ||
-    nickname.trim().length < VALIDATION_CONFIG.MIN_NICKNAME_LENGTH
-  ) {
+  const trimmed = nickname?.trim();
+
+  // 닉네임 최소 길이 검사
+  if (!trimmed || trimmed.length < VALIDATION_CONFIG.MIN_NICKNAME_LENGTH) {
     throw new ValidationError(PROFILE_ERROR_MESSAGES.NICKNAME_REQUIRED);
   }
 
-  const nicknameExists = await userRepository.checkNicknameExists(nickname, excludeUserId);
+  // 닉네임 최대 길이 검사
+  if (trimmed.length > VALIDATION_CONFIG.MAX_NICKNAME_LENGTH) {
+    throw new ValidationError(PROFILE_ERROR_MESSAGES.NICKNAME_TOO_LONG);
+  }
+
+  if (!NICKNAME_REGEX.test(trimmed)) {
+    throw new ValidationError(PROFILE_ERROR_MESSAGES.NICKNAME_INVALID_FORMAT);
+  }
+
+  const nicknameExists = await userRepository.checkNicknameExists(
+    trimmed,
+    excludeUserId
+  );
+
   if (nicknameExists) {
     throw new ValidationError(PROFILE_ERROR_MESSAGES.NICKNAME_ALREADY_EXISTS);
   }
@@ -138,27 +153,33 @@ export const validateMoverProfileData = async (
     throw new ValidationError(PROFILE_ERROR_MESSAGES.EXPERIENCE_REQUIRED);
   }
 
-  // 5. 한줄 소개 유효성 검사 (선택사항, 있으면 최소 길이 체크)
+  // 5. 한줄 소개 유효성 검사 (선택사항, 있으면 최소/최대 길이 체크)
   if (profileData.shortIntro !== undefined) {
+    const trimmedIntro = profileData.shortIntro.trim();
     if (
-      profileData.shortIntro.trim().length > 0 &&
-      profileData.shortIntro.trim().length <
-        VALIDATION_CONFIG.MIN_INTRODUCTION_LENGTH
+      trimmedIntro.length > 0 &&
+      trimmedIntro.length < VALIDATION_CONFIG.MIN_INTRODUCTION_LENGTH
     ) {
       throw new ValidationError(PROFILE_ERROR_MESSAGES.INTRODUCTION_REQUIRED);
+    }
+    if (trimmedIntro.length > VALIDATION_CONFIG.MAX_INTRODUCTION_LENGTH) {
+      throw new ValidationError(PROFILE_ERROR_MESSAGES.INTRODUCTION_TOO_LONG);
     }
   } else if (!profileData.shortIntro) {
     throw new ValidationError(PROFILE_ERROR_MESSAGES.INTRODUCTION_REQUIRED);
   }
 
-  // 6. 상세 소개 유효성 검사 (선택사항, 있으면 최소 길이 체크)
+  // 6. 상세 소개 유효성 검사 (선택사항, 있으면 최소/최대 길이 체크)
   if (profileData.detailIntro !== undefined) {
+    const trimmedDetail = profileData.detailIntro.trim();
     if (
-      profileData.detailIntro.trim().length > 0 &&
-      profileData.detailIntro.trim().length <
-        VALIDATION_CONFIG.MIN_DESCRIPTION_LENGTH
+      trimmedDetail.length > 0 &&
+      trimmedDetail.length < VALIDATION_CONFIG.MIN_DESCRIPTION_LENGTH
     ) {
       throw new ValidationError(PROFILE_ERROR_MESSAGES.DESCRIPTION_REQUIRED);
+    }
+    if (trimmedDetail.length > VALIDATION_CONFIG.MAX_DESCRIPTION_LENGTH) {
+      throw new ValidationError(PROFILE_ERROR_MESSAGES.DESCRIPTION_TOO_LONG);
     }
   } else if (!profileData.detailIntro) {
     throw new ValidationError(PROFILE_ERROR_MESSAGES.DESCRIPTION_REQUIRED);


### PR DESCRIPTION
## ✨ 작업 개요
- 유저 플로우 테스트 피드백을 반영하여 회원가입 및 프로필 등록 관련 유효성 검사 로직을 개선했습니다.
- 소셜 로그인 시 프로필 수정 오류를 해결하기 위해 비밀번호 필드를 선택값으로 처리했습니다.

## ✅ 주요 작업 내용

- 이름 입력값을 한글, 영어, 중국어 15자 이내로 제한
- 별명 입력값을 한글, 영어, 중국어, 숫자 조합 15자 이내로 제한
- 기사님 프로필 등록 시:
  - 한줄 소개: 최대 30자
  - 상세 소개: 최대 300자
- 유효성 실패 시 반환 메시지의 사용자 노출 레벨을 조정하여 UX 개선
- 소셜 로그인 사용자의 경우 비밀번호 없이 프로필 수정 가능하도록 처리
- 유저 정보 조회시 현재 로그인한 provider를 반환하도록 수정

## 🔄 관련 이슈

Closes #210 

## 스크린샷

### 한줄소개
<img width="507" height="345" alt="한줄소개" src="https://github.com/user-attachments/assets/bc98e8eb-b409-4efa-a486-1c1f1a914a65" />

### 상세설명
<img width="446" height="343" alt="상세설명 300자" src="https://github.com/user-attachments/assets/2b42dbb1-3a1f-43f7-b57e-345055904483" />



## 🧪 테스트 방법 (선택)
- [x] 이름, 별명, 소개글 유효성 검사가 정상 작동하는지 확인
- [x] 소셜 로그인 사용자가 비밀번호 없이 프로필 수정 가능한지 확인
- [x] 유효성 실패 시 사용자에게 적절한 메시지가 노출되는지 확인

## 📝 비고
- 프론트엔드와 함께 QA 테스트 예정
