### PR TITLE
HOTFIX: 단일 프리즈마 클라이언트 인스턴스 사용으로 트래픽 문제 해결

### DIFF
--- a/src/db/prisma/prisma.ts
+++ b/src/db/prisma/prisma.ts
@@ -2,7 +2,28 @@ import { PrismaClient } from "@prisma/client";
 import { reviewPrismaMiddleware } from "../../middlewares/reviewMiddleware";
 import { notificationMiddleware } from "../../middlewares/notificationMiddleware";
 
-const prisma = new PrismaClient();
+// Singleton 패턴으로 Prisma 클라이언트 인스턴스를 관리하여 연결 풀 최적화
+let prisma: PrismaClient;
+
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: process.env.DATABASE_URL,
+      },
+    },
+    // 프로덕션 환경에서의 연결 풀 최적화 설정
+    // log: ["query", "info", "warn", "error"], // 필요시 로그 활성화
+  });
+} else {
+  // 개발 환경에서 HMR 시 연결이 누적되지 않도록 global 변수 사용
+  if (!(global as any).prisma) {
+    (global as any).prisma = new PrismaClient({
+      // log: ["query", "info", "warn", "error"], // 개발 시 디버깅용
+    });
+  }
+  prisma = (global as any).prisma;
+}
 
 // 리뷰생성 Prisma 미들웨어 등록
 prisma.$use(reviewPrismaMiddleware);

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -1,11 +1,6 @@
-import { AuthProvider, PrismaClient } from "@prisma/client";
-import {
-  TSocialSignupInput,
-  TUserRole,
-  TUserSignup,
-} from "../types/user.types";
-
-const prisma = new PrismaClient();
+import { AuthProvider } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
+import { TSocialSignupInput, TUserRole, TUserSignup } from "../types/user.types";
 
 // 유저 생성
 const createUser = async (user: TUserSignup) => {
@@ -73,11 +68,7 @@ const findUserByEmail = async (email: string) => {
 };
 
 // 로그인에 따른 유저 토큰 업데이트
-const updateUserToken = async (
-  userId: string,
-  refreshToken: string | null,
-  userType?: TUserRole[]
-) => {
+const updateUserToken = async (userId: string, refreshToken: string | null, userType?: TUserRole[]) => {
   return await prisma.user.update({
     where: { id: userId },
     data: { refreshToken, userType },
@@ -97,7 +88,7 @@ const updateUser = async (
   provider: AuthProvider,
   providerId: string,
   userType?: TUserRole[],
-  name?: string
+  name?: string,
 ) => {
   return await prisma.user.update({
     where: { id: userId },

--- a/src/repositories/customerEstimateRequest.repository.ts
+++ b/src/repositories/customerEstimateRequest.repository.ts
@@ -1,17 +1,7 @@
-import {
-  EstimateRequest,
-  Estimate,
-  User,
-  EstimateStatus,
-} from "@prisma/client";
-import { PrismaClient } from "@prisma/client";
-import {
-  SingleEstimateRequestWithRelations,
-  MultipleEstimateRequestWithRelations,
-} from "../types/repository.types";
+import { EstimateRequest, Estimate, User, EstimateStatus } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
+import { SingleEstimateRequestWithRelations, MultipleEstimateRequestWithRelations } from "../types/repository.types";
 import { RepositoryQueryError } from "../types/errors.types";
-
-const prisma = new PrismaClient();
 
 const customerEstimateRequestRepository = {
   // 활성상태인 견적 아이디 조회 (미래 이사일만)
@@ -33,10 +23,7 @@ const customerEstimateRequestRepository = {
       if (!EstimateRequest) return null;
       return EstimateRequest.id;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `사용자 ${userId}의 활성 견적요청 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`사용자 ${userId}의 활성 견적요청 조회 실패`, error);
     }
   },
 
@@ -59,7 +46,7 @@ const customerEstimateRequestRepository = {
   // 진행중인 이사 견적들 조회
   getPendingEstimateRequest: async (
     activeEstimateRequestId: string,
-    userId: string
+    userId: string,
   ): Promise<SingleEstimateRequestWithRelations> => {
     try {
       const pendingEstimateRequest = await prisma.estimateRequest.findFirst({
@@ -160,15 +147,13 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `진행중인 견적요청 조회 실패 - 활성ID: ${activeEstimateRequestId}, 사용자ID: ${userId}`,
-        error
+        error,
       );
     }
   },
 
   // 완료된 견적요청 목록 조회
-  getReceivedEstimateRequests: async (
-    userId: string
-  ): Promise<MultipleEstimateRequestWithRelations> => {
+  getReceivedEstimateRequests: async (userId: string): Promise<MultipleEstimateRequestWithRelations> => {
     try {
       const receivedEstimateRequests = await prisma.estimateRequest.findMany({
         where: {
@@ -267,27 +252,19 @@ const customerEstimateRequestRepository = {
       // Repository는 순수 데이터만 반환
       return receivedEstimateRequests;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `사용자 ${userId}의 완료된 견적요청 목록 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`사용자 ${userId}의 완료된 견적요청 목록 조회 실패`, error);
     }
   },
 
   // 견적요청 ID로 견적요청 조회
-  getEstimateRequestById: async (
-    estimateRequestId: string
-  ): Promise<EstimateRequest | null> => {
+  getEstimateRequestById: async (estimateRequestId: string): Promise<EstimateRequest | null> => {
     try {
       const estimateRequest = await prisma.estimateRequest.findUnique({
         where: { id: estimateRequestId },
       });
       return estimateRequest;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적요청 ID ${estimateRequestId} 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`견적요청 ID ${estimateRequestId} 조회 실패`, error);
     }
   },
 
@@ -304,10 +281,7 @@ const customerEstimateRequestRepository = {
   },
 
   // 견적 ID와 견적요청 ID로 견적 조회
-  getEstimateByIdAndRequestId: async (
-    estimateId: string,
-    estimateRequestId: string
-  ): Promise<Estimate | null> => {
+  getEstimateByIdAndRequestId: async (estimateId: string, estimateRequestId: string): Promise<Estimate | null> => {
     try {
       const estimate = await prisma.estimate.findUnique({
         where: {
@@ -324,7 +298,7 @@ const customerEstimateRequestRepository = {
   // 견적요청 상태 업데이트
   updateEstimateRequestStatus: async (
     estimateRequestId: string,
-    status: "PENDING" | "APPROVED" | "COMPLETED" | "EXPIRED"
+    status: "PENDING" | "APPROVED" | "COMPLETED" | "EXPIRED",
   ): Promise<EstimateRequest> => {
     try {
       const updatedEstimateRequest = await prisma.estimateRequest.update({
@@ -335,16 +309,13 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `견적요청 상태 업데이트 실패 - 견적요청ID: ${estimateRequestId}, 상태: ${status}`,
-        error
+        error,
       );
     }
   },
 
   // 견적 상태 업데이트
-  updateEstimateStatus: async (
-    estimateId: string,
-    status: EstimateStatus
-  ): Promise<Estimate> => {
+  updateEstimateStatus: async (estimateId: string, status: EstimateStatus): Promise<Estimate> => {
     try {
       const updatedEstimate = await prisma.estimate.update({
         where: { id: estimateId },
@@ -352,10 +323,7 @@ const customerEstimateRequestRepository = {
       });
       return updatedEstimate;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적 상태 업데이트 실패 - 견적ID: ${estimateId}, 상태: ${status}`,
-        error
-      );
+      throw new RepositoryQueryError(`견적 상태 업데이트 실패 - 견적ID: ${estimateId}, 상태: ${status}`, error);
     }
   },
 
@@ -363,7 +331,7 @@ const customerEstimateRequestRepository = {
   updateAllEstimatesStatus: async (
     estimateRequestId: string,
     status: EstimateStatus,
-    excludeEstimateId?: string
+    excludeEstimateId?: string,
   ): Promise<void> => {
     try {
       await prisma.estimate.updateMany({
@@ -376,7 +344,7 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `견적 일괄 상태 업데이트 실패 - 견적요청ID: ${estimateRequestId}, 상태: ${status}`,
-        error
+        error,
       );
     }
   },
@@ -417,18 +385,12 @@ const customerEstimateRequestRepository = {
       });
       return estimate;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적 상세 정보 조회 실패 - 견적ID: ${estimateId}`,
-        error
-      );
+      throw new RepositoryQueryError(`견적 상세 정보 조회 실패 - 견적ID: ${estimateId}`, error);
     }
   },
 
   // 다른 견적들 조회 (확정 시 반려용)
-  getOtherEstimates: async (
-    estimateRequestId: string,
-    excludeEstimateId: string
-  ) => {
+  getOtherEstimates: async (estimateRequestId: string, excludeEstimateId: string) => {
     try {
       const otherEstimates = await prisma.estimate.findMany({
         where: {
@@ -447,16 +409,13 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `다른 견적들 조회 실패 - 견적요청ID: ${estimateRequestId}, 제외견적ID: ${excludeEstimateId}`,
-        error
+        error,
       );
     }
   },
 
   // AUTO_REJECTED된 견적들 조회 (액션 생성용)
-  getAutoRejectedEstimates: async (
-    estimateRequestId: string,
-    excludeEstimateId: string
-  ) => {
+  getAutoRejectedEstimates: async (estimateRequestId: string, excludeEstimateId: string) => {
     try {
       const autoRejectedEstimates = await prisma.estimate.findMany({
         where: {
@@ -475,7 +434,7 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `AUTO_REJECTED 견적들 조회 실패 - 견적요청ID: ${estimateRequestId}, 제외견적ID: ${excludeEstimateId}`,
-        error
+        error,
       );
     }
   },

--- a/src/repositories/estimateRequest.repository.ts
+++ b/src/repositories/estimateRequest.repository.ts
@@ -1,4 +1,5 @@
-import { PrismaClient, RequestStatus, EstimateRequest, UserType, MoveType, RegionType } from "@prisma/client";
+import { RequestStatus, EstimateRequest, UserType, MoveType, RegionType } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
 import { getCurrentDateString } from "../utils/dateUtils";
 import {
   IParsedAddressData,
@@ -7,8 +8,6 @@ import {
   TUpdateEstimateRequestData,
   IUserTypeResult,
 } from "../types/estimateRequest.types";
-
-const prisma = new PrismaClient();
 
 const createEstimateRequest = async (data: TCreateEstimateRequestData, userId: string): Promise<EstimateRequest> => {
   return await prisma.estimateRequest.create({

--- a/src/repositories/favorite.repository.ts
+++ b/src/repositories/favorite.repository.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../db/prisma/prisma";
 
 // 찜하기 추가
 const addFavorite = async (customerId: string, moverId: string) => {

--- a/src/repositories/mover.repository.ts
+++ b/src/repositories/mover.repository.ts
@@ -1,22 +1,11 @@
-import { PrismaClient } from "@prisma/client";
-import type {
-  MoverListFilter,
-  DesignatedQuoteRequestDto,
-} from "../types/mover.types";
-const prisma = new PrismaClient();
+import prisma from "../db/prisma/prisma";
+import type { MoverListFilter, DesignatedQuoteRequestDto } from "../types/mover.types";
 
 /**
  * 기사님 리스트 조회
  */
 export const getMoverList = async (filter: MoverListFilter) => {
-  const {
-    region,
-    serviceType,
-    search,
-    sort = "review",
-    cursor,
-    take = 2,
-  } = filter;
+  const { region, serviceType, search, sort = "review", cursor, take = 2 } = filter;
 
   const getServiceTypeEnum = (serviceTypeId: string | number) => {
     const id = Number(serviceTypeId);
@@ -96,13 +85,9 @@ export const getMoverList = async (filter: MoverListFilter) => {
   } else if (sort === "confirmed") {
     sortedMovers.sort((a, b) => (b.workedCount || 0) - (a.workedCount || 0));
   } else if (sort === "rating") {
-    sortedMovers.sort(
-      (a, b) => (b.averageRating || 0) - (a.averageRating || 0)
-    );
+    sortedMovers.sort((a, b) => (b.averageRating || 0) - (a.averageRating || 0));
   } else if (sort === "review") {
-    sortedMovers.sort(
-      (a, b) => (b.totalReviewCount || 0) - (a.totalReviewCount || 0)
-    );
+    sortedMovers.sort((a, b) => (b.totalReviewCount || 0) - (a.totalReviewCount || 0));
   }
 
   const hasNext = sortedMovers.length > take;
@@ -162,9 +147,7 @@ export const getMoverDetail = async (id: string, userId?: string) => {
 
   if (!mover) return null;
 
-  const favoriteCount = mover.Favorite.filter(
-    (fav) => fav.deletedAt === null
-  ).length;
+  const favoriteCount = mover.Favorite.filter((fav) => fav.deletedAt === null).length;
 
   let isFavorited = false;
   if (userId) {
@@ -217,9 +200,7 @@ export const getFavoriteMovers = async (customerId: string) => {
   return favorites.map((fav) => {
     const mover = fav.mover;
     // 찜 개수 계산 (deletedAt이 null이 아닌 것 제외)
-    const favoriteCount = mover.Favorite.filter(
-      (fav) => fav.deletedAt === null
-    ).length;
+    const favoriteCount = mover.Favorite.filter((fav) => fav.deletedAt === null).length;
 
     return {
       ...mover,
@@ -231,9 +212,7 @@ export const getFavoriteMovers = async (customerId: string) => {
 /**
  * 지정 견적 요청 생성
  */
-export const createDesignatedEstimateRequest = async (
-  dto: DesignatedQuoteRequestDto
-) => {
+export const createDesignatedEstimateRequest = async (dto: DesignatedQuoteRequestDto) => {
   const { quoteId, moverId, message, expiresAt } = dto;
   const exists = await prisma.designatedMover.findFirst({
     where: { estimateRequestId: quoteId, moverId },
@@ -252,10 +231,7 @@ export const createDesignatedEstimateRequest = async (
 /**
  * 지정 견적 요청 여부 조회
  */
-export const checkDesignatedEstimateRequest = async (params: {
-  quoteId: string;
-  moverId: string;
-}) => {
+export const checkDesignatedEstimateRequest = async (params: { quoteId: string; moverId: string }) => {
   const { quoteId, moverId } = params;
   return await prisma.designatedMover.findFirst({
     where: {

--- a/src/repositories/moverEstimate.repository.ts
+++ b/src/repositories/moverEstimate.repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
 import {
   EstimateWithRelations,
   TMyEstimateResponse,
@@ -67,7 +67,7 @@ const createPrismaOrderBy = (orderBy: PrismaOrderBy) => {
   return orderBy as any; // Prisma 타입과 호환성을 위해 임시로 any 사용
 };
 
-const prisma = new PrismaClient();
+// Prisma 클라이언트는 상단에서 import
 
 // 공통 select 옵션 - EstimateRequest용
 const estimateRequestSelectOptions = {
@@ -269,7 +269,7 @@ const moverEstimateRepository = {
     price: number,
     comment: string,
     status: "PROPOSED" | "REJECTED",
-    isDesignated: boolean
+    isDesignated: boolean,
   ): Promise<EstimateWithRelations | null> => {
     try {
       // 파라미터 검증
@@ -285,11 +285,7 @@ const moverEstimateRepository = {
         throw new RepositoryQueryError("유효하지 않은 가격입니다");
       }
 
-      if (
-        !comment ||
-        typeof comment !== "string" ||
-        comment.trim().length === 0
-      ) {
+      if (!comment || typeof comment !== "string" || comment.trim().length === 0) {
         throw new RepositoryQueryError("유효하지 않은 코멘트입니다");
       }
 
@@ -337,7 +333,7 @@ const moverEstimateRepository = {
     sortBy?: "moveDate" | "createdAt",
     customerName?: string,
     movingType?: "SMALL" | "HOME" | "OFFICE",
-    currentAreas?: string[]
+    currentAreas?: string[],
   ): Promise<TEstimateRequestResponse[]> => {
     try {
       let orderBy: PrismaOrderBy = {};
@@ -410,7 +406,7 @@ const moverEstimateRepository = {
             ...estimateRequest,
             isDesignated: !!designatedRequest,
           };
-        })
+        }),
       );
 
       return estimateRequestsWithDesignatedFlag;
@@ -424,7 +420,7 @@ const moverEstimateRepository = {
     moverId: string,
     sortBy?: "moveDate" | "createdAt",
     customerName?: string,
-    movingType?: "SMALL" | "HOME" | "OFFICE"
+    movingType?: "SMALL" | "HOME" | "OFFICE",
   ): Promise<TEstimateRequestResponse[]> => {
     try {
       let orderBy: PrismaOrderBy = {};
@@ -549,7 +545,7 @@ const moverEstimateRepository = {
             ...estimate,
             isDesignated: !!designatedRequest,
           };
-        })
+        }),
       );
 
       return estimatesWithDesignatedFlag as TMyEstimateResponse[];
@@ -559,9 +555,7 @@ const moverEstimateRepository = {
   },
 
   // 내가 반려한 견적들 조회
-  getMyRejectedEstimates: async (
-    moverId: string
-  ): Promise<TMyRejectedEstimateResponse[]> => {
+  getMyRejectedEstimates: async (moverId: string): Promise<TMyRejectedEstimateResponse[]> => {
     try {
       const rejectedEstimates = await prisma.estimate.findMany({
         where: {
@@ -589,7 +583,7 @@ const moverEstimateRepository = {
             ...estimate,
             isDesignated: !!designatedRequest,
           };
-        })
+        }),
       );
 
       return estimatesWithDesignatedFlag as TMyRejectedEstimateResponse[];
@@ -599,10 +593,7 @@ const moverEstimateRepository = {
   },
 
   // 견적 존재 여부 및 권한 확인
-  checkEstimateOwnership: async (
-    estimateId: string,
-    moverId: string
-  ): Promise<boolean> => {
+  checkEstimateOwnership: async (estimateId: string, moverId: string): Promise<boolean> => {
     try {
       const estimate = await prisma.estimate.findUnique({
         where: {
@@ -619,7 +610,7 @@ const moverEstimateRepository = {
   // 견적 상태 업데이트 (순수 데이터 업데이트)
   updateEstimateStatus: async (
     estimateId: string,
-    status: "PROPOSED" | "ACCEPTED" | "REJECTED" | "AUTO_REJECTED"
+    status: "PROPOSED" | "ACCEPTED" | "REJECTED" | "AUTO_REJECTED",
   ): Promise<EstimateWithRelations | null> => {
     try {
       const estimate = await prisma.estimate.update({
@@ -641,7 +632,7 @@ const moverEstimateRepository = {
   updateEstimatePrice: async (
     estimateId: string,
     price: number,
-    comment: string
+    comment: string,
   ): Promise<EstimateWithRelations | null> => {
     try {
       const estimate = await prisma.estimate.update({

--- a/src/repositories/moverSchedule.repository.ts
+++ b/src/repositories/moverSchedule.repository.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
 import { TMoverScheduleWithDetails } from "../types/moverSchedule";
 import { RepositoryQueryError } from "../types/errors.types";
-
-const prisma = new PrismaClient();
 
 const moverScheduleRepository = {
   // 월별 스케줄 조회 (캘린더용)

--- a/src/repositories/review.repository.ts
+++ b/src/repositories/review.repository.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../db/prisma/prisma";
 
 // 리뷰 상세 정보 조회 (액션 메타데이터용)
 const getReviewDetailForAction = async (reviewId: string) => {
@@ -33,10 +31,7 @@ const reviewRepository = {
   },
 
   // 2. 리뷰 작성 가능한 견적 요청 리스트 조회
-  getWritableEstimateRequests: async (
-    customerId: string,
-    pageQuery: { page: number; pageSize: number }
-  ) => {
+  getWritableEstimateRequests: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
@@ -72,10 +67,7 @@ const reviewRepository = {
   },
 
   // 3. 내가 쓴 리뷰 목록 조회
-  getWrittenReviews: async (
-    customerId: string,
-    pageQuery: { page: number; pageSize: number }
-  ) => {
+  getWrittenReviews: async (customerId: string, pageQuery: { page: number; pageSize: number }) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
     const [items, total] = await Promise.all([
@@ -100,10 +92,7 @@ const reviewRepository = {
   },
 
   // 4. 내가 받은 리뷰 목록 조회
-  getReceivedReviews: async (
-    moverId: string,
-    pageQuery: { page: number; pageSize: number }
-  ) => {
+  getReceivedReviews: async (moverId: string, pageQuery: { page: number; pageSize: number }) => {
     const { page, pageSize } = pageQuery;
     const skip = (page - 1) * pageSize;
 

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import prisma from "../db/prisma/prisma";
 import {
   TCreateMoverProfile,
   TCreateCustomerProfile,
@@ -9,8 +9,6 @@ import {
   TCustomerProfileUpdate,
   TMoverProfileUpdateInput,
 } from "../types/user.types";
-
-const prisma = new PrismaClient();
 
 // 사용자 정보 조회
 const getUserById = async (userId: string) => {
@@ -113,10 +111,7 @@ const createCustomerProfile = async (profileData: TCreateCustomerProfile) => {
 };
 
 // 일반 유저(CUSTOMER) 프로필 수정
-const updateCustomerProfile = async (
-  userId: string,
-  updateData: TCustomerProfileUpdate
-) => {
+const updateCustomerProfile = async (userId: string, updateData: TCustomerProfileUpdate) => {
   return await prisma.user.update({
     where: { id: userId },
     data: updateData,
@@ -161,10 +156,7 @@ const createMoverProfile = async (profileData: TCreateMoverProfile) => {
 };
 
 // 기사님 프로필 수정
-const updateMoverProfile = async (
-  userId: string,
-  updateData: TMoverProfileUpdateInput
-) => {
+const updateMoverProfile = async (userId: string, updateData: TMoverProfileUpdateInput) => {
   // currentAreas 배열을 그대로 사용
   const data = {
     ...updateData,
@@ -193,10 +185,7 @@ const updateMoverProfile = async (
 };
 
 // 닉네임 중복 확인
-const checkNicknameExists = async (
-  nickname: string,
-  excludeUserId?: string
-) => {
+const checkNicknameExists = async (nickname: string, excludeUserId?: string) => {
   const user = await prisma.user.findUnique({
     where: {
       nickname,
@@ -207,11 +196,7 @@ const checkNicknameExists = async (
 };
 
 // 사용자 프로필 업데이트
-const updateUserProfile = async (
-  userId: string,
-  updateData: TUpdateUserProfile,
-  serviceIds?: TServiceId[]
-) => {
+const updateUserProfile = async (userId: string, updateData: TUpdateUserProfile, serviceIds?: TServiceId[]) => {
   // 업데이트할 데이터 준비
   const updateFields: any = {};
 

--- a/src/services/expiration.service.ts
+++ b/src/services/expiration.service.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../db/prisma/prisma";
 
 const expirationService = {
   // 만료된 견적 요청 처리
@@ -49,7 +47,7 @@ const expirationService = {
             });
 
             console.log(
-              `🔄 [만료] 견적 요청 ${request.id} (${request.customer.name}님, 이사일: ${request.moveDate.toLocaleDateString()}) - 견적 ${updatedEstimates.count}개를 AUTO_REJECTED로 변경`
+              `🔄 [만료] 견적 요청 ${request.id} (${request.customer.name}님, 이사일: ${request.moveDate.toLocaleDateString()}) - 견적 ${updatedEstimates.count}개를 AUTO_REJECTED로 변경`,
             );
           });
         }
@@ -168,9 +166,7 @@ const expirationService = {
         });
 
         orphanedCount = updatedOrphanedEstimates.count;
-        console.log(
-          `🧹 [정리] 삭제/취소된 견적 요청의 orphaned 견적 ${orphanedCount}개를 AUTO_REJECTED로 변경`
-        );
+        console.log(`🧹 [정리] 삭제/취소된 견적 요청의 orphaned 견적 ${orphanedCount}개를 AUTO_REJECTED로 변경`);
       }
 
       if (totalProcessed === 0 && orphanedCount === 0) {

--- a/src/types/customerEstimateRequest.ts
+++ b/src/types/customerEstimateRequest.ts
@@ -1,9 +1,4 @@
-import {
-  EstimateRequest,
-  Estimate,
-  User,
-  DesignatedMover,
-} from "@prisma/client";
+import { EstimateRequest, Estimate, User, DesignatedMover } from "@prisma/client";
 
 // 진행중인 견적 응답 타입
 export type TPendingQuoteResponse = {
@@ -59,7 +54,7 @@ export type TEstimateResponse = {
 
 export type TMoverInfo = {
   id: string;
-  name: string;
+  name: string | null;
   userType: string[];
   moverImage: string | null;
   nickname: string | null;


### PR DESCRIPTION
## ✨ 작업 개요

- 트래픽으로 서버 다운 HOTFIX

## ✅ 주요 작업 내용

- 단일 프리즈마 클라이언트 인스턴스 사용으로 메모리 사용량 감소

## 🔄 관련 이슈

HOTFIX

## 📎 참고 자료 (선택)
<img width="551" height="434" alt="image" src="https://github.com/user-attachments/assets/a93c7f12-66e2-439a-b0a9-6bd07a894e3e" />


## 🧪 테스트 방법 (선택)



## 📝 비고
- 임시 방편으로 ec2에서 rds 연결하는 env에 파라미터 connection_limit=5: 최대 커넥션 수를 5개로 제한 (기본값: 무제한)
pool_timeout=20: 커넥션 풀에서 커넥션을 기다리는 시간 (20초) 로 해결했고 정확한 원인 해결을 위해 단일 프리즈마 클라이언트 사용으로 변경 

