### PR TITLE
[#275] test : user 유닛 테스트 작성

### DIFF
--- a/src/controllers/user.controller.test.ts
+++ b/src/controllers/user.controller.test.ts
@@ -1,0 +1,498 @@
+import {
+  getProfile,
+  getUser,
+  patchCustomerProfile,
+  patchMoverBasicInfo,
+  patchMoverProfile,
+  postProfile,
+} from "./user.controller";
+import * as userService from "../services/user.service";
+import { handleError } from "../utils/handleError";
+import { Request, Response } from "express";
+import {
+  PROFILE_ERROR_MESSAGES,
+  PROFILE_SUCCESS_MESSAGES,
+} from "../constants/profile.constants";
+import { TUserRole } from "../types/user.types";
+
+jest.mock("../services/user.service");
+jest.mock("../utils/handleError");
+
+describe("유저 정보 조회 컨트롤러 (getUser)", () => {
+  const mockUserInfo = userService.userInfo as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    user: {
+      userId: "user-123",
+      userType: "CUSTOMER",
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 유저 정보 조회 성공 시 응답 반환", async () => {
+    const fakeUser = {
+      id: "user-123",
+      name: "홍길동",
+      userType: "CUSTOMER",
+    };
+
+    mockUserInfo.mockResolvedValue(fakeUser);
+
+    await getUser(mockReq, mockRes);
+
+    expect(mockUserInfo).toHaveBeenCalledWith("user-123", "CUSTOMER");
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      data: fakeUser,
+    });
+  });
+
+  it("❌ 유저 정보 조회 실패 시 handleError 호출", async () => {
+    const error = new Error("조회 실패");
+    mockUserInfo.mockRejectedValue(error);
+
+    await getUser(mockReq, mockRes);
+
+    expect(mockUserInfo).toHaveBeenCalled();
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("프로필 조회 컨트롤러 (getProfile)", () => {
+  const mockGetProfileData = userService.getProfileData as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockReq = {
+    user: {
+      userId: "user-456",
+      userType: "MOVER",
+    },
+  } as Partial<Request> as Request;
+
+  const mockRes = {
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 프로필 조회 성공 시 응답 반환", async () => {
+    const mockProfile = {
+      nickname: "이사왕",
+      moverImage: "https://example.com/image.jpg",
+      currentAreas: ["강남구", "송파구"],
+      serviceTypes: ["소형이사", "보관이사"],
+    };
+
+    mockGetProfileData.mockResolvedValue(mockProfile);
+
+    await getProfile(mockReq, mockRes);
+
+    expect(mockGetProfileData).toHaveBeenCalledWith("user-456", "MOVER");
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      data: mockProfile,
+    });
+  });
+
+  it("❌ 프로필 조회 실패 시 handleError 호출", async () => {
+    const error = new Error("프로필 조회 실패");
+    mockGetProfileData.mockRejectedValue(error);
+
+    await getProfile(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("프로필 등록 컨트롤러 (postProfile)", () => {
+  const mockCreateCustomerProfile =
+    userService.createCustomerProfile as jest.Mock;
+  const mockCreateMoverProfile = userService.createMoverProfile as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ CUSTOMER 프로필 등록 성공 시 쿠키 설정 및 응답 반환", async () => {
+    const mockReq = {
+      user: { userId: "user-1", userType: "CUSTOMER" },
+      body: {
+        nickname: "홍길동",
+        customerImage: "image.jpg",
+        currentArea: "강남구",
+        preferredServices: ["소형이사"],
+      },
+    } as Partial<Request> as Request;
+
+    const fakeResult = {
+      result: { id: "profile-1", nickname: "홍길동" },
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      provider: "LOCAL",
+    };
+
+    mockCreateCustomerProfile.mockResolvedValue(fakeResult);
+
+    await postProfile(mockReq, mockRes);
+
+    expect(mockCreateCustomerProfile).toHaveBeenCalledWith("user-1", {
+      nickname: "홍길동",
+      customerImage: "image.jpg",
+      currentArea: "강남구",
+      preferredServices: ["소형이사"],
+    });
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "accessToken",
+      "access-token",
+      expect.objectContaining({ httpOnly: false })
+    );
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "refreshToken",
+      "refresh-token",
+      expect.any(Object)
+    );
+
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: PROFILE_SUCCESS_MESSAGES.CUSTOMER_PROFILE_CREATED,
+      data: fakeResult.result,
+    });
+  });
+
+  it("✅ MOVER 프로필 등록 성공 시 쿠키 설정 및 응답 반환", async () => {
+    const mockReq = {
+      user: { userId: "user-2", userType: "MOVER" },
+      body: {
+        nickname: "이사왕",
+        moverImage: "mover.jpg",
+        career: 5,
+        shortIntro: "짧은 소개",
+        detailIntro: "긴 소개입니다.",
+        currentAreas: ["송파구", "서초구"],
+        serviceTypes: ["보관이사"],
+      },
+    } as Partial<Request> as Request;
+
+    const fakeResult = {
+      result: { id: "profile-2", nickname: "이사왕" },
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    };
+
+    mockCreateMoverProfile.mockResolvedValue(fakeResult);
+
+    await postProfile(mockReq, mockRes);
+
+    expect(mockCreateMoverProfile).toHaveBeenCalledWith("user-2", {
+      nickname: "이사왕",
+      moverImage: "mover.jpg",
+      career: 5,
+      shortIntro: "짧은 소개",
+      detailIntro: "긴 소개입니다.",
+      currentAreas: ["송파구", "서초구"],
+      serviceTypes: ["보관이사"],
+    });
+
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "accessToken",
+      "access-token",
+      expect.objectContaining({ httpOnly: false })
+    );
+    expect(mockRes.cookie).toHaveBeenCalledWith(
+      "refreshToken",
+      "refresh-token",
+      expect.any(Object)
+    );
+
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: PROFILE_SUCCESS_MESSAGES.MOVER_PROFILE_CREATED,
+      data: fakeResult.result,
+    });
+  });
+
+  it("❌ 유효하지 않은 userType일 경우 400 반환", async () => {
+    const mockReq = {
+      user: { userId: "user-3", userType: "ADMIN" as unknown as TUserRole }, // 잘못된 userType
+      body: {},
+    } as Partial<Request> as Request;
+
+    await postProfile(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: false,
+      message: PROFILE_ERROR_MESSAGES.INVALID_USER_ROLE,
+    });
+  });
+
+  it("❌ CUSTOMER 프로필 등록 중 오류 발생 시 handleError 호출", async () => {
+    const mockReq = {
+      user: { userId: "user-4", userType: "CUSTOMER" },
+      body: {
+        nickname: "에러고객",
+        customerImage: "error.jpg",
+        currentArea: "노원구",
+        preferredServices: ["원룸이사"],
+      },
+    } as Partial<Request> as Request;
+
+    const error = new Error("등록 실패");
+    mockCreateCustomerProfile.mockRejectedValue(error);
+
+    await postProfile(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+
+  it("❌ MOVER 프로필 등록 중 오류 발생 시 handleError 호출", async () => {
+    const mockReq = {
+      user: { userId: "user-5", userType: "MOVER" },
+      body: {
+        nickname: "에러기사",
+        moverImage: "mover.jpg",
+        career: 1,
+        shortIntro: "에러 짧은 소개",
+        detailIntro: "에러 긴 소개",
+        currentAreas: ["성북구"],
+        serviceTypes: ["가정이사"],
+      },
+    } as Partial<Request> as Request;
+
+    const error = new Error("등록 실패");
+    mockCreateMoverProfile.mockRejectedValue(error);
+
+    await postProfile(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("일반 유저 프로필 수정 컨트롤러 (patchCustomerProfile)", () => {
+  const mockUpdateCustomerProfileCheck =
+    userService.updateCustomerProfileCheck as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockRes = {
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 일반 유저 프로필 수정 성공 시 응답 반환", async () => {
+    const mockReq = {
+      user: { userId: "user-1" },
+      body: {
+        name: "홍길동",
+        nickname: "길동이",
+        email: "gil@example.com",
+        phoneNumber: "01012345678",
+        password: "oldPass123!",
+        newPassword: "newPass456!",
+        customerImage: "image.jpg",
+        currentArea: "강남구",
+        preferredServices: ["소형이사"],
+      },
+    } as Partial<Request> as Request;
+
+    await patchCustomerProfile(mockReq, mockRes);
+
+    expect(mockUpdateCustomerProfileCheck).toHaveBeenCalledWith("user-1", {
+      name: "홍길동",
+      nickname: "길동이",
+      email: "gil@example.com",
+      phoneNumber: "01012345678",
+      password: "oldPass123!",
+      newPassword: "newPass456!",
+      customerImage: "image.jpg",
+      currentArea: "강남구",
+      preferredServices: ["소형이사"],
+    });
+
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: PROFILE_SUCCESS_MESSAGES.CUSTOMER_PROFILE_UPDATED,
+      data: {
+        name: "홍길동",
+        nickname: "길동이",
+        email: "gil@example.com",
+        phoneNumber: "01012345678",
+        password: "oldPass123!",
+        newPassword: "newPass456!",
+        customerImage: "image.jpg",
+        currentArea: "강남구",
+        preferredServices: ["소형이사"],
+      },
+    });
+  });
+
+  it("❌ 프로필 수정 중 오류 발생 시 handleError 호출", async () => {
+    const mockReq = {
+      user: { userId: "user-2" },
+      body: {
+        name: "에러유저",
+      },
+    } as Partial<Request> as Request;
+
+    const error = new Error("수정 실패");
+    mockUpdateCustomerProfileCheck.mockRejectedValue(error);
+
+    await patchCustomerProfile(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});
+
+describe("기사님 기본정보 수정 컨트롤러 (patchMoverBasicInfo)", () => {
+  const mockUpdateMoverBasicInfo =
+    userService.updateMoverBasicInfo as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockRes = {
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 기사님 기본정보 수정 성공 시 응답 반환", async () => {
+    const mockReq = {
+      user: { userId: "user-123" },
+      body: {
+        name: "이사왕",
+        phoneNumber: "01012345678",
+        currentPassword: "oldpass123",
+        newPassword: "newpass456",
+      },
+    } as Partial<Request> as Request;
+
+    await patchMoverBasicInfo(mockReq, mockRes);
+
+    expect(mockUpdateMoverBasicInfo).toHaveBeenCalledWith("user-123", {
+      name: "이사왕",
+      phoneNumber: "01012345678",
+      currentPassword: "oldpass123",
+      newPassword: "newpass456",
+    });
+
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "기사님 기본정보가 성공적으로 수정되었습니다.",
+    });
+  });
+
+  it("❌ 수정 중 오류 발생 시 handleError 호출", async () => {
+    const mockReq = {
+      user: { userId: "user-123" },
+      body: {
+        name: "이사왕",
+      },
+    } as Partial<Request> as Request;
+
+    const error = new Error("수정 실패");
+    mockUpdateMoverBasicInfo.mockRejectedValue(error);
+
+    await patchMoverBasicInfo(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(
+      mockRes,
+      error,
+      "기사님 기본정보 수정 중 오류가 발생했습니다"
+    );
+  });
+});
+
+describe("기사님 프로필 수정 컨트롤러 (patchMoverProfile)", () => {
+  const mockUpdateMoverProfileCheck =
+    userService.updateMoverProfileCheck as jest.Mock;
+  const mockHandleError = handleError as jest.Mock;
+
+  const mockRes = {
+    json: jest.fn(),
+  } as Partial<Response> as Response;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("✅ 기사님 프로필 수정 성공 시 응답 반환", async () => {
+    const mockReq = {
+      user: { userId: "user-456" },
+      body: {
+        nickname: "이사천국",
+        moverImage: "mover.jpg",
+        currentAreas: ["강남구", "송파구"],
+        serviceTypes: ["소형이사"],
+        shortIntro: "짧은 소개",
+        detailIntro: "긴 소개글입니다.",
+        career: 10,
+        isVeteran: true,
+      },
+    } as Partial<Request> as Request;
+
+    const fakeResult = {
+      nickname: "이사천국",
+      career: 10,
+      isVeteran: true,
+    };
+
+    mockUpdateMoverProfileCheck.mockResolvedValue(fakeResult);
+
+    await patchMoverProfile(mockReq, mockRes);
+
+    expect(mockUpdateMoverProfileCheck).toHaveBeenCalledWith("user-456", {
+      nickname: "이사천국",
+      moverImage: "mover.jpg",
+      currentAreas: ["강남구", "송파구"],
+      serviceTypes: ["소형이사"],
+      shortIntro: "짧은 소개",
+      detailIntro: "긴 소개글입니다.",
+      career: 10,
+      isVeteran: true,
+    });
+
+    expect(mockRes.json).toHaveBeenCalledWith({
+      success: true,
+      message: "기사님 프로필이 성공적으로 수정되었습니다.",
+      data: fakeResult,
+    });
+  });
+
+  it("❌ 수정 중 오류 발생 시 handleError 호출", async () => {
+    const mockReq = {
+      user: { userId: "user-456" },
+      body: {
+        nickname: "에러기사",
+      },
+    } as Partial<Request> as Request;
+
+    const error = new Error("수정 실패");
+    mockUpdateMoverProfileCheck.mockRejectedValue(error);
+
+    await patchMoverProfile(mockReq, mockRes);
+
+    expect(mockHandleError).toHaveBeenCalledWith(mockRes, error);
+  });
+});

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -44,9 +44,13 @@ const getProfile = async (req: Request, res: Response) => {
     userType: TUserRole;
   };
 
-  const profile = await getProfileData(userId, userType);
+  try {
+    const profile = await getProfileData(userId, userType);
 
-  res.json({ success: true, data: profile });
+    res.json({ success: true, data: profile });
+  } catch (error) {
+    handleError(res, error);
+  }
 };
 
 // 프로필 등록

--- a/src/repositories/user.repository.test.ts
+++ b/src/repositories/user.repository.test.ts
@@ -1,0 +1,945 @@
+import userRepository from "./user.repository";
+import prisma from "../db/prisma/prisma";
+import { MoveType, RegionType } from "@prisma/client";
+import { TCreateMoverProfile, TServiceId } from "../types/user.types";
+
+jest.mock("../db/prisma/prisma", () => ({
+  __esModule: true,
+  default: {
+    user: {
+      update: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+describe("userRepository", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getUserById", () => {
+    const userId = "user-123";
+
+    const mockUser = {
+      id: userId,
+      name: "홍길동",
+      email: "hong@example.com",
+      encryptedPhoneNumber: "encrypted-01012345678",
+      currentArea: "강남구",
+      preferredServices: ["소형이사", "보관이사"],
+      nickname: "이사왕",
+      customerImage: "customer.jpg",
+      moverImage: "mover.jpg",
+      userType: ["CUSTOMER"],
+      refreshToken: "refresh-token",
+      provider: "LOCAL",
+      isCustomer: true,
+      isMover: false,
+    };
+
+    it("✅ 유저 ID로 유저 정보를 조회하고 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const result = await userRepository.getUserById(userId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          encryptedPhoneNumber: true,
+          currentArea: true,
+          preferredServices: true,
+          nickname: true,
+          customerImage: true,
+          moverImage: true,
+          userType: true,
+          refreshToken: true,
+          provider: true,
+          isCustomer: true,
+          isMover: true,
+        },
+      });
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("❌ 유저가 존재하지 않으면 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.getUserById(userId);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(userRepository.getUserById(userId)).rejects.toThrow(
+        "DB 오류"
+      );
+    });
+  });
+
+  describe("getUserWithPassword", () => {
+    const userId = "user-456";
+
+    const mockUser = {
+      id: userId,
+      name: "이비번",
+      encryptedPassword: "hashed_password",
+      currentArea: "서초구",
+      userType: ["MOVER"],
+    };
+
+    it("✅ 유저 ID로 유저 정보(비밀번호 포함)를 조회하고 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+      const result = await userRepository.getUserWithPassword(userId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          encryptedPassword: true,
+          currentArea: true,
+          userType: true,
+        },
+      });
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it("❌ 유저가 존재하지 않으면 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.getUserWithPassword(userId);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 조회 실패")
+      );
+
+      await expect(userRepository.getUserWithPassword(userId)).rejects.toThrow(
+        "DB 조회 실패"
+      );
+    });
+  });
+
+  describe("getCustomerProfile", () => {
+    const userId = "customer-123";
+
+    const mockProfile = {
+      name: "홍길동",
+      nickname: "길동이",
+      email: "gil@example.com",
+      encryptedPhoneNumber: "encrypted-01012345678",
+      customerImage: "customer.jpg",
+      preferredServices: ["소형이사"],
+      currentArea: "강남구",
+    };
+
+    it("✅ 일반 유저 프로필을 정상적으로 조회하고 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockProfile);
+
+      const result = await userRepository.getCustomerProfile(userId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+        select: {
+          name: true,
+          nickname: true,
+          email: true,
+          encryptedPhoneNumber: true,
+          customerImage: true,
+          preferredServices: true,
+          currentArea: true,
+        },
+      });
+
+      expect(result).toEqual(mockProfile);
+    });
+
+    it("❌ 유저가 존재하지 않으면 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.getCustomerProfile(userId);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(userRepository.getCustomerProfile(userId)).rejects.toThrow(
+        "DB 오류"
+      );
+    });
+  });
+
+  describe("getMoverProfile", () => {
+    const userId = "mover-123";
+
+    const mockProfile = {
+      name: "이사왕",
+      nickname: "프로이사꾼",
+      moverImage: "mover.jpg",
+      career: 5,
+      shortIntro: "빠르고 안전한 이사",
+      detailIntro: "5년 경력의 전문 이사 기사입니다.",
+      serviceTypes: ["보관이사", "가정이사"],
+      currentAreas: ["송파구", "강동구"],
+      isVeteran: true,
+      workedCount: 120,
+      averageRating: 4.9,
+      totalReviewCount: 50,
+      totalFavoriteCount: 30,
+    };
+
+    it("✅ 기사님 프로필을 정상적으로 조회하고 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockProfile);
+
+      const result = await userRepository.getMoverProfile(userId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+        select: {
+          name: true,
+          nickname: true,
+          moverImage: true,
+          career: true,
+          shortIntro: true,
+          detailIntro: true,
+          serviceTypes: true,
+          currentAreas: true,
+          isVeteran: true,
+          workedCount: true,
+          averageRating: true,
+          totalReviewCount: true,
+          totalFavoriteCount: true,
+        },
+      });
+
+      expect(result).toEqual(mockProfile);
+    });
+
+    it("❌ 유저가 존재하지 않으면 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.getMoverProfile(userId);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(userRepository.getMoverProfile(userId)).rejects.toThrow(
+        "DB 오류"
+      );
+    });
+  });
+
+  describe("createCustomerProfile", () => {
+    const mockProfileInput = {
+      userId: "customer-999",
+      nickname: "길동이",
+      customerImage: "profile.jpg",
+      currentArea: "SEOUL" as RegionType,
+      preferredServices: ["SMALL", "HOME"] as MoveType[],
+    };
+
+    const mockUpdatedUser = {
+      id: "customer-999",
+      name: "홍길동",
+      nickname: "길동이",
+      customerImage: "profile.jpg",
+      currentArea: "SEOUL" as RegionType,
+      preferredServices: ["SMALL", "HOME"] as MoveType[],
+    };
+
+    it("✅ 프로필 등록 시 유저 정보를 업데이트하고 결과를 반환한다", async () => {
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUpdatedUser);
+
+      const result =
+        await userRepository.createCustomerProfile(mockProfileInput);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: mockProfileInput.userId },
+        data: {
+          customerImage: mockProfileInput.customerImage,
+          currentArea: mockProfileInput.currentArea,
+          preferredServices: mockProfileInput.preferredServices,
+          nickname: mockProfileInput.nickname,
+          isCustomer: true,
+        },
+        select: {
+          id: true,
+          name: true,
+          nickname: true,
+          customerImage: true,
+          currentArea: true,
+          preferredServices: true,
+        },
+      });
+
+      expect(result).toEqual(mockUpdatedUser);
+    });
+
+    it("❌ 프로필 등록 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(
+        new Error("프로필 등록 실패")
+      );
+
+      await expect(
+        userRepository.createCustomerProfile(mockProfileInput)
+      ).rejects.toThrow("프로필 등록 실패");
+    });
+  });
+
+  describe("updateCustomerProfile", () => {
+    const userId = "customer-123";
+    const updateData = {
+      nickname: "테스트닉네임",
+      customerImage: "test-image.png",
+      currentArea: "SEOUL" as RegionType,
+      preferredServices: ["SMALL", "HOME"] as MoveType[],
+    };
+
+    it("✅ 고객 프로필 정보를 정상적으로 업데이트한다", async () => {
+      const mockUpdatedUser = { id: userId, ...updateData };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUpdatedUser);
+
+      const result = await userRepository.updateCustomerProfile(
+        userId,
+        updateData
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: updateData,
+      });
+
+      expect(result).toEqual(mockUpdatedUser);
+    });
+
+    it("❌ DB 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(new Error("DB 오류"));
+
+      await expect(
+        userRepository.updateCustomerProfile(userId, updateData)
+      ).rejects.toThrow("DB 오류");
+    });
+  });
+
+  describe("updateMoverProfile", () => {
+    const userId = "mover-999";
+
+    const updateData = {
+      nickname: "이사킹",
+      moverImage: "mover.jpg",
+      career: 10,
+      shortIntro: "친절하고 빠릅니다",
+      detailIntro: "10년 경력의 전문가입니다.",
+      serviceTypes: ["HOME", "OFFICE"] as MoveType[],
+      currentAreas: ["SEOUL", "GYEONGGI"] as RegionType[],
+      isVeteran: true,
+    };
+
+    const mockUpdatedProfile = {
+      id: userId,
+      name: "김기사",
+      nickname: "이사킹",
+      moverImage: "mover.jpg",
+      career: 10,
+      shortIntro: "친절하고 빠릅니다",
+      detailIntro: "10년 경력의 전문가입니다.",
+      serviceTypes: ["HOME", "OFFICE"],
+      currentAreas: ["SEOUL", "GYEONGGI"],
+      isVeteran: true,
+      workedCount: 120,
+      averageRating: 4.8,
+      totalReviewCount: 42,
+      totalFavoriteCount: 20,
+    };
+
+    it("✅ 기사님 프로필을 업데이트하고 결과를 반환한다", async () => {
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUpdatedProfile);
+
+      const result = await userRepository.updateMoverProfile(
+        userId,
+        updateData
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: updateData,
+        select: {
+          id: true,
+          name: true,
+          nickname: true,
+          moverImage: true,
+          career: true,
+          shortIntro: true,
+          detailIntro: true,
+          serviceTypes: true,
+          currentAreas: true,
+          isVeteran: true,
+          workedCount: true,
+          averageRating: true,
+          totalReviewCount: true,
+          totalFavoriteCount: true,
+        },
+      });
+
+      expect(result).toEqual(mockUpdatedProfile);
+    });
+
+    it("❌ 프로필 업데이트 중 오류가 발생하면 예외를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(
+        new Error("DB 업데이트 실패")
+      );
+
+      await expect(
+        userRepository.updateMoverProfile(userId, updateData)
+      ).rejects.toThrow("DB 업데이트 실패");
+    });
+  });
+
+  describe("createMoverProfile", () => {
+    const profileData: TCreateMoverProfile = {
+      userId: "user-999",
+      nickname: "철수",
+      moverImage: "mover.jpg",
+      career: 3,
+      shortIntro: "빠르고 친절해요!",
+      detailIntro: "서울 전 지역 가능, 1톤 트럭 보유",
+      serviceTypes: ["HOME", "OFFICE"],
+      currentAreas: ["SEOUL", "GYEONGGI"] as RegionType[],
+    };
+
+    const mockReturn = {
+      id: profileData.userId,
+      name: null,
+      ...profileData,
+      isVeteran: false,
+      workedCount: 0,
+      averageRating: 0,
+      totalReviewCount: 0,
+      totalFavoriteCount: 0,
+    };
+
+    it("✅ 기사님 프로필을 생성하고 사용자 정보를 반환한다", async () => {
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockReturn);
+
+      const result = await userRepository.createMoverProfile(profileData);
+
+      expect(result).toEqual(mockReturn);
+    });
+
+    it("❌ 프로필 생성 중 오류가 발생하면 예외를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(new Error("DB 오류"));
+
+      await expect(
+        userRepository.createMoverProfile(profileData)
+      ).rejects.toThrow("DB 오류");
+    });
+  });
+
+  describe("checkNicknameExists", () => {
+    const nickname = "이사왕";
+    const excludeUserId = "user-123";
+
+    it("✅ 해당 닉네임을 가진 유저가 존재하면 true를 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        id: "someone-else",
+        nickname,
+      });
+
+      const result = await userRepository.checkNicknameExists(nickname);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: {
+          nickname,
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("✅ excludeUserId를 전달하면 해당 유저를 제외하고 검색한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        id: "someone-else",
+        nickname,
+      });
+
+      const result = await userRepository.checkNicknameExists(
+        nickname,
+        excludeUserId
+      );
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: {
+          nickname,
+          NOT: { id: excludeUserId },
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("❌ 닉네임이 존재하지 않으면 false를 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.checkNicknameExists(nickname);
+
+      expect(result).toBe(false);
+    });
+
+    it("❌ DB 조회 중 오류가 발생하면 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(
+        userRepository.checkNicknameExists(nickname)
+      ).rejects.toThrow("DB 오류");
+    });
+  });
+
+  describe("updateUserProfile", () => {
+    const userId = "user-999";
+
+    const baseSelect = {
+      id: true,
+      name: true,
+      nickname: true,
+      customerImage: true,
+      moverImage: true,
+      currentArea: true,
+      preferredServices: true,
+      serviceTypes: true,
+      userType: true,
+    };
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    // ✅ 여기 추가
+    it("✅ currentRegion이 존재할 경우 currentArea를 업데이트한다", async () => {
+      const updateData = {
+        currentRegion: "SEOUL" as RegionType,
+      };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        currentArea: "SEOUL",
+      });
+
+      const result = await userRepository.updateUserProfile(userId, updateData);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {
+          currentArea: "SEOUL",
+        },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+        currentArea: "SEOUL",
+      });
+    });
+
+    it("✅ currentRegion이 undefined일 경우 currentArea를 업데이트하지 않는다", async () => {
+      const updateData = {
+        currentRegion: undefined,
+      };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({ id: userId });
+
+      const result = await userRepository.updateUserProfile(userId, updateData);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {},
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({ id: userId });
+    });
+
+    it("✅ 기본 정보만 업데이트 (이름, 전화번호, 비밀번호)", async () => {
+      const updateData = {
+        name: "홍길동",
+        encryptedPhoneNumber: "encrypted-01012345678",
+        encryptedPassword: "hashed_pw",
+      };
+
+      const mockUpdated = { id: userId, ...updateData };
+
+      (prisma.user.update as jest.Mock).mockResolvedValue(mockUpdated);
+
+      const result = await userRepository.updateUserProfile(userId, updateData);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: updateData,
+        select: baseSelect,
+      });
+
+      expect(result).toEqual(mockUpdated);
+    });
+
+    it("✅ 사용자 타입이 CUSTOMER일 때 customerImage 필드 업데이트", async () => {
+      const updateData = {
+        profileImage: "customer.jpg",
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["CUSTOMER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        customerImage: "customer.jpg",
+      });
+
+      const result = await userRepository.updateUserProfile(userId, updateData);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { customerImage: "customer.jpg" },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+        customerImage: "customer.jpg",
+      });
+    });
+
+    it("✅ 사용자 타입이 MOVER일 때 moverImage 필드 업데이트", async () => {
+      const updateData = {
+        profileImage: "mover.jpg",
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["MOVER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        moverImage: "mover.jpg",
+      });
+
+      const result = await userRepository.updateUserProfile(userId, updateData);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { moverImage: "mover.jpg" },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+        moverImage: "mover.jpg",
+      });
+    });
+
+    it("✅ 유저 정보가 없을 경우 이미지 필드 업데이트는 무시된다", async () => {
+      const updateData = {
+        profileImage: "no-user.jpg",
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+      });
+
+      const result = await userRepository.updateUserProfile(userId, updateData);
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {}, // user가 null이므로 이미지 필드 없음
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+      });
+    });
+
+    it("✅ serviceIds를 전달하면 userType에 따라 서비스 필드가 설정된다 (CUSTOMER)", async () => {
+      const serviceIds = [1, 2] as TServiceId[]; // SMALL, HOME
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["CUSTOMER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        preferredServices: ["SMALL", "HOME"],
+      });
+
+      const result = await userRepository.updateUserProfile(
+        userId,
+        {},
+        serviceIds
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {
+          preferredServices: ["SMALL", "HOME"],
+        },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+        preferredServices: ["SMALL", "HOME"],
+      });
+    });
+
+    it("✅ 서비스 타입 - CUSTOMER일 때 preferredServices 필드가 업데이트된다", async () => {
+      const serviceIds = [1, 3] as TServiceId[]; // SMALL, OFFICE
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["CUSTOMER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        preferredServices: ["SMALL", "OFFICE"],
+      });
+
+      const result = await userRepository.updateUserProfile(
+        userId,
+        {},
+        serviceIds
+      );
+
+      expect(result).toEqual({
+        id: userId,
+        preferredServices: ["SMALL", "OFFICE"],
+      });
+    });
+
+    it("✅ 서비스 타입 - MOVER일 때 serviceTypes 필드가 업데이트된다", async () => {
+      const serviceIds = [2, 3] as TServiceId[]; // HOME, OFFICE
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["MOVER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        serviceTypes: ["HOME", "OFFICE"],
+      });
+
+      const result = await userRepository.updateUserProfile(
+        userId,
+        {},
+        serviceIds
+      );
+
+      expect(result).toEqual({
+        id: userId,
+        serviceTypes: ["HOME", "OFFICE"],
+      });
+    });
+
+    it("✅ 유저 타입이 없을 때 서비스 필드는 업데이트되지 않는다", async () => {
+      const serviceIds = [1] as TServiceId[]; // SMALL
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: [],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+      });
+
+      const result = await userRepository.updateUserProfile(
+        userId,
+        {},
+        serviceIds
+      );
+
+      expect(result).toEqual({
+        id: userId,
+      });
+    });
+
+    it("✅ 알 수 없는 serviceId가 들어올 경우 fallback으로 SMALL 처리된다", async () => {
+      const serviceIds = [999] as unknown as TServiceId[];
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["CUSTOMER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        preferredServices: ["SMALL"],
+      });
+
+      const result = await userRepository.updateUserProfile(
+        userId,
+        {},
+        serviceIds
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { preferredServices: ["SMALL"] },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+        preferredServices: ["SMALL"],
+      });
+    });
+
+    it("✅ serviceIds를 전달하면 userType에 따라 서비스 필드가 설정된다 (MOVER)", async () => {
+      const serviceIds = [2, 3] as TServiceId[]; // HOME, OFFICE
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        userType: ["MOVER"],
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValue({
+        id: userId,
+        serviceTypes: ["HOME", "OFFICE"],
+      });
+
+      const result = await userRepository.updateUserProfile(
+        userId,
+        {},
+        serviceIds
+      );
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: {
+          serviceTypes: ["HOME", "OFFICE"],
+        },
+        select: baseSelect,
+      });
+
+      expect(result).toEqual({
+        id: userId,
+        serviceTypes: ["HOME", "OFFICE"],
+      });
+    });
+
+    it("❌ 업데이트 중 오류가 발생하면 예외를 throw한다", async () => {
+      (prisma.user.update as jest.Mock).mockRejectedValue(
+        new Error("업데이트 실패")
+      );
+
+      await expect(
+        userRepository.updateUserProfile(userId, { name: "에러" })
+      ).rejects.toThrow("업데이트 실패");
+    });
+  });
+
+  describe("getUserNameById", () => {
+    const userId = "user-777";
+
+    it("✅ 유저가 존재하면 이름을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+        name: "홍길동",
+      });
+
+      const result = await userRepository.getUserNameById(userId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: userId },
+        select: { name: true },
+      });
+
+      expect(result).toBe("홍길동");
+    });
+
+    it("❌ 유저가 존재하지 않으면 빈 문자열을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.getUserNameById(userId);
+
+      expect(result).toBe("");
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(userRepository.getUserNameById(userId)).rejects.toThrow(
+        "DB 오류"
+      );
+    });
+  });
+
+  describe("getMoverInfoById", () => {
+    const moverId = "mover-888";
+
+    const mockMover = {
+      id: moverId,
+      name: "이사왕",
+      nickname: "프로이사꾼",
+    };
+
+    it("✅ 무버 정보가 존재하면 name, nickname을 포함한 정보를 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockMover);
+
+      const result = await userRepository.getMoverInfoById(moverId);
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: moverId },
+        select: {
+          id: true,
+          name: true,
+          nickname: true,
+        },
+      });
+
+      expect(result).toEqual(mockMover);
+    });
+
+    it("❌ 무버 정보가 존재하지 않으면 null을 반환한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await userRepository.getMoverInfoById(moverId);
+
+      expect(result).toBeNull();
+    });
+
+    it("❌ DB 조회 중 오류 발생 시 예외를 throw한다", async () => {
+      (prisma.user.findUnique as jest.Mock).mockRejectedValue(
+        new Error("DB 오류")
+      );
+
+      await expect(userRepository.getMoverInfoById(moverId)).rejects.toThrow(
+        "DB 오류"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## ✨ 작업 개요

- user 관련 API들의 유닛 테스트를 보완하고 누락된 테스트 케이스를 추가하여 전체 테스트 커버리지를 개선하였습니다.

## ✅ 주요 작업 내용

- `updateMoverProfile` API 유닛 테스트 추가
  - 정상 업데이트 케이스
  - 에러 발생 시 예외 처리 케이스
- `updateCustomerProfile` API 유닛 테스트 추가
- `getUserNameById`, `getMoverInfoById` API 유닛 테스트 추가
- `createMoverProfile` API 유닛 테스트 작성
- 컨트롤러 레벨 테스트에서 모든 분기 처리 확인

## 🔄 관련 이슈

Closes #275

## 📎 참고 자료 
### 개선전
<img width="1916" height="52" alt="유저레포지토리 개선전" src="https://github.com/user-attachments/assets/0e7ecef5-832c-4fa9-a95a-e4a16af28f3e" />
<img width="1914" height="53" alt="유저 컨트롤러 개선 전" src="https://github.com/user-attachments/assets/c5bb0664-8ff4-4298-a664-90f9e93b79cc" />

### 개선후
<img width="1909" height="43" alt="유저 컨트롤러 커버리지 개선" src="https://github.com/user-attachments/assets/8852ae9a-788c-4008-88f7-09d77000d90a" />
<img width="1916" height="78" alt="유저 레포지토리 커버리지 개선" src="https://github.com/user-attachments/assets/493f5a78-0527-4e1d-a490-5c5bcd3f13c8" />

