### PR TITLE
[#248] test : auth 관련 테스트 코드 커버리지 개선 작업

### DIFF
--- a/src/controllers/auth.controller.test.ts
+++ b/src/controllers/auth.controller.test.ts
@@ -1,0 +1,600 @@
+import { Request, Response } from "express";
+import authService from "../services/auth.service";
+import { handleError } from "../utils/handleError";
+import {
+  getGoogleCallback,
+  getKakaoCallback,
+  getNaverCallback,
+  postLogout,
+  postRefresh,
+  postSignin,
+  postSignup,
+  postSwitchRole,
+} from "./auth.controller";
+import { TUserRole } from "../types/user.types";
+
+jest.mock("../services/auth.service");
+jest.mock("../utils/handleError");
+
+describe("로그인 컨트롤러", () => {
+  const mockSignin = authService.signin as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    body: {
+      email: "test@example.com",
+      password: "password123",
+      userType: "CUSTOMER",
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 로그인 성공 시 쿠키와 응답 반환", async () => {
+    // setup
+    const fakeUser = {
+      id: 1,
+      userName: "홍길동",
+      userType: "CUSTOMER",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    };
+
+    mockSignin.mockResolvedValue(fakeUser);
+
+    // exercise
+    await postSignin(mockReq, mockRes);
+
+    // assertion
+    expect(mockSignin).toHaveBeenCalledWith(
+      "test@example.com",
+      "password123",
+      "CUSTOMER"
+    );
+    expect(mockRes.cookie).toHaveBeenCalledTimes(2);
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "로그인 성공",
+      user: {
+        id: 1,
+        userName: "홍길동",
+        userType: "CUSTOMER",
+      },
+    });
+  });
+
+  it("❌ 로그인 실패 시 handleError 호출", async () => {
+    // setup
+    const error = new Error("로그인 실패");
+    mockSignin.mockRejectedValue(error);
+
+    // exercise
+    await postSignin(mockReq, mockRes);
+
+    // assertion
+    expect(mockSignin).toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("회원가입 컨트롤러", () => {
+  const mockSignup = authService.signup as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    body: {
+      name: "홍길동",
+      email: "hong@test.com",
+      phoneNumber: "01012345678",
+      password: "1234abcd!",
+      userType: "CUSTOMER",
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 회원가입 성공 시 쿠키 설정 및 200 응답 반환", async () => {
+    const fakeUser = {
+      id: 100,
+      userName: "홍길동",
+      userType: "CUSTOMER",
+      accessToken: "mock-access-token",
+      refreshToken: "mock-refresh-token",
+    };
+
+    mockSignup.mockResolvedValue(fakeUser);
+
+    await postSignup(mockReq, mockRes);
+
+    expect(mockSignup).toHaveBeenCalledWith({
+      name: "홍길동",
+      email: "hong@test.com",
+      phoneNumber: "01012345678",
+      password: "1234abcd!",
+      userType: "CUSTOMER",
+    });
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "accessToken",
+      "mock-access-token",
+      expect.objectContaining({ httpOnly: false }) // 실제 옵션 타입 매칭
+    );
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "refreshToken",
+      "mock-refresh-token",
+      expect.objectContaining({ httpOnly: true })
+    );
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "회원가입 성공",
+      user: {
+        id: 100,
+        name: "홍길동",
+        userType: "CUSTOMER",
+      },
+    });
+  });
+
+  it("❌ 회원가입 실패 시 handleError 호출", async () => {
+    const error = new Error("회원가입 실패");
+    mockSignup.mockRejectedValue(error);
+
+    await postSignup(mockReq, mockRes);
+
+    expect(mockSignup).toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("로그아웃 컨트롤러", () => {
+  const mockLogout = authService.logout as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    user: {
+      userId: "user-123",
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    clearCookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 로그아웃 성공 시 쿠키 삭제 및 200 반환", async () => {
+    mockLogout.mockResolvedValue(undefined); // 반환 없음
+
+    await postLogout(mockReq, mockRes);
+
+    expect(mockLogout).toHaveBeenCalledWith("user-123");
+
+    expect(mockRes.clearCookie).toHaveBeenCalledWith(
+      "accessToken",
+      expect.objectContaining({ maxAge: 0 })
+    );
+    expect(mockRes.clearCookie).toHaveBeenCalledWith(
+      "refreshToken",
+      expect.objectContaining({ maxAge: 0 })
+    );
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "로그아웃 성공",
+    });
+  });
+
+  it("❌ 로그아웃 실패 시 handleError 호출", async () => {
+    const error = new Error("로그아웃 실패");
+    mockLogout.mockRejectedValue(error);
+
+    await postLogout(mockReq, mockRes);
+
+    expect(mockLogout).toHaveBeenCalledWith("user-123");
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("역할 변경 컨트롤러", () => {
+  const mockSwitchRole = authService.switchRole as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    user: {
+      userId: "user-123",
+      userType: "CUSTOMER" as TUserRole,
+    },
+    body: {
+      userType: "MOVER" as TUserRole,
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 역할 변경 성공 시 토큰 설정 및 응답 반환", async () => {
+    mockSwitchRole.mockResolvedValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      provider: "LOCAL",
+    });
+
+    await postSwitchRole(mockReq, mockRes);
+
+    expect(mockSwitchRole).toHaveBeenCalledWith("user-123", "MOVER");
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "accessToken",
+      "new-access-token",
+      expect.objectContaining({ httpOnly: false })
+    );
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "refreshToken",
+      "new-refresh-token",
+      expect.objectContaining({ httpOnly: true })
+    );
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "역할 변경 성공",
+      oldUserType: "CUSTOMER",
+      newUserType: "MOVER",
+    });
+  });
+
+  it("❌ 역할 변경 실패 시 handleError 호출", async () => {
+    const error = new Error("역할 변경 실패");
+    mockSwitchRole.mockRejectedValue(error);
+
+    await postSwitchRole(mockReq, mockRes);
+
+    expect(mockSwitchRole).toHaveBeenCalledWith("user-123", "MOVER");
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("토큰 갱신 컨트롤러", () => {
+  const mockRefresh = authService.refresh as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    refreshToken: {
+      userId: "user-123",
+      userType: "CUSTOMER" as TUserRole,
+      exp: 9999999999,
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ accessToken만 갱신되는 경우", async () => {
+    mockRefresh.mockResolvedValue({
+      accessToken: "new-access-token",
+      refreshToken: undefined,
+    });
+
+    await postRefresh(mockReq, mockRes);
+
+    expect(mockRefresh).toHaveBeenCalledWith({
+      userId: "user-123",
+      userType: "CUSTOMER",
+      exp: 9999999999,
+    });
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "accessToken",
+      "new-access-token",
+      expect.objectContaining({ httpOnly: false })
+    );
+
+    expect(mockRes.cookie).toHaveBeenCalledTimes(1); // refreshToken 없음
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "토큰 갱신 성공",
+    });
+  });
+
+  it("✅ accessToken + refreshToken 모두 갱신되는 경우", async () => {
+    mockRefresh.mockResolvedValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+    });
+
+    await postRefresh(mockReq, mockRes);
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "accessToken",
+      "new-access-token",
+      expect.objectContaining({ httpOnly: false })
+    );
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "refreshToken",
+      "new-refresh-token",
+      expect.objectContaining({ httpOnly: true })
+    );
+
+    expect(mockRes.cookie).toHaveBeenCalledTimes(2);
+  });
+
+  it("❌ 갱신 실패 시 handleError 호출", async () => {
+    const error = new Error("리프레시 실패");
+    mockRefresh.mockRejectedValue(error);
+
+    await postRefresh(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("소셜 로그인 콜백 컨트롤러", () => {
+  beforeAll(() => {
+    // 로컬 테스트용
+    process.env.FRONTEND_URL = "http://localhost:3000";
+  });
+
+  describe("구글 로그인 콜백 컨트롤러", () => {
+    const baseUser = {
+      accessToken: "google-access-token",
+      refreshToken: "google-refresh-token",
+      userType: "CUSTOMER",
+    };
+
+    // ✅ Mock된 Request 생성기
+    const createMockReq = (user = baseUser): Request =>
+      ({ user }) as unknown as Request;
+
+    // ✅ Mock된 Response 생성기
+    const createMockRes = (): Response =>
+      ({
+        cookie: jest.fn(),
+        redirect: jest.fn(),
+      }) as unknown as Response;
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("✅ 로그인 성공 시 쿠키 설정 후 /로 리다이렉트", async () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getGoogleCallback(req, res);
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        "accessToken",
+        baseUser.accessToken,
+        expect.any(Object)
+      );
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        "refreshToken",
+        baseUser.refreshToken,
+        expect.any(Object)
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(`${process.env.FRONTEND_URL}/`);
+    });
+
+    it("❌ 쿠키 설정 실패 시 CUSTOMER → /userSignin 리다이렉트", async () => {
+      const req = createMockReq({ ...baseUser, userType: "CUSTOMER" });
+      const res = createMockRes();
+
+      res.cookie = jest.fn(() => {
+        throw new Error("쿠키 설정 실패");
+      });
+
+      await getGoogleCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringMatching(/\/userSignin\?/)
+      );
+    });
+
+    it("❌ 쿠키 설정 실패 시 MOVER → /moverSignin 리다이렉트", async () => {
+      const req = createMockReq({ ...baseUser, userType: "MOVER" });
+      const res = createMockRes();
+
+      res.cookie = jest.fn(() => {
+        throw new Error("쿠키 설정 실패");
+      });
+
+      await getGoogleCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringMatching(/\/moverSignin\?/)
+      );
+    });
+  });
+
+  describe("카카오 로그인 콜백 컨트롤러", () => {
+    const baseUser = {
+      accessToken: "kakao-access-token",
+      refreshToken: "kakao-refresh-token",
+      userType: "CUSTOMER",
+    };
+
+    // ✅ Mock된 Request 생성기
+    const createMockReq = (user = baseUser): Request =>
+      ({ user }) as unknown as Request;
+
+    // ✅ Mock된 Response 생성기
+    const createMockRes = (): Response =>
+      ({
+        cookie: jest.fn(),
+        redirect: jest.fn(),
+      }) as unknown as Response;
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("✅ 로그인 성공 시 쿠키 설정 후 /로 리다이렉트", async () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getKakaoCallback(req, res);
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        "accessToken",
+        baseUser.accessToken,
+        expect.any(Object)
+      );
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        "refreshToken",
+        baseUser.refreshToken,
+        expect.any(Object)
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(`${process.env.FRONTEND_URL}/`);
+    });
+
+    it("❌ 쿠키 설정 실패 시 CUSTOMER → /userSignin 리다이렉트", async () => {
+      const req = createMockReq({ ...baseUser, userType: "CUSTOMER" });
+      const res = createMockRes();
+
+      res.cookie = jest.fn(() => {
+        throw new Error("쿠키 설정 실패");
+      });
+
+      await getKakaoCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringMatching(/\/userSignin\?/)
+      );
+    });
+
+    it("❌ 쿠키 설정 실패 시 MOVER → /moverSignin 리다이렉트", async () => {
+      const req = createMockReq({ ...baseUser, userType: "MOVER" });
+      const res = createMockRes();
+
+      res.cookie = jest.fn(() => {
+        throw new Error("쿠키 설정 실패");
+      });
+
+      await getKakaoCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringMatching(/\/moverSignin\?/)
+      );
+    });
+  });
+
+  describe("네이버 로그인 콜백 컨트롤러", () => {
+    const baseUser = {
+      accessToken: "kakao-access-token",
+      refreshToken: "kakao-refresh-token",
+      userType: "CUSTOMER",
+    };
+
+    // ✅ Mock된 Request 생성기
+    const createMockReq = (user = baseUser): Request =>
+      ({ user }) as unknown as Request;
+
+    // ✅ Mock된 Response 생성기
+    const createMockRes = (): Response =>
+      ({
+        cookie: jest.fn(),
+        redirect: jest.fn(),
+      }) as unknown as Response;
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("✅ 로그인 성공 시 쿠키 설정 후 /로 리다이렉트", async () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getNaverCallback(req, res);
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        "accessToken",
+        baseUser.accessToken,
+        expect.any(Object)
+      );
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        "refreshToken",
+        baseUser.refreshToken,
+        expect.any(Object)
+      );
+
+      expect(res.redirect).toHaveBeenCalledWith(`${process.env.FRONTEND_URL}/`);
+    });
+
+    it("❌ 쿠키 설정 실패 시 CUSTOMER → /userSignin 리다이렉트", async () => {
+      const req = createMockReq({ ...baseUser, userType: "CUSTOMER" });
+      const res = createMockRes();
+
+      res.cookie = jest.fn(() => {
+        throw new Error("쿠키 설정 실패");
+      });
+
+      await getNaverCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringMatching(/\/userSignin\?/)
+      );
+    });
+
+    it("❌ 쿠키 설정 실패 시 MOVER → /moverSignin 리다이렉트", async () => {
+      const req = createMockReq({ ...baseUser, userType: "MOVER" });
+      const res = createMockRes();
+
+      res.cookie = jest.fn(() => {
+        throw new Error("쿠키 설정 실패");
+      });
+
+      await getNaverCallback(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringMatching(/\/moverSignin\?/)
+      );
+    });
+  });
+});

--- a/src/repositories/auth.repository.test.ts
+++ b/src/repositories/auth.repository.test.ts
@@ -1,0 +1,423 @@
+// auth.repository.test.ts
+import authRepository from "./auth.repository";
+import prisma from "../db/prisma/prisma";
+import { TUserRole } from "../types/user.types";
+import { AuthProvider } from "@prisma/client";
+
+jest.mock("../db/prisma/prisma", () => ({
+  __esModule: true,
+  default: {
+    user: {
+      update: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+describe("authRepository", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("createUser", () => {
+    it("✅ 유저 생성 시 DB에 저장된 유저 정보를 반환한다", async () => {
+      const mockUserInput = {
+        email: "test@example.com",
+        name: "홍길동",
+        encryptedPassword: "hashed_pw",
+        encryptedPhoneNumber: "encrypted_phone",
+        userType: "CUSTOMER" as TUserRole,
+      };
+
+      const mockCreatedUser = {
+        id: "1",
+        name: "홍길동",
+        userType: ["CUSTOMER"],
+        nickname: null,
+      };
+
+      (prisma.user.create as jest.Mock).mockResolvedValue(mockCreatedUser);
+
+      const result = await authRepository.createUser(mockUserInput);
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: {
+          email: mockUserInput.email,
+          name: mockUserInput.name,
+          encryptedPassword: mockUserInput.encryptedPassword,
+          encryptedPhoneNumber: mockUserInput.encryptedPhoneNumber,
+          userType: [mockUserInput.userType],
+        },
+        select: {
+          id: true,
+          name: true,
+          userType: true,
+          nickname: true,
+        },
+      });
+
+      expect(result).toEqual(mockCreatedUser);
+    });
+
+    it("❌ 유저 생성 시 오류가 발생하면 오류를 반환한다", async () => {
+      const mockUserInput = {
+        email: "test@example.com",
+        name: "홍길동",
+        encryptedPassword: "hashed_pw",
+        encryptedPhoneNumber: "encrypted_phone",
+        userType: "CUSTOMER" as TUserRole,
+      };
+
+      (prisma.user.create as jest.Mock).mockRejectedValue(
+        new Error("유저 생성 오류")
+      );
+
+      await expect(authRepository.createUser(mockUserInput)).rejects.toThrow(
+        "유저 생성 오류"
+      );
+    });
+  });
+
+  describe("createSocialUser", () => {
+    const mockUserInput = {
+      email: "social@example.com",
+      name: "김소셜",
+      userType: "MOVER" as TUserRole,
+      provider: AuthProvider.GOOGLE, // ✅ 여기를 수정
+      providerId: "google-12345",
+    };
+
+    const mockCreatedUser = {
+      id: "2",
+      name: "김소셜",
+      userType: ["MOVER"],
+      nickname: null,
+      provider: AuthProvider.GOOGLE,
+    };
+
+    it("✅ 소셜 유저 생성 시 DB에 저장된 유저 정보를 반환한다", async () => {
+      (prisma.user.create as jest.Mock).mockResolvedValue(mockCreatedUser);
+
+      const result = await authRepository.createSocialUser(mockUserInput);
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: {
+          email: mockUserInput.email,
+          name: mockUserInput.name,
+          userType: [mockUserInput.userType],
+          provider: mockUserInput.provider,
+          providerId: mockUserInput.providerId,
+        },
+        select: {
+          id: true,
+          name: true,
+          userType: true,
+          nickname: true,
+          provider: true,
+        },
+      });
+
+      expect(result).toEqual(mockCreatedUser);
+    });
+
+    it("❌ 소셜 유저 생성 시 오류가 발생하면 오류를 반환한다", async () => {
+      (prisma.user.create as jest.Mock).mockRejectedValue(
+        new Error("소셜 유저 생성 오류")
+      );
+
+      await expect(
+        authRepository.createSocialUser(mockUserInput)
+      ).rejects.toThrow("소셜 유저 생성 오류");
+    });
+  });
+
+  describe("findUserByEmailAndPassword", () => {
+    const mockEmail = "login@example.com";
+
+    const mockUser = {
+      id: "3",
+      name: "로그인유저",
+      userType: ["CUSTOMER"],
+      email: mockEmail,
+      encryptedPassword: "hashed_pw",
+      customerImage: "customer.jpg",
+      moverImage: "mover.jpg",
+      isCustomer: true,
+      isMover: false,
+      provider: AuthProvider.LOCAL,
+    };
+
+    it("✅ 이메일로 유저를 조회하면 유저 정보를 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const result = await authRepository.findUserByEmailAndPassword(mockEmail);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { email: mockEmail },
+        select: {
+          id: true,
+          name: true,
+          userType: true,
+          email: true,
+          encryptedPassword: true,
+          customerImage: true,
+          moverImage: true,
+          isCustomer: true,
+          isMover: true,
+          provider: true,
+        },
+      });
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("❌ 조회 결과가 없을 경우 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await authRepository.findUserByEmailAndPassword(mockEmail);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 조회 중 에러 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(
+        authRepository.findUserByEmailAndPassword(mockEmail)
+      ).rejects.toThrow("DB 오류");
+    });
+  });
+
+  describe("findUserByEmail", () => {
+    const mockEmail = "test@example.com";
+
+    const mockUser = {
+      id: "10",
+      email: mockEmail,
+      name: "홍길동",
+      userType: ["CUSTOMER"],
+      encryptedPassword: "hashed_pw",
+      refreshToken: null,
+      provider: AuthProvider.LOCAL,
+    };
+
+    it("✅ 이메일로 유저를 조회하면 유저 정보를 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const result = await authRepository.findUserByEmail(mockEmail);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { email: mockEmail },
+      });
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("❌ 해당 이메일의 유저가 없으면 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await authRepository.findUserByEmail(mockEmail);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(authRepository.findUserByEmail(mockEmail)).rejects.toThrow(
+        "DB 오류"
+      );
+    });
+  });
+
+  describe("updateUserToken", () => {
+    const userId = "123";
+    const refreshToken = "new-refresh-token";
+    const userType: TUserRole[] = ["CUSTOMER"];
+
+    const mockUpdatedUser = {
+      id: userId,
+      refreshToken,
+      userType,
+    };
+
+    it("✅ refreshToken과 userType을 모두 업데이트한다", async () => {
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUpdatedUser);
+
+      const result = await authRepository.updateUserToken(
+        userId,
+        refreshToken,
+        userType
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { refreshToken, userType },
+      });
+
+      expect(result).toEqual(mockUpdatedUser);
+    });
+
+    it("✅ userType이 없이 refreshToken만 업데이트할 수 있다", async () => {
+      const mockOnlyRefresh = {
+        id: userId,
+        refreshToken,
+        userType: undefined,
+      };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockOnlyRefresh);
+
+      const result = await authRepository.updateUserToken(userId, refreshToken);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { refreshToken, userType: undefined },
+      });
+
+      expect(result).toEqual(mockOnlyRefresh);
+    });
+
+    it("❌ DB 업데이트 실패 시 에러를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(
+        new Error("DB 업데이트 오류")
+      );
+
+      await expect(
+        authRepository.updateUserToken(userId, refreshToken, userType)
+      ).rejects.toThrow("DB 업데이트 오류");
+    });
+  });
+
+  describe("findUserById", () => {
+    const userId = "user-123";
+
+    const mockUser = {
+      id: userId,
+      email: "test@example.com",
+      name: "홍길동",
+      userType: ["CUSTOMER"],
+    };
+
+    it("✅ 유저 ID로 유저 정보를 조회한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const result = await authRepository.findUserById(userId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 에러를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 조회 실패")
+      );
+
+      await expect(authRepository.findUserById(userId)).rejects.toThrow(
+        "DB 조회 실패"
+      );
+    });
+  });
+
+  describe("updateUser", () => {
+    const userId = "user-456";
+    const provider = "GOOGLE" as AuthProvider;
+    const providerId = "google-123";
+    const userType = ["CUSTOMER"] as TUserRole[];
+
+    const baseSelect = {
+      id: true,
+      name: true,
+      userType: true,
+      nickname: true,
+      provider: true,
+      isCustomer: true,
+      isMover: true,
+    };
+
+    const mockUpdatedUser = {
+      id: userId,
+      name: "홍길동",
+      userType,
+      nickname: null,
+      provider,
+      isCustomer: true,
+      isMover: false,
+    };
+
+    it("✅ name이 있을 경우 유저 정보를 업데이트한다", async () => {
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUpdatedUser);
+
+      const result = await authRepository.updateUser(
+        userId,
+        provider,
+        providerId,
+        userType,
+        "홍길동"
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {
+          provider,
+          providerId,
+          userType,
+          name: "홍길동",
+        },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual(mockUpdatedUser);
+    });
+
+    it("✅ name이 없는 경우 유저 정보를 업데이트한다", async () => {
+      const updatedUserWithoutName = { ...mockUpdatedUser, name: undefined };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue(
+        updatedUserWithoutName
+      );
+
+      const result = await authRepository.updateUser(
+        userId,
+        provider,
+        providerId,
+        userType
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {
+          provider,
+          providerId,
+          userType,
+        },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual(updatedUserWithoutName);
+    });
+
+    it("❌ 업데이트 중 에러 발생 시 예외를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(
+        new Error("업데이트 실패")
+      );
+
+      await expect(
+        authRepository.updateUser(
+          userId,
+          provider,
+          providerId,
+          userType,
+          "홍길동"
+        )
+      ).rejects.toThrow("업데이트 실패");
+    });
+  });
+});

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -1,6 +1,10 @@
 import { AuthProvider } from "@prisma/client";
 import prisma from "../db/prisma/prisma";
-import { TSocialSignupInput, TUserRole, TUserSignup } from "../types/user.types";
+import {
+  TSocialSignupInput,
+  TUserRole,
+  TUserSignup,
+} from "../types/user.types";
 
 // 유저 생성
 const createUser = async (user: TUserSignup) => {
@@ -68,7 +72,11 @@ const findUserByEmail = async (email: string) => {
 };
 
 // 로그인에 따른 유저 토큰 업데이트
-const updateUserToken = async (userId: string, refreshToken: string | null, userType?: TUserRole[]) => {
+const updateUserToken = async (
+  userId: string,
+  refreshToken: string | null,
+  userType?: TUserRole[]
+) => {
   return await prisma.user.update({
     where: { id: userId },
     data: { refreshToken, userType },
@@ -88,7 +96,7 @@ const updateUser = async (
   provider: AuthProvider,
   providerId: string,
   userType?: TUserRole[],
-  name?: string,
+  name?: string
 ) => {
   return await prisma.user.update({
     where: { id: userId },


### PR DESCRIPTION
## ✨ 작업 개요
- `auth`에 대한 단위 테스트 커버리지를 개선하였습니다.

## ✅ 주요 작업 내용
- 로그인/회원가입/역할 전환 컨트롤러 테스트 추가
- 요청 body/쿼리 유효성, 응답 포맷, 예외 응답 확인
- 유저 조회/생성/토큰 업데이트 로직 테스트 케이스 추가
- DB 오류 및 null 반환 상황에 대한 예외 처리 테스트 포함
- `jest.mock`으로 Prisma 인스턴스를 부분 목(mock) 처리하여 테스트 환경 구성

## 🔄 관련 이슈

Closes #248

## 📎 참고 자료 (선택)
### 컨트롤러
<img width="1903" height="41" alt="auth" src="https://github.com/user-attachments/assets/cd4b156f-57fb-44b6-929a-a1188e4e43ec" />

### 서비스
<img width="1907" height="42" alt="auth 서비스" src="https://github.com/user-attachments/assets/06b12c19-a960-4681-88f7-49708143f215" />

### 레포지토리
<img width="1914" height="37" alt="auth 레포" src="https://github.com/user-attachments/assets/5029e598-e6dc-4956-8c4b-beb71b1799ae" />

