### PR TITLE
fix:견적 요청에서 proosed 상태의 견적만 관리, 스케줄 유틸에서 region과 city 둘 다 사용

### DIFF
--- a/src/middlewares/translationMiddleware.ts
+++ b/src/middlewares/translationMiddleware.ts
@@ -37,18 +37,7 @@ interface TranslationOptions {
  */
 export function translationMiddleware(options: TranslationOptions = {}) {
   const {
-    excludeKeys = [
-      "id",
-      "uuid",
-      "createdAt",
-      "updatedAt",
-      "email",
-      "phone",
-      "url",
-      "link",
-      "name",
-      "nickname",
-    ],
+    excludeKeys = ["id", "uuid", "createdAt", "updatedAt", "email", "phone", "url", "link", "name", "nickname"],
     shouldTranslate,
     enableLogging = true,
   } = options;
@@ -58,19 +47,8 @@ export function translationMiddleware(options: TranslationOptions = {}) {
       // 쿼리 파라미터에서 언어 코드 추출
       const targetLang = req.query.lang as string;
 
-      console.log(
-        `[Translation Debug] Request: ${req.method} ${req.path}, lang: ${targetLang}`
-      );
-
       // 번역이 필요하지 않은 경우
-      if (
-        !targetLang ||
-        targetLang === "ko" ||
-        !translationService.isLanguageSupported(targetLang)
-      ) {
-        console.log(
-          `[Translation Debug] Skipping translation - lang: ${targetLang}, supported: ${translationService.isLanguageSupported(targetLang)}`
-        );
+      if (!targetLang || targetLang === "ko" || !translationService.isLanguageSupported(targetLang)) {
         return next();
       }
 
@@ -88,9 +66,6 @@ export function translationMiddleware(options: TranslationOptions = {}) {
         const startTime = Date.now();
 
         // 비동기 번역 처리
-        console.log(
-          `[Translation Debug] Starting translation for ${targetLang}`
-        );
         translationService
           .translateObject(data, targetLang, excludeKeys)
           .then((translatedData) => {
@@ -98,14 +73,9 @@ export function translationMiddleware(options: TranslationOptions = {}) {
             const translationTime = Date.now() - startTime;
 
             if (enableLogging) {
-              console.log(
-                `[Translation] ${req.method} ${req.path} -> ${targetLang} (${translationTime}ms)`
-              );
+              console.log(`[Translation] ${req.method} ${req.path} -> ${targetLang} (${translationTime}ms)`);
             }
 
-            console.log(
-              `[Translation Debug] Translation completed, original: ${JSON.stringify(data).substring(0, 100)}..., translated: ${JSON.stringify(translatedData).substring(0, 100)}...`
-            );
             // 번역된 데이터로 응답
             originalJson(translatedData);
           })
@@ -141,9 +111,7 @@ export const defaultTranslationMiddleware = translationMiddleware();
 /**
  * 특정 키들을 추가로 제외하는 번역 미들웨어
  */
-export function createCustomTranslationMiddleware(
-  additionalExcludeKeys: string[] = []
-) {
+export function createCustomTranslationMiddleware(additionalExcludeKeys: string[] = []) {
   const defaultExcludeKeys = [
     "id",
     "uuid",

--- a/src/repositories/estimateRequest.repository.ts
+++ b/src/repositories/estimateRequest.repository.ts
@@ -213,6 +213,7 @@ const hasEstimateFromMover = async (userId: string): Promise<boolean> => {
   const estimate = await prisma.estimate.findFirst({
     where: {
       estimateRequestId: request.id,
+      status: "PROPOSED", // PROPOSED 상태의 견적만 유효한 견적으로 인식
       deletedAt: null,
     },
   });

--- a/src/utils/scheduleUtils.ts
+++ b/src/utils/scheduleUtils.ts
@@ -49,10 +49,13 @@ export const validateScheduleInput = (moverId: string, year: number, month: numb
 export const formatAddressForTranslation = (address: AddressFormatInput): string => {
   const parts: string[] = [];
 
-  // 리전 (시/도) - region이 있으면 region을 사용, 없으면 city 사용
+  // 리전 (시/도)
   if (address.region) {
     parts.push(convertRegionToKorean(address.region));
-  } else if (address.city) {
+  }
+
+  // 시/군
+  if (address.city) {
     parts.push(address.city);
   }
 


### PR DESCRIPTION
## ✨ 작업 개요

- 견적 요청에서 proposed 상태만 관리
- 스케줄 유틸에서 region과 city 둘 다 사용
- 번역 미들웨어에서 콘솔 제거

## ✅ 주요 작업 내용

- 견적 요청에서 proposed 상태만 관리
- 스케줄 유틸에서 region과 city 둘 다 사용
- 번역 미들웨어에서 콘솔 제거
- 
## 🔄 관련 이슈

## 📎 참고 자료 (선택)

- API 명세서: [링크]

## 📝 비고

- 