### PR TITLE
[#299]feat: redis를 이용하여 API 캐싱 적용하기

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import helmet from "helmet";
 import { errorHandler, notFoundHandler } from "./middlewares/errorMiddleware";
 import { setupManualSwagger } from "./utils/swagger-manual";
 import cookieParser from "cookie-parser";
+import { cache } from "./middlewares/cacheMiddleware";
 
 // 라우터 import
 import authIndexRoutes from "./routes/authIndex.routes";

--- a/src/controllers/estimateRequest.controller.ts
+++ b/src/controllers/estimateRequest.controller.ts
@@ -3,6 +3,7 @@ import EstimateRequestService from "../services/estimateRequest.service";
 import { convertRegionToKorean } from "../utils/addressUtils";
 import { validateMoveDate, formatDateForAPI } from "../utils/dateUtils";
 import * as Sentry from "@sentry/node";
+import { invalidateCacheByKey } from "../middlewares/cacheMiddleware";
 import {
   TCreateEstimateRequest,
   TUpdateEstimateRequest,
@@ -191,6 +192,10 @@ class EstimateRequestController {
 
       const createdRequest = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
 
+      // 캐시 무효화: 활성 견적 요청 조회 캐시 (해당 사용자 기준)
+      const activeKey = ["cache", "GET", "/estimateRequests", "/active", `u:${userId}`, ""];
+      void invalidateCacheByKey(activeKey);
+
       return res.status(201).json({
         success: true,
         message: "견적 요청이 성공적으로 생성되었습니다.",
@@ -317,6 +322,10 @@ class EstimateRequestController {
 
       const updatedRequest = await estimateRequestService.getActiveEstimateRequestByUserId(userId);
 
+      // 캐시 무효화: 활성 견적 요청 조회 캐시 (해당 사용자 기준)
+      const activeKey = ["cache", "GET", "/estimateRequests", "/active", `u:${userId}`, ""];
+      void invalidateCacheByKey(activeKey);
+
       return res.status(200).json({
         success: true,
         message: "견적 요청이 성공적으로 수정되었습니다.",
@@ -379,6 +388,9 @@ class EstimateRequestController {
       }
 
       await estimateRequestService.cancelActiveEstimateRequest(active.id);
+      // 캐시 무효화: 활성 견적 요청 조회 캐시 (해당 사용자 기준)
+      const activeKey = ["cache", "GET", "/estimateRequests", "/active", `u:${userId}`, ""];
+      void invalidateCacheByKey(activeKey);
       return res.status(204).send();
     } catch (error) {
       // 센트리로 에러 전송

--- a/src/controllers/favorite.controller.ts
+++ b/src/controllers/favorite.controller.ts
@@ -3,6 +3,7 @@ import favoriteService from "../services/favorite.service";
 import favoriteRepository from "../repositories/favorite.repository";
 import { IFavoriteRequest } from "../types/favorite.types";
 import * as Sentry from "@sentry/node";
+import { invalidateCacheByKey, invalidateCacheByPattern } from "../middlewares/cacheMiddleware";
 
 // 커스텀 Request 타입 정의
 interface IUserRequest extends Request {
@@ -49,6 +50,12 @@ class FavoriteController {
       }
 
       const result = await favoriteService.addFavorite(customerId!, moverId);
+
+      // 캐시 무효화: 목록과 상태 키 (해당 사용자 기준)
+      const listPattern = `cache:GET:/favorites/movers:u:${customerId}:*`;
+      const statusKey = ["cache", "GET", "/favorites", `/${moverId}/status`, `u:${customerId}`, ""];
+      void invalidateCacheByPattern(listPattern);
+      void invalidateCacheByKey(statusKey);
 
       // 생성 성공 시 201, 그 외(이미 존재 등) 200
       const statusCode = result.success ? 201 : 200;
@@ -108,6 +115,12 @@ class FavoriteController {
       }
 
       const result = await favoriteService.removeFavorite(customerId!, moverId);
+
+      // 캐시 무효화: 목록과 상태 키 (해당 사용자 기준)
+      const listPattern = `cache:GET:/favorites/movers:u:${customerId}:*`;
+      const statusKey = ["cache", "GET", "/favorites", `/${moverId}/status`, `u:${customerId}`, ""];
+      void invalidateCacheByPattern(listPattern);
+      void invalidateCacheByKey(statusKey);
 
       // success가 false인 경우도 정상적인 상황이므로 200 상태 코드로 반환
       return res.status(200).json(result);

--- a/src/middlewares/cacheMiddleware.ts
+++ b/src/middlewares/cacheMiddleware.ts
@@ -1,0 +1,67 @@
+import { Request, Response, NextFunction } from "express";
+import { buildCacheKey, redisGet, redisSetEx, redisDel, redisDeleteByPattern } from "../utils/redisClient";
+
+export type CacheKeyBuilder = (req: Request) => string;
+
+export interface CacheOptions {
+  ttlSeconds?: number;
+  keyBuilder?: CacheKeyBuilder;
+  varyByAuth?: boolean; // include userId when authenticated
+}
+
+const DEFAULT_TTL = 60; // 1 minute default
+
+export function cache(options: CacheOptions = {}) {
+  const ttl = options.ttlSeconds ?? DEFAULT_TTL;
+  const keyBuilder = options.keyBuilder;
+  const varyByAuth = options.varyByAuth ?? true;
+
+  return async function cacheMiddleware(req: Request, res: Response, next: NextFunction) {
+    // Only cache idempotent GET
+    if (req.method !== "GET") return next();
+
+    const authPart = varyByAuth && (req as any).user?.userId ? `u:${(req as any).user.userId}` : "anon";
+
+    const cacheKey = keyBuilder
+      ? keyBuilder(req)
+      : buildCacheKey(["cache", req.method, req.baseUrl, req.path, authPart, req.originalUrl.split("?")[1] ?? ""]);
+
+    try {
+      const cached = await redisGet(cacheKey);
+      if (cached) {
+        console.log("cache hit");
+        res.setHeader("X-Cache", "HIT");
+        res.setHeader("Cache-Key", cacheKey);
+        return res.status(200).type("application/json").send(cached);
+      }
+    } catch {
+      // cache read failure -> fallthrough
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = (body: any) => {
+      try {
+        const payload = typeof body === "string" ? body : JSON.stringify(body);
+        void redisSetEx(cacheKey, ttl, payload);
+        console.log("cache miss");
+        res.setHeader("X-Cache", "MISS");
+        res.setHeader("Cache-Key", cacheKey);
+      } catch {
+        // ignore
+      }
+      return originalJson(body);
+    };
+
+    next();
+  };
+}
+
+// Helper to invalidate by composing same key parts
+export async function invalidateCacheByKey(keyParts: Array<string | number | undefined | null>): Promise<void> {
+  const key = buildCacheKey(keyParts);
+  await redisDel(key);
+}
+
+export async function invalidateCacheByPattern(pattern: string): Promise<void> {
+  await redisDeleteByPattern(pattern);
+}

--- a/src/routes/estimateRequest.routes.ts
+++ b/src/routes/estimateRequest.routes.ts
@@ -3,6 +3,7 @@ import EstimateRequestController from "../controllers/estimateRequest.controller
 import { verifyAccessToken } from "../middlewares/verifyToken";
 import { defaultTranslationMiddleware } from "../middlewares/translationMiddleware";
 import { estimateRequestLimiter } from "../middlewares/rateLimiter";
+import { cache } from "../middlewares/cacheMiddleware";
 
 const router = Router();
 const estimateRequestController = new EstimateRequestController();
@@ -376,8 +377,12 @@ router.post("/create", verifyAccessToken, estimateRequestLimiter, (req, res) =>
  *               success: false
  *               message: "서버 내부 오류가 발생했습니다."
  */
-router.get("/active", verifyAccessToken, defaultTranslationMiddleware, (req, res) =>
-  estimateRequestController.getActiveEstimateRequest(req, res),
+router.get(
+  "/active",
+  verifyAccessToken,
+  cache({ ttlSeconds: 15, varyByAuth: true }),
+  defaultTranslationMiddleware,
+  (req, res) => estimateRequestController.getActiveEstimateRequest(req, res),
 );
 
 // 견적 요청 수정

--- a/src/routes/favorite.routes.ts
+++ b/src/routes/favorite.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import favoriteController from "../controllers/favorite.controller";
 import { verifyAccessToken } from "../middlewares/verifyToken";
 import { defaultTranslationMiddleware } from "../middlewares/translationMiddleware";
+import { cache } from "../middlewares/cacheMiddleware";
 
 const router = Router();
 
@@ -272,7 +273,13 @@ router.post("/", verifyAccessToken, favoriteController.addFavorite);
  *               success: false
  *               message: "서버 내부 오류가 발생했습니다"
  */
-router.get("/movers", verifyAccessToken, defaultTranslationMiddleware, favoriteController.getFavoriteMovers);
+router.get(
+  "/movers",
+  verifyAccessToken,
+  cache({ ttlSeconds: 30, varyByAuth: true }),
+  defaultTranslationMiddleware,
+  favoriteController.getFavoriteMovers,
+);
 
 /**
  * @swagger
@@ -340,7 +347,13 @@ router.get("/movers", verifyAccessToken, defaultTranslationMiddleware, favoriteC
  *               success: false
  *               message: "서버 내부 오류가 발생했습니다"
  */
-router.get("/:moverId/status", verifyAccessToken, defaultTranslationMiddleware, favoriteController.getFavoriteStatus);
+router.get(
+  "/:moverId/status",
+  verifyAccessToken,
+  cache({ ttlSeconds: 15, varyByAuth: true }),
+  defaultTranslationMiddleware,
+  favoriteController.getFavoriteStatus,
+);
 
 /**
  * @swagger

--- a/src/routes/moverSchedule.routes.ts
+++ b/src/routes/moverSchedule.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import moverScheduleController from "../controllers/moverSchedule.controller";
 import { verifyAccessToken } from "../middlewares/verifyToken";
 import { translationMiddleware } from "../middlewares/translationMiddleware";
+import { cache } from "../middlewares/cacheMiddleware";
 
 const moverScheduleRouter = Router();
 
@@ -46,7 +47,7 @@ const moverScheduleRouter = Router();
  *     tags:
  *       - MoverSchedule
  *     security:
- *       - BearerAuth: []
+ *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: year
@@ -93,21 +94,9 @@ const moverScheduleRouter = Router();
 moverScheduleRouter.get(
   "/monthly/:year/:month",
   verifyAccessToken,
+  cache({ ttlSeconds: 60, varyByAuth: true }),
   translationMiddleware({
-    excludeKeys: [
-      "id",
-      "uuid",
-      "createdAt",
-      "updatedAt",
-      "email",
-      "phone",
-      "url",
-      "link",
-      "customerName",
-      "moveDate",
-      "movingType",
-      "status",
-    ],
+    excludeKeys: ["id", "uuid", "createdAt", "updatedAt", "email", "phone", "url", "link", "customerName", "moveDate"],
   }),
   moverScheduleController.getMonthlySchedules,
 );

--- a/src/utils/phoneEncryption.test.ts
+++ b/src/utils/phoneEncryption.test.ts
@@ -37,3 +37,4 @@ describe("phoneEncryption", () => {
     expect(h1).toMatch(/^[0-9a-f]{64}$/);
   });
 });
+

--- a/src/utils/redisClient.ts
+++ b/src/utils/redisClient.ts
@@ -1,0 +1,104 @@
+import Redis, { Redis as RedisClient } from "ioredis";
+
+let redisClientInstance: RedisClient | null = null;
+
+function createRedisClient(): RedisClient {
+  const host = process.env.REDIS_HOST ?? "127.0.0.1";
+  const port = Number(process.env.REDIS_PORT ?? "6379");
+  const password = process.env.REDIS_PASSWORD;
+  const useTls = (process.env.REDIS_TLS ?? "false").toLowerCase() === "true";
+
+  const client = new Redis({
+    host,
+    port,
+    password,
+    tls: useTls ? {} : undefined,
+    lazyConnect: true,
+    retryStrategy: (times) => Math.min(times * 100, 2000),
+    maxRetriesPerRequest: null,
+    enableReadyCheck: true,
+  });
+
+  client.on("error", (err) => {
+    // eslint-disable-next-line no-console
+    console.error("[Redis] error:", err?.message ?? err);
+  });
+
+  client.on("connect", () => {
+    // eslint-disable-next-line no-console
+    console.log("[Redis] connected");
+  });
+
+  client.on("reconnecting", () => {
+    // eslint-disable-next-line no-console
+    console.log("[Redis] reconnecting...");
+  });
+
+  return client;
+}
+
+export async function getRedisClient(): Promise<RedisClient> {
+  if (!redisClientInstance) {
+    redisClientInstance = createRedisClient();
+  }
+  if (redisClientInstance.status !== "ready") {
+    try {
+      await redisClientInstance.connect();
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn("[Redis] connect failed; continuing without cache", e);
+    }
+  }
+  return redisClientInstance;
+}
+
+export async function redisGet(key: string): Promise<string | null> {
+  const client = await getRedisClient();
+  try {
+    return await client.get(key);
+  } catch {
+    return null;
+  }
+}
+
+export async function redisSetEx(key: string, ttlSeconds: number, value: string): Promise<void> {
+  const client = await getRedisClient();
+  try {
+    await client.set(key, value, "EX", ttlSeconds);
+  } catch {
+    // ignore cache write failures
+  }
+}
+
+export async function redisDel(key: string): Promise<void> {
+  const client = await getRedisClient();
+  try {
+    await client.del(key);
+  } catch {
+    // ignore
+  }
+}
+
+export function buildCacheKey(parts: Array<string | number | undefined | null>): string {
+  return parts
+    .filter((p) => p !== undefined && p !== null && String(p).length > 0)
+    .map((p) => String(p))
+    .join(":");
+}
+
+export async function redisDeleteByPattern(pattern: string): Promise<void> {
+  const client = await getRedisClient();
+  try {
+    let cursor = "0";
+    do {
+      const result = (await client.scan(cursor, "MATCH", pattern, "COUNT", 100)) as [string, string[]];
+      cursor = result[0];
+      const keys = result[1];
+      if (keys.length > 0) {
+        await client.del(...keys);
+      }
+    } while (cursor !== "0");
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## ✨ 작업 개요

- redis를 이용하여 API 캐싱 적용하기

## ✅ 주요 작업 내용

- redis 클라이언트 제작
- 미들웨어 제작
- 견적 요청 일정관리 찜하기에 도입
- POST DELETE 요청 시 캐싱 무효화 적용


## 🔄 관련 이슈

Closes #299

## 📎 참고 자료 (선택)

- API 명세서: swagger

## 🧪 테스트 방법 (선택)
<img width="394" height="424" alt="스크린샷 2025-08-11 153237" src="https://github.com/user-attachments/assets/caddc606-cac3-490e-a4b9-c8a5531bb260" />
<img width="330" height="283" alt="스크린샷 2025-08-11 153250" src="https://github.com/user-attachments/assets/859d8541-2f66-4fdd-9e01-4b66e68fa59e" />



## 📝 비고

- 헤더에서 MISS(캐싱안됨 - 처음 요청할 때), HIT(캐싱됨 - 이 후 요청에 대하여)
