### PR TITLE
fix : 토큰 재발급의 hasProfile 오류 수정

### DIFF
--- a/src/constants/token.constants.ts
+++ b/src/constants/token.constants.ts
@@ -8,11 +8,11 @@ export const TIME = {
 
 export const TOKEN_EXPIRES = {
   // 토큰 만료 시간
-  ACCESS_TOKEN: "10m", // 10분
+  ACCESS_TOKEN: "1m", // 1시간
   REFRESH_TOKEN: "2w", // 2주
 
   // 쿠키 만료 시간
-  ACCESS_TOKEN_COOKIE: 10 * TIME.MINUTE, //  10분
+  ACCESS_TOKEN_COOKIE: 1 * TIME.MINUTE, //  10분
   REFRESH_TOKEN_COOKIE: 2 * TIME.WEEK, //  2주
 } as const;
 

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -111,7 +111,10 @@ const createCustomerProfile = async (profileData: TCreateCustomerProfile) => {
 };
 
 // 일반 유저(CUSTOMER) 프로필 수정
-const updateCustomerProfile = async (userId: string, updateData: TCustomerProfileUpdate) => {
+const updateCustomerProfile = async (
+  userId: string,
+  updateData: TCustomerProfileUpdate
+) => {
   return await prisma.user.update({
     where: { id: userId },
     data: updateData,
@@ -156,7 +159,10 @@ const createMoverProfile = async (profileData: TCreateMoverProfile) => {
 };
 
 // 기사님 프로필 수정
-const updateMoverProfile = async (userId: string, updateData: TMoverProfileUpdateInput) => {
+const updateMoverProfile = async (
+  userId: string,
+  updateData: TMoverProfileUpdateInput
+) => {
   // currentAreas 배열을 그대로 사용
   const data = {
     ...updateData,
@@ -185,7 +191,10 @@ const updateMoverProfile = async (userId: string, updateData: TMoverProfileUpdat
 };
 
 // 닉네임 중복 확인
-const checkNicknameExists = async (nickname: string, excludeUserId?: string) => {
+const checkNicknameExists = async (
+  nickname: string,
+  excludeUserId?: string
+) => {
   const user = await prisma.user.findUnique({
     where: {
       nickname,
@@ -196,7 +205,11 @@ const checkNicknameExists = async (nickname: string, excludeUserId?: string) => 
 };
 
 // 사용자 프로필 업데이트
-const updateUserProfile = async (userId: string, updateData: TUpdateUserProfile, serviceIds?: TServiceId[]) => {
+const updateUserProfile = async (
+  userId: string,
+  updateData: TUpdateUserProfile,
+  serviceIds?: TServiceId[]
+) => {
   // 업데이트할 데이터 준비
   const updateFields: any = {};
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -272,7 +272,10 @@ const refresh = async (decoded: TDecodedToken) => {
     id: user.id,
     name: user.name,
     userType: decoded.userType,
-    hasProfile: user.isCustomer || false,
+    hasProfile:
+      decoded.userType === "CUSTOMER"
+        ? user.isCustomer || false
+        : user.isMover || false,
   });
 
   let refreshToken = undefined;
@@ -282,7 +285,10 @@ const refresh = async (decoded: TDecodedToken) => {
       id: user.id,
       name: user.name,
       userType: decoded.userType,
-      hasProfile: user.isCustomer || false,
+      hasProfile:
+        decoded.userType === "CUSTOMER"
+          ? user.isCustomer || false
+          : user.isMover || false,
     });
 
     await authRepository.updateUserToken(


### PR DESCRIPTION
## ✨ 작업 개요
- 토큰 재발급의 hasProfile 오류 수정

## ✅ 주요 작업 내용
- 토큰 재발급시 hasProfile의 값을 커스터머로만 판단하던 오류 수정

## 비고
- 현재 테스트를 위해 엑세스 토큰의 유효시간을 1분으로 설정했습니다. 테스트 완료시 다시 10분으로 변경 예정입니다