### PR TITLE
[#258] [#263] [알림] 3차 QA 피드백 반영 및 sentry 모니터링 추가.

### DIFF
--- a/src/middlewares/notification.middleware.test.ts
+++ b/src/middlewares/notification.middleware.test.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, NotificationType, Action } from "@prisma/client";
+import { PrismaClient, NotificationType, Action, ActionType } from "@prisma/client";
 
 // PrismaClient를 모킹
 jest.mock("@prisma/client", () => ({
@@ -16,12 +16,31 @@ jest.mock("@prisma/client", () => ({
     ESTIMATE_REQUEST_ARRIVED: "ESTIMATE_REQUEST_ARRIVED",
     ESTIMATE_ARRIVED: "ESTIMATE_ARRIVED",
     ESTIMATE_STATUS_UPDATED: "ESTIMATE_STATUS_UPDATED",
-    DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED:
-      "DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED",
+    DESIGNATED_ESTIMATE_REQUEST_ARRIVED: "DESIGNATED_ESTIMATE_REQUEST_ARRIVED",
+    DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED: "DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED",
+    DESIGNATED_ESTIMATE_ARRIVED: "DESIGNATED_ESTIMATE_ARRIVED",
     DESIGNATED_ESTIMATE_STATUS_UPDATED: "DESIGNATED_ESTIMATE_STATUS_UPDATED",
     REVIEW_EVENT: "REVIEW_EVENT",
     FAVORITE_EVENT: "FAVORITE_EVENT",
     MOVE_DAY_REMINDER: "MOVE_DAY_REMINDER",
+  },
+  ActionType: {
+    WELCOME: "WELCOME",
+    ESTIMATE_REQUEST_CREATE: "ESTIMATE_REQUEST_CREATE",
+    ESTIMATE_SUBMITTED: "ESTIMATE_SUBMITTED",
+    ESTIMATE_ACCEPTED: "ESTIMATE_ACCEPTED",
+    ESTIMATE_REJECTED: "ESTIMATE_REJECTED",
+    DESIGNATED_ESTIMATE_REQUEST_SUBMITTED: "DESIGNATED_ESTIMATE_REQUEST_SUBMITTED",
+    DESIGNATED_ESTIMATE_REQUEST_REJECTED: "DESIGNATED_ESTIMATE_REQUEST_REJECTED",
+    DESIGNATED_ESTIMATE_SUBMITTED: "DESIGNATED_ESTIMATE_SUBMITTED",
+    DESIGNATED_ESTIMATE_ACCEPTED: "DESIGNATED_ESTIMATE_ACCEPTED",
+    DESIGNATED_ESTIMATE_REJECTED: "DESIGNATED_ESTIMATE_REJECTED",
+    REVIEW_SUBMITTED: "REVIEW_SUBMITTED",
+    FAVORITE_ADDED: "FAVORITE_ADDED",
+    FAVORITE_REMOVED: "FAVORITE_REMOVED",
+    MOVE_DAY_REMINDER_TOMORROW: "MOVE_DAY_REMINDER_TOMORROW",
+    MOVE_DAY_REMINDER_TODAY: "MOVE_DAY_REMINDER_TODAY",
+    MOVE_DAY_REVIEW_REQUEST: "MOVE_DAY_REVIEW_REQUEST",
   },
 }));
 
@@ -53,6 +72,17 @@ jest.mock("../utils/actionNotificationMap", () => ({
         path: "/estimates",
       }),
     },
+    WELCOME: {
+      type: "WELCOME",
+      getReceivers: jest
+        .fn()
+        .mockResolvedValue([{ id: "user-1", userType: "CUSTOMER" }]),
+      buildMessage: jest.fn().mockReturnValue({
+        title: "회원가입을 환영합니다!",
+        content: "서비스 이용을 시작해보세요.",
+        path: "/",
+      }),
+    },
   },
 }));
 
@@ -61,13 +91,26 @@ jest.mock("../utils/emitNotificationSSE", () => ({
   emitNotificationSSE: jest.fn(),
 }));
 
+// Sentry 유틸리티를 모킹
+jest.mock("../utils/sentryUtils", () => ({
+  captureNotificationError: jest.fn(),
+  captureActionMappingError: jest.fn(),
+}));
+
 import { notificationMiddleware } from "./notificationMiddleware";
 import { emitNotificationSSE } from "../utils/emitNotificationSSE";
+import { captureNotificationError, captureActionMappingError } from "../utils/sentryUtils";
 import prisma from "../db/prisma/prisma";
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockEmitNotificationSSE = emitNotificationSSE as jest.MockedFunction<
   typeof emitNotificationSSE
+>;
+const mockCaptureNotificationError = captureNotificationError as jest.MockedFunction<
+  typeof captureNotificationError
+>;
+const mockCaptureActionMappingError = captureActionMappingError as jest.MockedFunction<
+  typeof captureActionMappingError
 >;
 
 describe("NotificationMiddleware", () => {
@@ -80,7 +123,7 @@ describe("NotificationMiddleware", () => {
       // Setup
       const mockAction: Action = {
         id: "action-1",
-        type: "ESTIMATE_REQUEST_CREATE",
+        type: "ESTIMATE_REQUEST_CREATE" as ActionType,
         userId: "user-1",
         entityId: "request-1",
         entityType: "EstimateRequest",
@@ -154,7 +197,7 @@ describe("NotificationMiddleware", () => {
       // Setup
       const mockAction: Action = {
         id: "action-1",
-        type: "WELCOME",
+        type: "WELCOME" as ActionType,
         userId: "user-1",
         entityId: "request-1",
         entityType: "EstimateRequest",
@@ -225,7 +268,7 @@ describe("NotificationMiddleware", () => {
       // Setup
       const mockAction: Action = {
         id: "action-1",
-        type: "ESTIMATE_REQUEST_CREATE",
+        type: "ESTIMATE_REQUEST_CREATE" as ActionType,
         userId: "user-1",
         entityId: "request-1",
         entityType: "EstimateRequest",
@@ -263,6 +306,139 @@ describe("NotificationMiddleware", () => {
 
       // Assertion
       expect(next).toHaveBeenCalledWith(params);
+      expect(mockEmitNotificationSSE).not.toHaveBeenCalled();
+      expect(mockCaptureActionMappingError).toHaveBeenCalledWith(
+        expect.any(Error),
+        {
+          operation: "notification_creation",
+          actionType: "ESTIMATE_REQUEST_CREATE",
+          entityId: "request-1",
+          entityType: "EstimateRequest",
+        }
+      );
+    });
+
+    it("SSE 이벤트 발송 실패 시 Sentry에 에러를 캡처한다", async () => {
+      // Setup
+      const mockAction: Action = {
+        id: "action-1",
+        type: "ESTIMATE_REQUEST_CREATE" as ActionType,
+        userId: "user-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "견적 요청이 생성되었습니다.",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockNotification = {
+        id: "notification-1",
+        actionId: "action-1",
+        userId: "user-1",
+        userType: "CUSTOMER",
+        type: "ESTIMATE_REQUEST_ARRIVED",
+        title: "새로운 견적 요청",
+        content: "새로운 견적 요청이 생성되었습니다.",
+        path: "/estimates",
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      (mockPrisma.action.create as jest.Mock).mockResolvedValue(mockAction);
+      (mockPrisma.notification.create as jest.Mock).mockResolvedValue(
+        mockNotification
+      );
+      mockEmitNotificationSSE.mockRejectedValue(new Error("SSE 발송 실패"));
+
+      // Exercise
+      const params = {
+        model: "Action" as any,
+        action: "create" as any,
+        args: {
+          data: {
+            type: "ESTIMATE_REQUEST_CREATE",
+            userId: "user-1",
+            entityId: "request-1",
+            entityType: "EstimateRequest",
+            description: "견적 요청이 생성되었습니다.",
+          },
+        },
+        dataPath: [],
+        runInTransaction: false,
+      };
+
+      const next = jest.fn().mockResolvedValue(mockAction);
+
+      await notificationMiddleware(params, next);
+
+      // Assertion
+      expect(next).toHaveBeenCalledWith(params);
+      expect(mockPrisma.notification.create).toHaveBeenCalled();
+      expect(mockEmitNotificationSSE).toHaveBeenCalledWith(
+        "user-1",
+        mockNotification
+      );
+      expect(mockCaptureNotificationError).toHaveBeenCalledWith(
+        expect.any(Error),
+        {
+          operation: "sse_emit",
+          userId: "user-1",
+          userType: "CUSTOMER",
+          notificationType: "ESTIMATE_REQUEST_ARRIVED",
+          actionType: "ESTIMATE_REQUEST_CREATE",
+        }
+      );
+    });
+
+    it("수신자가 없으면 알림을 생성하지 않는다", async () => {
+      // Setup
+      const mockAction: Action = {
+        id: "action-1",
+        type: "ESTIMATE_REQUEST_CREATE" as ActionType,
+        userId: "user-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "견적 요청이 생성되었습니다.",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      (mockPrisma.action.create as jest.Mock).mockResolvedValue(mockAction);
+
+      // actionNotificationMap 모킹을 동적으로 변경
+      const { actionNotificationMap } = require("../utils/actionNotificationMap");
+      actionNotificationMap.ESTIMATE_REQUEST_CREATE.getReceivers = jest
+        .fn()
+        .mockResolvedValue([]);
+
+      // Exercise
+      const params = {
+        model: "Action" as any,
+        action: "create" as any,
+        args: {
+          data: {
+            type: "ESTIMATE_REQUEST_CREATE",
+            userId: "user-1",
+            entityId: "request-1",
+            entityType: "EstimateRequest",
+            description: "견적 요청이 생성되었습니다.",
+          },
+        },
+        dataPath: [],
+        runInTransaction: false,
+      };
+
+      const next = jest.fn().mockResolvedValue(mockAction);
+
+      await notificationMiddleware(params, next);
+
+      // Assertion
+      expect(next).toHaveBeenCalledWith(params);
+      expect(mockPrisma.notification.create).not.toHaveBeenCalled();
       expect(mockEmitNotificationSSE).not.toHaveBeenCalled();
     });
   });

--- a/src/middlewares/notificationMiddleware.ts
+++ b/src/middlewares/notificationMiddleware.ts
@@ -3,6 +3,7 @@ import prisma from "../db/prisma/prisma";
 import { actionNotificationMap } from "../utils/actionNotificationMap";
 import { emitNotificationSSE } from "../utils/emitNotificationSSE";
 import { Action } from "@prisma/client";
+import { captureNotificationError, captureActionMappingError } from "../utils/sentryUtils";
 
 // Prisma 미들웨어: actionCreate 함수에서 새로운 액션이 생성될 때 notification 자동 생성.
 export const notificationMiddleware: Prisma.Middleware = async (
@@ -51,10 +52,23 @@ export const notificationMiddleware: Prisma.Middleware = async (
           emitNotificationSSE(notification.userId, notification);
         } catch (error) {
           console.error("SSE 이벤트 발송 실패:", error);
+          captureNotificationError(error as Error, {
+            operation: "sse_emit",
+            userId: notification.userId,
+            userType: notification.userType,
+            notificationType: notification.type,
+            actionType: action.type,
+          });
         }
       }
     } catch (error) {
       console.error("알림 생성 실패:", error);
+      captureActionMappingError(error as Error, {
+        operation: "notification_creation",
+        actionType: action.type,
+        entityId: action.entityId,
+        entityType: action.entityType,
+      });
       // 알림 생성 실패해도 Action 생성은 계속 진행
     }
   }

--- a/src/middlewares/notificationMiddleware.ts
+++ b/src/middlewares/notificationMiddleware.ts
@@ -23,9 +23,14 @@ export const notificationMiddleware: Prisma.Middleware = async (
     try {
       const receivers = await mapping.getReceivers(action);
 
+      if (receivers.length === 0) {
+        return result;
+      }
+
       const notifications = await Promise.all(
         receivers.map(async (receiver) => {
           const message = mapping.buildMessage(action, receiver.userType);
+          
           return prisma.notification.create({
             data: {
               userId: receiver.id,

--- a/src/repositories/notification.repository.test.ts
+++ b/src/repositories/notification.repository.test.ts
@@ -1,49 +1,20 @@
-import { PrismaClient, NotificationType, UserType } from "@prisma/client";
+import { UserType, NotificationType } from "@prisma/client";
+import notificationRepository from "./notification.repository";
 
-// PrismaClient를 모킹
-jest.mock("@prisma/client", () => ({
-  PrismaClient: jest.fn().mockImplementation(() => ({
-    notification: {
-      findMany: jest.fn(),
-      update: jest.fn(),
-      updateMany: jest.fn(),
-      count: jest.fn(),
-      findFirst: jest.fn(),
-    },
-  })),
-  NotificationType: {
-    WELCOME: "WELCOME",
-    ESTIMATE_REQUEST_ARRIVED: "ESTIMATE_REQUEST_ARRIVED",
-    ESTIMATE_ARRIVED: "ESTIMATE_ARRIVED",
-    ESTIMATE_STATUS_UPDATED: "ESTIMATE_STATUS_UPDATED",
-    DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED:
-      "DESIGNATED_ESTIMATE_REQUEST_STATUS_UPDATED",
-    DESIGNATED_ESTIMATE_STATUS_UPDATED: "DESIGNATED_ESTIMATE_STATUS_UPDATED",
-    REVIEW_EVENT: "REVIEW_EVENT",
-    FAVORITE_EVENT: "FAVORITE_EVENT",
-    MOVE_DAY_REMINDER: "MOVE_DAY_REMINDER",
-  },
-  UserType: {
-    CUSTOMER: "CUSTOMER",
-    MOVER: "MOVER",
-  },
-}));
-
-// prisma 모듈을 모킹
+// Prisma 모듈을 모킹
 jest.mock("../db/prisma/prisma", () => ({
   __esModule: true,
   default: {
     notification: {
       findMany: jest.fn(),
-      update: jest.fn(),
-      updateMany: jest.fn(),
       count: jest.fn(),
       findFirst: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
     },
   },
 }));
 
-import notificationRepository from "./notification.repository";
 import prisma from "../db/prisma/prisma";
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
@@ -62,26 +33,32 @@ describe("NotificationRepository", () => {
           actionId: "action-1",
           userId: "user-1",
           userType: "CUSTOMER" as UserType,
-          type: "ESTIMATE_REQUEST_ARRIVED",
+          type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
           title: "새로운 견적 요청",
           content: "테스트 알림 1",
+          path: null,
           isRead: false,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+          deletedAt: null,
         },
         {
           id: "notification-2",
           actionId: "action-2",
           userId: "user-1",
           userType: "CUSTOMER" as UserType,
-          type: "ESTIMATE_ARRIVED",
+          type: "ESTIMATE_ARRIVED" as NotificationType,
           title: "견적이 도착했습니다",
           content: "테스트 알림 2",
+          path: null,
           isRead: true,
+          createdAt: new Date("2024-01-02T00:00:00Z"),
+          updatedAt: new Date("2024-01-02T00:00:00Z"),
+          deletedAt: null,
         },
       ];
 
-      (mockPrisma.notification.findMany as jest.Mock).mockResolvedValue(
-        mockNotifications
-      );
+      (mockPrisma.notification.findMany as jest.Mock).mockResolvedValue(mockNotifications);
       (mockPrisma.notification.count as jest.Mock).mockResolvedValue(2);
 
       // Exercise
@@ -110,28 +87,102 @@ describe("NotificationRepository", () => {
       });
     });
 
-    it("Prisma 에러 시 에러를 던진다", async () => {
+    it("페이지네이션을 올바르게 적용한다", async () => {
       // Setup
-      const error = new Error("Prisma 에러");
-      (mockPrisma.notification.findMany as jest.Mock).mockRejectedValue(error);
+      const mockNotifications = [
+        {
+          id: "notification-3",
+          actionId: "action-3",
+          userId: "user-1",
+          userType: "CUSTOMER" as UserType,
+          type: "ESTIMATE_STATUS_UPDATED" as NotificationType,
+          title: "견적 상태 업데이트",
+          content: "테스트 알림 3",
+          path: null,
+          isRead: false,
+          createdAt: new Date("2024-01-03T00:00:00Z"),
+          updatedAt: new Date("2024-01-03T00:00:00Z"),
+          deletedAt: null,
+        },
+      ];
+
+      (mockPrisma.notification.findMany as jest.Mock).mockResolvedValue(mockNotifications);
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(3);
+
+      // Exercise
+      const result = await notificationRepository.getNotifications(
+        "CUSTOMER" as UserType,
+        "user-1",
+        1,
+        2
+      );
+
+      // Assertion
+      expect(mockPrisma.notification.findMany).toHaveBeenCalledWith({
+        where: { userType: "CUSTOMER", userId: "user-1" },
+        orderBy: { createdAt: "desc" },
+        skip: 2,
+        take: 1,
+      });
+      expect(result).toEqual({
+        items: mockNotifications,
+        total: 3,
+        limit: 1,
+        offset: 2,
+      });
+    });
+
+    it("다양한 사용자 타입에 대해 올바르게 조회한다", async () => {
+      // Setup
+      const userTypes: UserType[] = ["CUSTOMER", "MOVER"];
+      const mockNotifications = [
+        {
+          id: "notification-1",
+          actionId: "action-1",
+          userId: "user-1",
+          userType: "MOVER" as UserType,
+          type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+          title: "새로운 견적 요청",
+          content: "테스트 알림",
+          path: null,
+          isRead: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        },
+      ];
+
+      (mockPrisma.notification.findMany as jest.Mock).mockResolvedValue(mockNotifications);
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(1);
 
       // Exercise & Assertion
-      await expect(
-        notificationRepository.getNotifications("CUSTOMER" as UserType, "user-1", 10, 0)
-      ).rejects.toThrow("Prisma 에러");
+      for (const userType of userTypes) {
+        await notificationRepository.getNotifications(userType, "user-1", 10, 0);
+
+        expect(mockPrisma.notification.findMany).toHaveBeenCalledWith({
+          where: { userType, userId: "user-1" },
+          orderBy: { createdAt: "desc" },
+          skip: 0,
+          take: 10,
+        });
+      }
     });
   });
 
   describe("hasUnreadNotification", () => {
     it("안읽은 알림이 있으면 true를 반환한다", async () => {
       // Setup
-      (mockPrisma.notification.findFirst as jest.Mock).mockResolvedValue({
+      const mockUnreadNotification = {
         id: "notification-1",
-      });
+      };
+
+      (mockPrisma.notification.findFirst as jest.Mock).mockResolvedValue(mockUnreadNotification as any);
 
       // Exercise
-      const result =
-        await notificationRepository.hasUnreadNotification("CUSTOMER" as UserType, "user-1");
+      const result = await notificationRepository.hasUnreadNotification(
+        "CUSTOMER" as UserType,
+        "user-1"
+      );
 
       // Assertion
       expect(mockPrisma.notification.findFirst).toHaveBeenCalledWith({
@@ -146,86 +197,130 @@ describe("NotificationRepository", () => {
       (mockPrisma.notification.findFirst as jest.Mock).mockResolvedValue(null);
 
       // Exercise
-      const result =
-        await notificationRepository.hasUnreadNotification("CUSTOMER" as UserType, "user-1");
+      const result = await notificationRepository.hasUnreadNotification(
+        "CUSTOMER" as UserType,
+        "user-1"
+      );
 
       // Assertion
+      expect(mockPrisma.notification.findFirst).toHaveBeenCalledWith({
+        where: { userType: "CUSTOMER", userId: "user-1", isRead: false },
+        select: { id: true },
+      });
       expect(result).toBe(false);
+    });
+
+    it("다양한 사용자 타입에 대해 올바르게 확인한다", async () => {
+      // Setup
+      const userTypes: UserType[] = ["CUSTOMER", "MOVER"];
+      (mockPrisma.notification.findFirst as jest.Mock).mockResolvedValue(null);
+
+      // Exercise & Assertion
+      for (const userType of userTypes) {
+        await notificationRepository.hasUnreadNotification(userType, "user-1");
+
+        expect(mockPrisma.notification.findFirst).toHaveBeenCalledWith({
+          where: { userType, userId: "user-1", isRead: false },
+          select: { id: true },
+        });
+      }
     });
   });
 
   describe("readNotification", () => {
     it("성공적으로 알림을 읽음 처리한다", async () => {
       // Setup
-      const mockNotification = {
+      const mockUpdatedNotification = {
         id: "notification-1",
         actionId: "action-1",
         userId: "user-1",
         userType: "CUSTOMER" as UserType,
-        type: "ESTIMATE_REQUEST_ARRIVED",
+        type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
         title: "새로운 견적 요청",
         content: "테스트 알림 1",
+        path: null,
         isRead: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
       };
-      (mockPrisma.notification.update as jest.Mock).mockResolvedValue(
-        mockNotification
-      );
+
+      (mockPrisma.notification.update as jest.Mock).mockResolvedValue(mockUpdatedNotification as any);
 
       // Exercise
-      const result =
-        await notificationRepository.readNotification("notification-1");
+      const result = await notificationRepository.readNotification("notification-1");
 
       // Assertion
       expect(mockPrisma.notification.update).toHaveBeenCalledWith({
         where: { id: "notification-1" },
         data: { isRead: true },
       });
-      expect(result).toEqual(mockNotification);
+      expect(result).toEqual(mockUpdatedNotification);
     });
 
-    it("Prisma 에러 시 에러를 던진다", async () => {
+    it("존재하지 않는 알림 ID에 대해 에러를 던진다", async () => {
       // Setup
-      const error = new Error("Prisma 에러");
-      (mockPrisma.notification.update as jest.Mock).mockRejectedValue(error);
+      (mockPrisma.notification.update as jest.Mock).mockRejectedValue(new Error("알림을 찾을 수 없습니다"));
 
       // Exercise & Assertion
       await expect(
-        notificationRepository.readNotification("notification-1")
-      ).rejects.toThrow("Prisma 에러");
+        notificationRepository.readNotification("non-existent-id")
+      ).rejects.toThrow("알림을 찾을 수 없습니다");
+      expect(mockPrisma.notification.update).toHaveBeenCalledWith({
+        where: { id: "non-existent-id" },
+        data: { isRead: true },
+      });
     });
   });
 
   describe("readAllNotifications", () => {
     it("성공적으로 모든 알림을 읽음 처리한다", async () => {
       // Setup
-      const mockResult = { count: 5 };
-      (mockPrisma.notification.updateMany as jest.Mock).mockResolvedValue(
-        mockResult
-      );
+      const mockUpdateResult = { count: 5 };
+      (mockPrisma.notification.updateMany as jest.Mock).mockResolvedValue(mockUpdateResult as any);
 
       // Exercise
-      const result =
-        await notificationRepository.readAllNotifications("user-1");
+      const result = await notificationRepository.readAllNotifications("user-1");
 
       // Assertion
       expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
         where: { userId: "user-1", isRead: false },
         data: { isRead: true },
       });
-      expect(result).toEqual(5);
+      expect(result).toBe(5);
     });
 
-    it("Prisma 에러 시 에러를 던진다", async () => {
+    it("읽음 처리할 알림이 없으면 0을 반환한다", async () => {
       // Setup
-      const error = new Error("Prisma 에러");
-      (mockPrisma.notification.updateMany as jest.Mock).mockRejectedValue(
-        error
-      );
+      const mockUpdateResult = { count: 0 };
+      (mockPrisma.notification.updateMany as jest.Mock).mockResolvedValue(mockUpdateResult as any);
+
+      // Exercise
+      const result = await notificationRepository.readAllNotifications("user-1");
+
+      // Assertion
+      expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+        where: { userId: "user-1", isRead: false },
+        data: { isRead: true },
+      });
+      expect(result).toBe(0);
+    });
+
+    it("다양한 사용자에 대해 올바르게 처리한다", async () => {
+      // Setup
+      const userIds = ["user-1", "user-2", "user-3"];
+      const mockUpdateResult = { count: 1 };
+      (mockPrisma.notification.updateMany as jest.Mock).mockResolvedValue(mockUpdateResult as any);
 
       // Exercise & Assertion
-      await expect(
-        notificationRepository.readAllNotifications("user-1")
-      ).rejects.toThrow("Prisma 에러");
+      for (const userId of userIds) {
+        await notificationRepository.readAllNotifications(userId);
+
+        expect(mockPrisma.notification.updateMany).toHaveBeenCalledWith({
+          where: { userId, isRead: false },
+          data: { isRead: true },
+        });
+      }
     });
   });
 });

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -158,15 +158,6 @@ const signup = async ({
     throw new DatabaseError("유저 생성 실패로 인한 회원가입 실패");
   }
 
-  // WELCOME 액션 생성
-  await actionService.createAction(
-    user.id,
-    ActionType.WELCOME,
-    user.id,
-    "USER",
-    {}
-  );
-
   let accessToken, refreshToken;
 
   // 유저 타입 배열에 CUSTOMER가 먼저 있는지 확인 없다면 현재 타입은 MOVER

--- a/src/services/customerEstimateRequest.service.ts
+++ b/src/services/customerEstimateRequest.service.ts
@@ -471,25 +471,6 @@ const customerEstimateRequestService = {
         throw new NotFoundError("견적 취소에 실패했습니다.");
       }
 
-      // 6. 견적 취소 액션 생성
-      if (estimateDetail) {
-        const actionType = estimateDetail.isDesignated
-          ? ActionType.DESIGNATED_ESTIMATE_REJECTED
-          : ActionType.ESTIMATE_REJECTED;
-
-        await actionService.createAction(
-          estimateDetail.moverId,
-          actionType,
-          estimateId,
-          estimateDetail.isDesignated ? "DESIGNATED_ESTIMATE" : "ESTIMATE",
-          {
-            customerName:
-              estimateDetail.estimateRequest?.customer?.nickname || "",
-            moveType: estimateDetail.estimateRequest?.moveType || "",
-          }
-        );
-      }
-
       return result;
     } catch (error) {
       if (error instanceof RepositoryError) {

--- a/src/services/moverEstimate.service.ts
+++ b/src/services/moverEstimate.service.ts
@@ -259,18 +259,15 @@ const moverEstimateService = {
         throw new ServiceError("견적 반려에 실패했습니다");
       }
 
-      // 견적 거절 액션 생성
+      // 지정 견적 요청 거절 액션 생성
       const estimateDetail =
         await moverEstimateRepository.getEstimateDetailForAction(estimate.id);
-      if (estimateDetail) {
-        const actionType = isDesignated
-          ? ActionType.DESIGNATED_ESTIMATE_REQUEST_REJECTED
-          : ActionType.ESTIMATE_REJECTED;
+      if (estimateDetail && isDesignated) {
         await actionService.createAction(
           data.moverId,
-          actionType,
+          ActionType.DESIGNATED_ESTIMATE_REQUEST_REJECTED,
           estimate.id,
-          isDesignated ? "DESIGNATED_ESTIMATE" : "ESTIMATE",
+          "DESIGNATED_ESTIMATE",
           {
             moveType: estimateDetail.estimateRequest?.moveType || "",
             estimateRequestId: data.estimateRequestId,

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -23,6 +23,8 @@ import {
 } from "../utils/validators/profileValidator";
 import { generateToken } from "../utils/generateToken";
 import { validateMoverProfileUpdate } from "../utils/validators/userValidator";
+import actionService from "./action.service";
+import { ActionType } from "@prisma/client";
 
 // 유저 정보 조회
 const userInfo = async (userId: string, userType: TUserRole) => {
@@ -120,6 +122,16 @@ const createCustomerProfile = async (
   });
 
   const result = await userRepository.createCustomerProfile(createProfileData);
+
+  // WELCOME 액션 생성 (프로필 등록 시점)
+  await actionService.createAction(
+    userId,
+    ActionType.WELCOME,
+    userId,
+    "WELCOME",
+    { userType: "CUSTOMER" }
+  );
+
   return {
     result,
     accessToken: newAccessToken,
@@ -212,6 +224,16 @@ const createMoverProfile = async (
   });
 
   const result = await userRepository.createMoverProfile(createProfileData);
+
+  // WELCOME 액션 생성 (프로필 등록 시점)
+  await actionService.createAction(
+    userId,
+    ActionType.WELCOME,
+    userId,
+    "WELCOME",
+    { userType: "MOVER" }
+  );
+
   return {
     result,
     accessToken: newAccessToken,

--- a/src/utils/actionNotificationMap.test.ts
+++ b/src/utils/actionNotificationMap.test.ts
@@ -1,0 +1,481 @@
+import { Action, UserType } from "@prisma/client";
+import { actionNotificationMap } from "./actionNotificationMap";
+
+// Prisma 모듈을 모킹
+jest.mock("../db/prisma/prisma", () => ({
+  __esModule: true,
+  default: {
+    user: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    estimateRequest: {
+      findUnique: jest.fn(),
+    },
+    estimate: {
+      findUnique: jest.fn(),
+    },
+    review: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+import prisma from "../db/prisma/prisma";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+describe("ActionNotificationMap", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("WELCOME 액션", () => {
+    it("회원가입 환영 알림을 생성한다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "WELCOME",
+        userId: "user-1",
+        entityId: "user-1",
+        entityType: "User",
+        description: "회원가입 환영",
+        metadata: { userType: "CUSTOMER" },
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      const mapping = actionNotificationMap.WELCOME;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "CUSTOMER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "user-1", userType: "CUSTOMER" }]);
+      expect(message).toEqual({
+        title: '<span class="font-bold">회원가입</span>을 환영합니다!',
+        content: "서비스 이용을 시작해보세요.",
+        path: "/",
+      });
+    });
+  });
+
+  describe("ESTIMATE_REQUEST_CREATE 액션", () => {
+    it("지역 기반으로 기사님들에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "ESTIMATE_REQUEST_CREATE",
+        userId: "customer-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "견적 요청 생성",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockEstimateRequest = {
+        id: "request-1",
+        fromAddress: {
+          region: "SEOUL",
+        },
+      };
+
+      const mockMovers = [
+        { id: "mover-1" },
+        { id: "mover-2" },
+        { id: "mover-3" },
+      ];
+
+      (mockPrisma.estimateRequest.findUnique as jest.Mock).mockResolvedValue(mockEstimateRequest as any);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue(mockMovers as any);
+
+      // Exercise
+      const mapping = actionNotificationMap.ESTIMATE_REQUEST_CREATE;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "MOVER");
+
+      // Assertion
+      expect(mockPrisma.estimateRequest.findUnique).toHaveBeenCalledWith({
+        where: { id: "request-1" },
+        select: { fromAddress: true },
+      });
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+        where: {
+          userType: { has: "MOVER" },
+          id: { not: "customer-1" },
+          currentAreas: { has: "SEOUL" },
+        },
+        select: { id: true },
+      });
+      expect(receivers).toEqual([
+        { id: "mover-1", userType: "MOVER" },
+        { id: "mover-2", userType: "MOVER" },
+        { id: "mover-3", userType: "MOVER" },
+      ]);
+      expect(message).toEqual({
+        title: "새 견적 요청이 등록되었습니다.",
+        content: "새로운 견적 요청이 등록되었습니다.",
+        path: `/estimate/received`,
+      });
+    });
+
+    it("지역 정보가 없으면 모든 기사님에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "ESTIMATE_REQUEST_CREATE",
+        userId: "customer-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "견적 요청 생성",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockEstimateRequest = {
+        id: "request-1",
+        fromAddress: null,
+      };
+
+      const mockMovers = [
+        { id: "mover-1" },
+        { id: "mover-2" },
+      ];
+
+      (mockPrisma.estimateRequest.findUnique as jest.Mock).mockResolvedValue(mockEstimateRequest as any);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue(mockMovers as any);
+
+      // Exercise
+      const mapping = actionNotificationMap.ESTIMATE_REQUEST_CREATE;
+      const receivers = await mapping.getReceivers(action);
+
+      // Assertion
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+        where: {
+          userType: { has: "MOVER" },
+          id: { not: "customer-1" },
+        },
+        select: { id: true },
+      });
+      expect(receivers).toEqual([
+        { id: "mover-1", userType: "MOVER" },
+        { id: "mover-2", userType: "MOVER" },
+      ]);
+    });
+  });
+
+  describe("ESTIMATE_SUBMITTED 액션", () => {
+    it("견적 요청자에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "ESTIMATE_SUBMITTED",
+        userId: "mover-1",
+        entityId: "estimate-1",
+        entityType: "Estimate",
+        description: "견적 제출",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockEstimate = {
+        id: "estimate-1",
+        estimateRequest: {
+          userId: "customer-1",
+        },
+      };
+
+      (mockPrisma.estimate.findUnique as jest.Mock).mockResolvedValue(mockEstimate as any);
+
+      // Exercise
+      const mapping = actionNotificationMap.ESTIMATE_SUBMITTED;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "CUSTOMER");
+
+      // Assertion
+      expect(mockPrisma.estimate.findUnique).toHaveBeenCalledWith({
+        where: { id: "estimate-1" },
+        select: { estimateRequest: { select: { userId: true } } },
+      });
+      expect(receivers).toEqual([{ id: "customer-1", userType: "CUSTOMER" }]);
+      expect(message).toEqual({
+        title: "새 견적이 도착했습니다!",
+        content: "새로운 견적이 도착했습니다. 확인해보세요.",
+        path: `/estimateRequests/${action.entityId}`,
+      });
+    });
+  });
+
+  describe("ESTIMATE_ACCEPTED 액션", () => {
+    it("견적 제출자에게 수락 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "ESTIMATE_ACCEPTED",
+        userId: "customer-1",
+        entityId: "estimate-1",
+        entityType: "Estimate",
+        description: "견적 수락",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockEstimate = {
+        id: "estimate-1",
+        userId: "mover-1",
+      };
+
+      (mockPrisma.estimate.findUnique as jest.Mock).mockResolvedValue(mockEstimate as any);
+
+      // Exercise
+      const mapping = actionNotificationMap.ESTIMATE_ACCEPTED;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "MOVER");
+
+      // Assertion
+      expect(mockPrisma.estimate.findUnique).toHaveBeenCalledWith({
+        where: { id: "estimate-1" },
+        select: { userId: true },
+      });
+      expect(receivers).toEqual([{ id: "mover-1", userType: "MOVER" }]);
+      expect(message).toEqual({
+        title: "견적이 수락되었습니다!",
+        content: "고객님이 견적을 수락했습니다.",
+        path: `/estimates/${action.entityId}`,
+      });
+    });
+  });
+
+  describe("ESTIMATE_REJECTED 액션", () => {
+    it("견적 제출자에게 거절 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "ESTIMATE_REJECTED",
+        userId: "customer-1",
+        entityId: "estimate-1",
+        entityType: "Estimate",
+        description: "견적 거절",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockEstimate = {
+        id: "estimate-1",
+        userId: "mover-1",
+      };
+
+      (mockPrisma.estimate.findUnique as jest.Mock).mockResolvedValue(mockEstimate as any);
+
+      // Exercise
+      const mapping = actionNotificationMap.ESTIMATE_REJECTED;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "MOVER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "mover-1", userType: "MOVER" }]);
+      expect(message).toEqual({
+        title: "견적이 거절되었습니다.",
+        content: "고객님이 견적을 거절했습니다.",
+        path: `/estimates/${action.entityId}`,
+      });
+    });
+  });
+
+  describe("REVIEW_SUBMITTED 액션", () => {
+    it("리뷰 대상자에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "REVIEW_SUBMITTED",
+        userId: "customer-1",
+        entityId: "review-1",
+        entityType: "Review",
+        description: "리뷰 작성",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockReview = {
+        id: "review-1",
+        receiverId: "mover-1",
+      };
+
+      (mockPrisma.review.findUnique as jest.Mock).mockResolvedValue(mockReview as any);
+
+      // Exercise
+      const mapping = actionNotificationMap.REVIEW_SUBMITTED;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "MOVER");
+
+      // Assertion
+      expect(mockPrisma.review.findUnique).toHaveBeenCalledWith({
+        where: { id: "review-1" },
+        select: { receiverId: true },
+      });
+      expect(receivers).toEqual([{ id: "mover-1", userType: "MOVER" }]);
+      expect(message).toEqual({
+        title: "새 리뷰가 작성되었습니다!",
+        content: "고객님이 리뷰를 작성했습니다.",
+        path: `/reviews/${action.entityId}`,
+      });
+    });
+  });
+
+  describe("FAVORITE_ADDED 액션", () => {
+    it("찜 대상자에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "FAVORITE_ADDED",
+        userId: "customer-1",
+        entityId: "favorite-1",
+        entityType: "Favorite",
+        description: "찜 추가",
+        metadata: { targetUserId: "mover-1" },
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      const mapping = actionNotificationMap.FAVORITE_ADDED;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "MOVER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "mover-1", userType: "MOVER" }]);
+      expect(message).toEqual({
+        title: "새로운 찜이 추가되었습니다!",
+        content: "고객님이 당신을 찜했습니다.",
+        path: `/profile/${(action.metadata as any).targetUserId}`,
+      });
+    });
+  });
+
+  describe("FAVORITE_REMOVED 액션", () => {
+    it("찜 제거 대상자에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "FAVORITE_REMOVED",
+        userId: "customer-1",
+        entityId: "favorite-1",
+        entityType: "Favorite",
+        description: "찜 제거",
+        metadata: { targetUserId: "mover-1" },
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      const mapping = actionNotificationMap.FAVORITE_REMOVED;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "MOVER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "mover-1", userType: "MOVER" }]);
+      expect(message).toEqual({
+        title: "찜이 제거되었습니다.",
+        content: "고객님이 찜을 제거했습니다.",
+        path: `/profile/${(action.metadata as any).targetUserId}`,
+      });
+    });
+  });
+
+  describe("MOVE_DAY_REMINDER_TOMORROW 액션", () => {
+    it("이사 전날 고객에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "MOVE_DAY_REMINDER_TOMORROW",
+        userId: "customer-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "이사 전날 알림",
+        metadata: { moveType: "HOME" },
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      const mapping = actionNotificationMap.MOVE_DAY_REMINDER_TOMORROW;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "CUSTOMER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "customer-1", userType: "CUSTOMER" }]);
+      expect(message).toEqual({
+        title: "내일이 이사 날입니다!",
+        content: "내일 가정이사가 예정되어 있습니다. 준비하세요.",
+        path: `/estimateRequests/${action.entityId}`,
+      });
+    });
+  });
+
+  describe("MOVE_DAY_REMINDER_TODAY 액션", () => {
+    it("이사 당일 고객에게 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "MOVE_DAY_REMINDER_TODAY",
+        userId: "customer-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "이사 당일 알림",
+        metadata: { moveType: "HOME" },
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      const mapping = actionNotificationMap.MOVE_DAY_REMINDER_TODAY;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "CUSTOMER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "customer-1", userType: "CUSTOMER" }]);
+      expect(message).toEqual({
+        title: "오늘이 이사 날입니다!",
+        content: "오늘 가정이사가 진행됩니다. 기사님이 곧 도착합니다.",
+        path: `/estimateRequests/${action.entityId}`,
+      });
+    });
+  });
+
+  describe("MOVE_DAY_REVIEW_REQUEST 액션", () => {
+    it("이사 다음날 고객에게 리뷰 요청 알림을 보낸다", async () => {
+      // Setup
+      const action: Action = {
+        id: "action-1",
+        type: "MOVE_DAY_REVIEW_REQUEST",
+        userId: "customer-1",
+        entityId: "request-1",
+        entityType: "EstimateRequest",
+        description: "리뷰 요청",
+        metadata: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      const mapping = actionNotificationMap.MOVE_DAY_REVIEW_REQUEST;
+      const receivers = await mapping.getReceivers(action);
+      const message = mapping.buildMessage(action, "CUSTOMER");
+
+      // Assertion
+      expect(receivers).toEqual([{ id: "customer-1", userType: "CUSTOMER" }]);
+      expect(message).toEqual({
+        title: "이사 후기를 작성해주세요!",
+        content: "이사 서비스에 대한 후기를 작성해주세요.",
+        path: `/estimateRequests/${action.entityId}/review`,
+      });
+    });
+  });
+}); 

--- a/src/utils/actionNotificationMap.ts
+++ b/src/utils/actionNotificationMap.ts
@@ -128,8 +128,8 @@ export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
       return {
         title:
           userType === "CUSTOMER"
-            ? `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
-            : `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
+            ? `<span class="font-bold">${moverName}</span> 기사님의 견적이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
+            : `<span class="font-bold">${customerName}</span> 고객님의 견적이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
         content: "내 견적 관리 > 확정 견적에서 확인할 수 있어요.",
         path:
           userType === "CUSTOMER"
@@ -270,8 +270,8 @@ export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
       return {
         title:
           userType === "CUSTOMER"
-            ? `<span class="font-bold">${moverName}</span> 기사님의 <span class="text-primary-400 font-bold">${moveTypeMap[moveType]}에 대한 지정 견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
-            : `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">${moveTypeMap[moveType]}에 대한 지정 견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
+            ? `<span class="font-bold">${moverName}</span> 기사님의 <span class="font-bold">${moveTypeMap[moveType]}</span>에 대한 <span class="text-primary-400 font-bold">지정 견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`
+            : `<span class="font-bold">${customerName}</span> 고객님의 <span class="font-bold">${moveTypeMap[moveType]}</span>에 대한 <span class="text-primary-400 font-bold">지정 견적</span>이 <span class="text-primary-400 font-bold">확정</span>되었어요.`,
         content: "내 견적 관리 > 확정 견적에서 확인할 수 있어요.",
         path:
           userType === "CUSTOMER"
@@ -296,7 +296,7 @@ export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
       const { customerName = "", moveType = "" } =
         (action.metadata as IActionMetadata) || {};
       return {
-        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="text-primary-400 font-bold">${moveTypeMap[moveType]}에 대한 지정 견적</span>이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
+        title: `<span class="font-bold">${customerName}</span> 고객님의 <span class="font-bold">${moveTypeMap[moveType]}</span>에 대한 <span class="text-primary-400 font-bold">지정 견적</span>이 <span class="text-primary-400 font-bold">반려</span>되었어요.`,
         content: "반려된 견적 상세를 확인하세요.",
         path: `/estimate/request/${action.entityId}`,
       };
@@ -397,7 +397,7 @@ export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
     buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
       const { moveType = "" } = (action.metadata as IActionMetadata) || {};
       return {
-        title: `내일은 <span class="font-bold">${moveTypeMap[moveType]}</span>의 이사 예정일이에요.`,
+        title: `내일은 <span class="font-bold">${moveTypeMap[moveType]}</span> 예정일이에요.`,
         content: "이사 준비를 미리 확인해보세요.",
         path:
           userType === "CUSTOMER"
@@ -441,7 +441,7 @@ export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
     buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => {
       const { moveType = "" } = (action.metadata as IActionMetadata) || {};
       return {
-        title: `오늘은 <span class="font-bold">${moveTypeMap[moveType]}</span>의 이사 예정일이에요.`,
+        title: `오늘은 <span class="font-bold">${moveTypeMap[moveType]}</span> 예정일이에요.`,
         content: "이사 준비를 미리 확인해보세요.",
         path:
           userType === "CUSTOMER"

--- a/src/utils/actionNotificationMap.ts
+++ b/src/utils/actionNotificationMap.ts
@@ -27,9 +27,10 @@ export const actionNotificationMap: Record<ActionType, INotificationPayload> = {
   //회원가입 -> 회원, 기사님
   WELCOME: {
     type: NotificationType.WELCOME,
-    getReceivers: async (action: Action) => [
-      { id: action.userId, userType: "CUSTOMER" },
-    ],
+    getReceivers: async (action: Action) => {
+      const { userType } = action.metadata as IActionMetadata;
+      return [{ id: action.userId, userType }];
+    },
     buildMessage: (action: Action, userType: "CUSTOMER" | "MOVER") => ({
       title: '<span class="font-bold">회원가입</span>을 환영합니다!',
       content: "서비스 이용을 시작해보세요.",

--- a/src/utils/emitNotificationSSE.test.ts
+++ b/src/utils/emitNotificationSSE.test.ts
@@ -1,0 +1,364 @@
+import { Notification, NotificationType, UserType } from "@prisma/client";
+import { emitNotificationSSE } from "./emitNotificationSSE";
+
+// Prisma 모듈을 모킹
+jest.mock("../db/prisma/prisma", () => ({
+  __esModule: true,
+  default: {
+    notification: {
+      count: jest.fn(),
+    },
+  },
+}));
+
+// Sentry 유틸리티를 모킹
+jest.mock("./sentryUtils", () => ({
+  captureSSEError: jest.fn(),
+}));
+
+import prisma from "../db/prisma/prisma";
+import { captureSSEError } from "./sentryUtils";
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockCaptureSSEError = captureSSEError as jest.MockedFunction<
+  typeof captureSSEError
+>;
+
+describe("EmitNotificationSSE", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("emitNotificationSSE", () => {
+    it("클라이언트가 연결되어 있으면 알림을 전송한다", async () => {
+      // Setup
+      const userId = "user-1";
+      const notification: Notification = {
+        id: "notification-1",
+        actionId: "action-1",
+        userId: "user-1",
+        userType: "CUSTOMER" as UserType,
+        type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+        title: "새로운 견적 요청",
+        content: "새로운 견적 요청이 생성되었습니다.",
+        path: "/estimates",
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockClient = {
+        write: jest.fn(),
+      };
+
+      // sseClients를 직접 모킹
+      const emitModule = require("./emitNotificationSSE");
+      const originalSseClients = emitModule.sseClients;
+      emitModule.sseClients = new Map();
+      emitModule.sseClients.set(userId, mockClient);
+
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(3);
+
+      // Exercise
+      await emitNotificationSSE(userId, notification);
+
+      // Assertion
+      expect(mockPrisma.notification.count).toHaveBeenCalledWith({
+        where: {
+          userId: "user-1",
+          isRead: false,
+        },
+      });
+
+      expect(mockClient.write).toHaveBeenCalledWith("event: notification\n");
+      expect(mockClient.write).toHaveBeenCalledWith(
+        `data: ${JSON.stringify({
+          notification,
+          unreadCount: 3,
+          hasUnread: true,
+        })}\n\n`
+      );
+
+      // 원래 상태로 복원
+      emitModule.sseClients = originalSseClients;
+    });
+
+    it("클라이언트가 연결되어 있지 않으면 아무것도 하지 않는다", async () => {
+      // Setup
+      const userId = "user-1";
+      const notification: Notification = {
+        id: "notification-1",
+        actionId: "action-1",
+        userId: "user-1",
+        userType: "CUSTOMER" as UserType,
+        type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+        title: "새로운 견적 요청",
+        content: "새로운 견적 요청이 생성되었습니다.",
+        path: "/estimates",
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      // Exercise
+      await emitNotificationSSE(userId, notification);
+
+      // Assertion
+      expect(mockPrisma.notification.count).not.toHaveBeenCalled();
+    });
+
+    it("안읽은 알림이 없으면 hasUnread가 false로 설정된다", async () => {
+      // Setup
+      const userId = "user-1";
+      const notification: Notification = {
+        id: "notification-1",
+        actionId: "action-1",
+        userId: "user-1",
+        userType: "CUSTOMER" as UserType,
+        type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+        title: "새로운 견적 요청",
+        content: "새로운 견적 요청이 생성되었습니다.",
+        path: "/estimates",
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockClient = {
+        write: jest.fn(),
+      };
+
+      // sseClients를 직접 모킹
+      const emitModule = require("./emitNotificationSSE");
+      const originalSseClients = emitModule.sseClients;
+      emitModule.sseClients = new Map();
+      emitModule.sseClients.set(userId, mockClient);
+
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(0);
+
+      // Exercise
+      await emitNotificationSSE(userId, notification);
+
+      // Assertion
+      expect(mockClient.write).toHaveBeenCalledWith("event: notification\n");
+      expect(mockClient.write).toHaveBeenCalledWith(
+        `data: ${JSON.stringify({
+          notification,
+          unreadCount: 0,
+          hasUnread: false,
+        })}\n\n`
+      );
+
+      // 원래 상태로 복원
+      emitModule.sseClients = originalSseClients;
+    });
+
+    it("에러 발생 시 Sentry에 에러를 캡처한다", async () => {
+      // Setup
+      const userId = "user-1";
+      const notification: Notification = {
+        id: "notification-1",
+        actionId: "action-1",
+        userId: "user-1",
+        userType: "CUSTOMER" as UserType,
+        type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+        title: "새로운 견적 요청",
+        content: "새로운 견적 요청이 생성되었습니다.",
+        path: "/estimates",
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockClient = {
+        write: jest.fn(),
+      };
+
+      // sseClients를 직접 모킹
+      const emitModule = require("./emitNotificationSSE");
+      const originalSseClients = emitModule.sseClients;
+      emitModule.sseClients = new Map();
+      emitModule.sseClients.set(userId, mockClient);
+
+      (mockPrisma.notification.count as jest.Mock).mockRejectedValue(new Error("DB 에러"));
+
+      // Exercise
+      await expect(emitNotificationSSE(userId, notification)).rejects.toThrow("DB 에러");
+
+      // Assertion
+      expect(mockCaptureSSEError).toHaveBeenCalledWith(
+        expect.any(Error),
+        {
+          operation: "emit_notification_sse",
+          userId: "user-1",
+          notificationId: "notification-1",
+        }
+      );
+
+      // 원래 상태로 복원
+      emitModule.sseClients = originalSseClients;
+    });
+
+    it("클라이언트 write 에러 시 Sentry에 에러를 캡처한다", async () => {
+      // Setup
+      const userId = "user-1";
+      const notification: Notification = {
+        id: "notification-1",
+        actionId: "action-1",
+        userId: "user-1",
+        userType: "CUSTOMER" as UserType,
+        type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+        title: "새로운 견적 요청",
+        content: "새로운 견적 요청이 생성되었습니다.",
+        path: "/estimates",
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      const mockClient = {
+        write: jest.fn().mockImplementation(() => {
+          throw new Error("Write 에러");
+        }),
+      };
+
+      // sseClients를 직접 모킹
+      const emitModule = require("./emitNotificationSSE");
+      const originalSseClients = emitModule.sseClients;
+      emitModule.sseClients = new Map();
+      emitModule.sseClients.set(userId, mockClient);
+
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(1);
+
+      // Exercise
+      await expect(emitNotificationSSE(userId, notification)).rejects.toThrow("Write 에러");
+
+      // Assertion
+      expect(mockCaptureSSEError).toHaveBeenCalledWith(
+        expect.any(Error),
+        {
+          operation: "emit_notification_sse",
+          userId: "user-1",
+          notificationId: "notification-1",
+        }
+      );
+
+      // 원래 상태로 복원
+      emitModule.sseClients = originalSseClients;
+    });
+
+    it("다양한 알림 타입에 대해 올바른 페이로드를 전송한다", async () => {
+      // Setup
+      const userId = "user-1";
+      const notificationTypes: NotificationType[] = [
+        "WELCOME",
+        "ESTIMATE_REQUEST_ARRIVED",
+        "ESTIMATE_ARRIVED",
+        "ESTIMATE_STATUS_UPDATED",
+        "DESIGNATED_ESTIMATE_REQUEST_ARRIVED",
+        "DESIGNATED_ESTIMATE_ARRIVED",
+        "DESIGNATED_ESTIMATE_STATUS_UPDATED",
+        "REVIEW_EVENT",
+        "FAVORITE_EVENT",
+        "MOVE_DAY_REMINDER",
+      ];
+
+      const mockClient = {
+        write: jest.fn(),
+      };
+
+      // sseClients를 직접 모킹
+      const emitModule = require("./emitNotificationSSE");
+      const originalSseClients = emitModule.sseClients;
+      emitModule.sseClients = new Map();
+      emitModule.sseClients.set(userId, mockClient);
+
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(1);
+
+      // Exercise & Assertion
+      for (const type of notificationTypes) {
+        const notification: Notification = {
+          id: `notification-${type}`,
+          actionId: "action-1",
+          userId: "user-1",
+          userType: "CUSTOMER" as UserType,
+          type,
+          title: `${type} 알림`,
+          content: `${type} 알림 내용`,
+          path: "/test",
+          isRead: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        };
+
+        await emitNotificationSSE(userId, notification);
+
+        expect(mockClient.write).toHaveBeenCalledWith("event: notification\n");
+        expect(mockClient.write).toHaveBeenCalledWith(
+          `data: ${JSON.stringify({
+            notification,
+            unreadCount: 1,
+            hasUnread: true,
+          })}\n\n`
+        );
+      }
+
+      // 원래 상태로 복원
+      emitModule.sseClients = originalSseClients;
+    });
+
+    it("다양한 사용자 타입에 대해 올바른 페이로드를 전송한다", async () => {
+      // Setup
+      const userTypes: UserType[] = ["CUSTOMER", "MOVER"];
+      const mockClient = {
+        write: jest.fn(),
+      };
+
+      // sseClients를 직접 모킹
+      const emitModule = require("./emitNotificationSSE");
+      const originalSseClients = emitModule.sseClients;
+      emitModule.sseClients = new Map();
+      emitModule.sseClients.set("user-1", mockClient);
+
+      (mockPrisma.notification.count as jest.Mock).mockResolvedValue(1);
+
+      // Exercise & Assertion
+      for (const userType of userTypes) {
+        const notification: Notification = {
+          id: `notification-${userType}`,
+          actionId: "action-1",
+          userId: "user-1",
+          userType,
+          type: "ESTIMATE_REQUEST_ARRIVED" as NotificationType,
+          title: `${userType} 알림`,
+          content: `${userType} 알림 내용`,
+          path: "/test",
+          isRead: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        };
+
+        await emitNotificationSSE("user-1", notification);
+
+        expect(mockClient.write).toHaveBeenCalledWith("event: notification\n");
+        expect(mockClient.write).toHaveBeenCalledWith(
+          `data: ${JSON.stringify({
+            notification,
+            unreadCount: 1,
+            hasUnread: true,
+          })}\n\n`
+        );
+      }
+
+      // 원래 상태로 복원
+      emitModule.sseClients = originalSseClients;
+    });
+  });
+}); 

--- a/src/utils/emitNotificationSSE.ts
+++ b/src/utils/emitNotificationSSE.ts
@@ -1,6 +1,7 @@
 import { Notification } from "@prisma/client";
 import { Response } from "express";
 import prisma from "../db/prisma/prisma";
+import { captureSSEError } from "./sentryUtils";
 
 // NotificationEvent 타입에 hasUnread 추가
 export type NotificationEvent = {
@@ -18,20 +19,28 @@ const sseClients = new Map<string, Response>();
  * @param res SSE Response 객체
  */
 export function registerSSE(userId: string, res: Response) {
-  res.writeHead(200, {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
+  try {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
 
-  res.write("\n"); // 연결 초기화
+    res.write("\n"); // 연결 초기화
 
-  sseClients.set(userId, res);
+    sseClients.set(userId, res);
 
-  // 연결 끊김 감지
-  res.on("close", () => {
-    sseClients.delete(userId);
-  });
+    // 연결 끊김 감지
+    res.on("close", () => {
+      sseClients.delete(userId);
+    });
+  } catch (error) {
+    captureSSEError(error as Error, {
+      operation: "register_sse",
+      userId,
+    });
+    throw error;
+  }
 }
 
 /**
@@ -43,26 +52,35 @@ export async function emitNotificationSSE(
   userId: string,
   notification: Notification
 ) {
-  const client = sseClients.get(userId);
-  if (!client) {
-    return;
-  }
+  try {
+    const client = sseClients.get(userId);
+    if (!client) {
+      return;
+    }
 
-  // 안읽은 알림 개수와 hasUnread 동시 계산
-  const unreadCount = await prisma.notification.count({
-    where: {
+    // 안읽은 알림 개수와 hasUnread 동시 계산
+    const unreadCount = await prisma.notification.count({
+      where: {
+        userId,
+        isRead: false,
+      },
+    });
+    const hasUnread = unreadCount > 0;
+
+    const payload: NotificationEvent = {
+      notification,
+      unreadCount,
+      hasUnread,
+    };
+
+    client.write(`event: notification\n`);
+    client.write(`data: ${JSON.stringify(payload)}\n\n`);
+  } catch (error) {
+    captureSSEError(error as Error, {
+      operation: "emit_notification_sse",
       userId,
-      isRead: false,
-    },
-  });
-  const hasUnread = unreadCount > 0;
-
-  const payload: NotificationEvent = {
-    notification,
-    unreadCount,
-    hasUnread,
-  };
-
-  client.write(`event: notification\n`);
-  client.write(`data: ${JSON.stringify(payload)}\n\n`);
+      notificationId: notification.id,
+    });
+    throw error;
+  }
 }

--- a/src/utils/emitNotificationSSE.ts
+++ b/src/utils/emitNotificationSSE.ts
@@ -44,7 +44,9 @@ export async function emitNotificationSSE(
   notification: Notification
 ) {
   const client = sseClients.get(userId);
-  if (!client) return;
+  if (!client) {
+    return;
+  }
 
   // 안읽은 알림 개수와 hasUnread 동시 계산
   const unreadCount = await prisma.notification.count({

--- a/src/utils/sentryUtils.ts
+++ b/src/utils/sentryUtils.ts
@@ -111,6 +111,87 @@ export const captureAuthError = (
 };
 
 /**
+ * 알림 생성 관련 에러를 센트리로 전송
+ * @param error 에러 객체
+ * @param context 추가 컨텍스트 정보
+ */
+export const captureNotificationError = (
+  error: Error,
+  context: {
+    operation: string;
+    actionType?: string;
+    userId?: string;
+    userType?: string;
+    notificationType?: string;
+  },
+) => {
+  Sentry.captureException(error, {
+    extra: {
+      userId: context.userId,
+      actionType: context.actionType,
+      notificationType: context.notificationType,
+    },
+    tags: {
+      error_type: "notification_error",
+      operation: context.operation,
+      user_type: context.userType || "unknown",
+    },
+  });
+};
+
+/**
+ * SSE 관련 에러를 센트리로 전송
+ * @param error 에러 객체
+ * @param context 추가 컨텍스트 정보
+ */
+export const captureSSEError = (
+  error: Error,
+  context: {
+    operation: string;
+    userId?: string;
+    notificationId?: string;
+  },
+) => {
+  Sentry.captureException(error, {
+    extra: {
+      userId: context.userId,
+      notificationId: context.notificationId,
+    },
+    tags: {
+      error_type: "sse_error",
+      operation: context.operation,
+    },
+  });
+};
+
+/**
+ * 알림 액션 매핑 관련 에러를 센트리로 전송
+ * @param error 에러 객체
+ * @param context 추가 컨텍스트 정보
+ */
+export const captureActionMappingError = (
+  error: Error,
+  context: {
+    operation: string;
+    actionType?: string;
+    entityId?: string;
+    entityType?: string;
+  },
+) => {
+  Sentry.captureException(error, {
+    extra: {
+      actionType: context.actionType,
+      entityId: context.entityId,
+      entityType: context.entityType,
+    },
+    tags: {
+      error_type: "action_mapping_error",
+      operation: context.operation,
+    },
+  });
+};
+
+/**
  * 사용자 컨텍스트 설정
  * @param userId 사용자 ID
  * @param userType 사용자 타입


### PR DESCRIPTION
## ✨ 작업 개요

- 3차 QA 피드백 반영 및 sentry 모니터링 추가.

## ✅ 주요 작업 내용


- 기사님도 회원가입 알림 받게 수정. -> 회원가입 시점에서 프로필 등록 시점으로 고객과 기사님 각각의 알림 생성.
- 고객의 견적을 반려했을때 오는 알림 오류 수정. -> 지정 견적만 알림 생성.
- SSE 실시간 알림 문제 로직 수정.
- sentry 캡쳐 코드 추가로 에러처리 모니터링 추가.

## 🔄 관련 이슈

Closes #258 - sentry 추가.
Closes #263 - 피드백 반영.

