### PR TITLE
fix:CSRF- 쿠키기반으로 변경 후 AWS ElasticCache 사용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/morgan": "^1.9.10",
         "@types/node-cron": "^3.0.11",
         "@types/passport-jwt": "^4.0.1",
+        "@types/redis": "^4.0.10",
         "@types/uuid": "^10.0.0",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.7",
@@ -35,6 +36,7 @@
         "passport-kakao": "^1.0.1",
         "passport-local": "^1.0.0",
         "passport-naver": "^1.0.6",
+        "redis": "^5.8.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.0"
@@ -2706,6 +2708,66 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.8.0.tgz",
+      "integrity": "sha512-kpKZzAAjGiGYn88Bqq6+ozxPg6kGYWRZH9vnOwGcoSCbrW14SZpZVMYMFSio8FH9ZJUdUcmT/RLGlA1W1t0UWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.0.tgz",
+      "integrity": "sha512-ywZjKGoSSAECGYOd9bJpws6d4867SN686obUWT/sRmo1c/Q8V+jWyInvlqwKa0BOvTHHwYeB2WFUEvd6PADeOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.8.0.tgz",
+      "integrity": "sha512-xPBpwY6aKoRzMSu67MpwrBiSliON9bfHo9Y/pSPBjW8/KoOm1MzGqwJUO20qdjXpFoKJsDWwxIE1LHdBNzcImw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.8.0.tgz",
+      "integrity": "sha512-lF9pNv9vySmirm1EzCH6YeRjhvH6lLT7tvebYHEM7WTkEQ/7kZWb4athliKESHpxzTQ36U9UbzuedSywHV6OhQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.8.0.tgz",
+      "integrity": "sha512-kPTlW2ACXokjQNXjCD8Pw9mHDoB94AHUlHFahyjxz9lUJUVwiva2Dgfrd2k3JxHhSBqyY2PREIj9YwIUSTSSqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.0"
+      }
+    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -3852,6 +3914,15 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/redis": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.10.tgz",
+      "integrity": "sha512-7CLy5b5fzzEGVcOccgZjoMlNpPhX6d10jEeRy2YWbFuaMNrSPc9ExRsMYsd+0VxvEHucf4EWx24Ja7cSU1FGUA==",
+      "license": "MIT",
+      "dependencies": {
+        "redis": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -4750,6 +4821,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -8383,6 +8463,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.8.0.tgz",
+      "integrity": "sha512-re0MHm1KHbiVIUPDGoUM3jldvjH5EM/wGZ3A33gyUYoC/UnVNKNnZHM5hcJVry7L2O2eJU3nflSXTliv10BTKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.8.0",
+        "@redis/client": "5.8.0",
+        "@redis/json": "5.8.0",
+        "@redis/search": "5.8.0",
+        "@redis/time-series": "5.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/morgan": "^1.9.10",
     "@types/node-cron": "^3.0.11",
     "@types/passport-jwt": "^4.0.1",
+    "@types/redis": "^4.0.10",
     "@types/uuid": "^10.0.0",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
@@ -55,6 +56,7 @@
     "passport-kakao": "^1.0.1",
     "passport-local": "^1.0.0",
     "passport-naver": "^1.0.6",
+    "redis": "^5.8.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import cookieParser from "cookie-parser";
 import { initializeScheduler } from "./utils/scheduler";
 import { generateCSRFToken } from "./middlewares/csrfMiddleware";
 import * as Sentry from "@sentry/node";
+import { connectRedis } from "./config/redis";
 
 // 라우터 import
 import authIndexRoutes from "./routes/authIndex.routes";
@@ -99,8 +100,20 @@ initializeScheduler();
 Sentry.setupExpressErrorHandler(app);
 
 // 서버 시작
-app.listen(PORT, () => {
-  console.log(`서버가 실행되었습니다. 포트번호 ${PORT} 에서 실행중입니다.`);
-});
+const startServer = async () => {
+  try {
+    // Redis 연결 초기화
+    await connectRedis();
+
+    app.listen(PORT, () => {
+      console.log(`서버가 실행되었습니다. 포트번호 ${PORT} 에서 실행중입니다.`);
+    });
+  } catch (error) {
+    console.error("서버 시작 실패:", error);
+    process.exit(1);
+  }
+};
+
+startServer();
 
 export default app;

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,0 +1,43 @@
+import { createClient } from "redis";
+
+// Redis 클라이언트 생성
+const redisClient = createClient({
+  url: process.env.REDIS_URL,
+  socket: {
+    connectTimeout: 10000,
+    reconnectStrategy: (retries) => {
+      if (retries > 10) {
+        console.error("Redis 연결 재시도 횟수 초과");
+        return new Error("Redis 연결 실패");
+      }
+      return Math.min(retries * 100, 3000);
+    },
+  },
+});
+
+// Redis 연결 이벤트 핸들러
+redisClient.on("connect", () => {
+  console.log("✅ Redis 서버에 연결되었습니다.");
+});
+
+redisClient.on("error", (err) => {
+  console.error("❌ Redis 연결 오류:", err);
+});
+
+redisClient.on("reconnecting", () => {
+  console.log("🔄 Redis 재연결 시도 중...");
+});
+
+// Redis 연결 함수
+export const connectRedis = async () => {
+  try {
+    await redisClient.connect();
+    return redisClient;
+  } catch (error) {
+    console.error("Redis 연결 실패:", error);
+    throw error;
+  }
+};
+
+// Redis 클라이언트 내보내기
+export default redisClient;

--- a/src/middlewares/csrfMiddleware.ts
+++ b/src/middlewares/csrfMiddleware.ts
@@ -1,44 +1,80 @@
 import { Request, Response, NextFunction } from "express";
 import crypto from "crypto";
+import redisClient from "../config/redis";
 
-// CSRF 토큰 저장소 (실제 프로덕션에서는 Redis 등을 사용)
-const csrfTokens = new Map<string, { token: string; expires: number }>();
+// CSRF 토큰 키 접두사
+const CSRF_TOKEN_PREFIX = "csrf:";
 
 // CSRF 토큰 생성 함수
 const generateToken = (): string => {
   return crypto.randomBytes(32).toString("hex");
 };
 
-// CSRF 토큰 검증 함수
-const validateToken = (sessionId: string, token: string): boolean => {
-  const stored = csrfTokens.get(sessionId);
-  if (!stored) return false;
+// Redis에 CSRF 토큰 저장
+const storeToken = async (token: string, expires: number): Promise<void> => {
+  try {
+    const key = `${CSRF_TOKEN_PREFIX}${token}`;
+    const expiresInSeconds = Math.floor((expires - Date.now()) / 1000);
 
-  // 토큰 만료 확인
-  if (Date.now() > stored.expires) {
-    csrfTokens.delete(sessionId);
-    return false;
+    await redisClient.setEx(key, expiresInSeconds, JSON.stringify({ token, expires }));
+  } catch (error) {
+    console.error("Redis 토큰 저장 실패:", error);
+    throw error;
   }
-
-  return stored.token === token;
 };
 
-// 세션 ID 생성 함수
-const getSessionId = (req: Request): string => {
-  // JWT 토큰에서 사용자 ID를 세션 ID로 사용
-  const userId = (req.user as any)?.userId;
-  return userId || req.ip || "anonymous";
+// Redis에서 CSRF 토큰 조회
+const getStoredToken = async (token: string): Promise<{ token: string; expires: number } | null> => {
+  try {
+    const key = `${CSRF_TOKEN_PREFIX}${token}`;
+    const data = await redisClient.get(key);
+
+    if (!data) return null;
+
+    return JSON.parse(data);
+  } catch (error) {
+    console.error("Redis 토큰 조회 실패:", error);
+    return null;
+  }
+};
+
+// Redis에서 CSRF 토큰 삭제
+const deleteToken = async (token: string): Promise<void> => {
+  try {
+    const key = `${CSRF_TOKEN_PREFIX}${token}`;
+    await redisClient.del(key);
+  } catch (error) {
+    console.error("Redis 토큰 삭제 실패:", error);
+  }
+};
+
+// CSRF 토큰 검증 함수
+const validateToken = async (token: string): Promise<boolean> => {
+  try {
+    const stored = await getStoredToken(token);
+    if (!stored) return false;
+
+    // 토큰 만료 확인
+    if (Date.now() > stored.expires) {
+      await deleteToken(token);
+      return false;
+    }
+
+    return stored.token === token;
+  } catch (error) {
+    console.error("토큰 검증 실패:", error);
+    return false;
+  }
 };
 
 // CSRF 토큰 생성 미들웨어
-export const generateCSRFToken = (req: Request, res: Response, next: NextFunction) => {
+export const generateCSRFToken = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const sessionId = getSessionId(req);
     const token = generateToken();
-    const expires = Date.now() + 15 * 60 * 1000; // 15분 (Access Token과 동일)
+    const expires = Date.now() + 15 * 60 * 1000; // 15분
 
-    // 토큰 저장
-    csrfTokens.set(sessionId, { token, expires });
+    // Redis에 토큰 저장
+    await storeToken(token, expires);
 
     // 응답 헤더에 CSRF 토큰 추가
     res.setHeader("X-CSRF-Token", token);
@@ -48,7 +84,7 @@ export const generateCSRFToken = (req: Request, res: Response, next: NextFunctio
       httpOnly: false, // 프론트엔드에서 접근 가능하도록
       secure: process.env.NODE_ENV === "production",
       sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-      maxAge: 15 * 60 * 1000, // 15분 (Access Token과 동일)
+      maxAge: 15 * 60 * 1000, // 15분
     });
 
     next();
@@ -62,9 +98,8 @@ export const generateCSRFToken = (req: Request, res: Response, next: NextFunctio
 };
 
 // CSRF 검증 미들웨어
-export const validateCSRFToken = (req: Request, res: Response, next: NextFunction) => {
+export const validateCSRFToken = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const sessionId = getSessionId(req);
     const token = (req.headers["x-csrf-token"] as string) || req.cookies["XSRF-TOKEN"];
 
     if (!token) {
@@ -74,7 +109,8 @@ export const validateCSRFToken = (req: Request, res: Response, next: NextFunctio
       });
     }
 
-    if (!validateToken(sessionId, token)) {
+    const isValid = await validateToken(token);
+    if (!isValid) {
       return res.status(403).json({
         success: false,
         message: "CSRF 토큰이 유효하지 않습니다. 페이지를 새로고침해주세요.",
@@ -92,21 +128,20 @@ export const validateCSRFToken = (req: Request, res: Response, next: NextFunctio
 };
 
 // CSRF 토큰 조회 API
-export const getCSRFToken = (req: Request, res: Response) => {
+export const getCSRFToken = async (req: Request, res: Response) => {
   try {
-    const sessionId = getSessionId(req);
     const token = generateToken();
-    const expires = Date.now() + 15 * 60 * 1000; // 15분 (Access Token과 동일)
+    const expires = Date.now() + 15 * 60 * 1000; // 15분
 
-    // 토큰 저장
-    csrfTokens.set(sessionId, { token, expires });
+    // Redis에 토큰 저장
+    await storeToken(token, expires);
 
     // 쿠키에도 토큰 설정
     res.cookie("XSRF-TOKEN", token, {
       httpOnly: false, // 프론트엔드에서 접근 가능하도록
       secure: process.env.NODE_ENV === "production",
       sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-      maxAge: 15 * 60 * 1000, // 15분 (Access Token과 동일)
+      maxAge: 15 * 60 * 1000, // 15분
     });
 
     res.json({
@@ -126,26 +161,35 @@ export const getCSRFToken = (req: Request, res: Response) => {
 };
 
 // 만료된 토큰 정리 함수 (스케줄러에서 호출)
-export const cleanupExpiredTokens = () => {
-  const now = Date.now();
-  let cleanedCount = 0;
-
-  for (const [sessionId, data] of csrfTokens.entries()) {
-    if (now > data.expires) {
-      csrfTokens.delete(sessionId);
-      cleanedCount++;
-    }
+export const cleanupExpiredTokens = async (): Promise<number> => {
+  try {
+    // Redis는 자동으로 만료된 키를 삭제하므로 별도 정리 로직이 필요하지 않음
+    console.log("🧹 Redis는 자동으로 만료된 CSRF 토큰을 정리합니다.");
+    return 0;
+  } catch (error) {
+    console.error("CSRF 토큰 정리 실패:", error);
+    return 0;
   }
-
-  console.log(`🧹 CSRF 토큰 정리 완료: ${cleanedCount}개 만료된 토큰 삭제`);
-  return cleanedCount;
 };
 
 // 토큰 저장소 상태 조회 함수
-export const getCSRFTokenStats = () => {
-  return {
-    totalTokens: csrfTokens.size,
-    activeTokens: Array.from(csrfTokens.values()).filter((data) => Date.now() <= data.expires).length,
-    expiredTokens: Array.from(csrfTokens.values()).filter((data) => Date.now() > data.expires).length,
-  };
+export const getCSRFTokenStats = async () => {
+  try {
+    // Redis에서 CSRF 토큰 패턴으로 키 개수 조회
+    const pattern = `${CSRF_TOKEN_PREFIX}*`;
+    const keys = await redisClient.keys(pattern);
+
+    return {
+      totalTokens: keys.length,
+      activeTokens: keys.length, // Redis는 자동으로 만료된 키를 삭제하므로 모든 키가 활성 상태
+      expiredTokens: 0, // Redis가 자동으로 처리
+    };
+  } catch (error) {
+    console.error("CSRF 토큰 통계 조회 실패:", error);
+    return {
+      totalTokens: 0,
+      activeTokens: 0,
+      expiredTokens: 0,
+    };
+  }
 };

--- a/src/routes/estimateRequest.routes.ts
+++ b/src/routes/estimateRequest.routes.ts
@@ -3,6 +3,7 @@ import EstimateRequestController from "../controllers/estimateRequest.controller
 import { verifyAccessToken } from "../middlewares/verifyToken";
 import { defaultTranslationMiddleware } from "../middlewares/translationMiddleware";
 import { estimateRequestLimiter } from "../middlewares/rateLimiter";
+import { validateCSRFToken } from "../middlewares/csrfMiddleware";
 
 const router = Router();
 const estimateRequestController = new EstimateRequestController();
@@ -302,7 +303,7 @@ const estimateRequestController = new EstimateRequestController();
  *               success: false
  *               message: "서버 내부 오류가 발생했습니다."
  */
-router.post("/create", verifyAccessToken, estimateRequestLimiter, (req, res) =>
+router.post("/create", verifyAccessToken, validateCSRFToken, estimateRequestLimiter, (req, res) =>
   estimateRequestController.createEstimateRequest(req, res),
 );
 
@@ -521,7 +522,7 @@ router.get("/active", verifyAccessToken, defaultTranslationMiddleware, (req, res
  *               success: false
  *               message: "서버 내부 오류가 발생했습니다."
  */
-router.patch("/active", verifyAccessToken, estimateRequestLimiter, (req, res) =>
+router.patch("/active", verifyAccessToken, validateCSRFToken, estimateRequestLimiter, (req, res) =>
   estimateRequestController.updateActiveEstimateRequest(req, res),
 );
 
@@ -592,7 +593,7 @@ router.patch("/active", verifyAccessToken, estimateRequestLimiter, (req, res) =>
  *               success: false
  *               message: "서버 내부 오류가 발생했습니다."
  */
-router.delete("/active", verifyAccessToken, (req, res) =>
+router.delete("/active", verifyAccessToken, validateCSRFToken, (req, res) =>
   estimateRequestController.cancelActiveEstimateRequest(req, res),
 );
 


### PR DESCRIPTION
## ✨ 작업 개요

- CSRF 쿠키 기반으로 변경
- CSRF REDIS 사용으로 변경

## ✅ 주요 작업 내용

- 기존 메모리 저장하던 CSRF 토큰을 AWS REDIS 사용
- CSRF 쿠키 기반으로 변경

## 🔄 관련 이슈


## 📎 참고 자료 (선택)

## 🧪 테스트 방법 (선택)
- 모든 API 테스트 시 정상 작동확인
- 프론트 견적요청까지 적용 시 정상 작동 확인 완료
- 
## 📝 비고
