### PR TITLE
test : auth 통합 테스트 작성

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -58,12 +58,6 @@ const postSignin = async (req: Request, res: Response) => {
       },
     });
   } catch (error: any) {
-    console.error("로그인 에러:", error);
-    console.error("에러 상세 정보:", {
-      message: error instanceof Error ? error.message : "Unknown error",
-      stack: error instanceof Error ? error.stack : undefined,
-      name: error instanceof Error ? error.name : "Unknown",
-    });
     handleError(res, error);
   }
 };
@@ -99,12 +93,12 @@ const postSignup = async (req: Request, res: Response) => {
       authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
     );
 
-    res.status(200).json({
+    res.status(201).json({
       success: true,
       message: "회원가입 성공",
       user: {
         id,
-        name: userName,
+        userName,
         userType: userTypeResponse,
       },
     });
@@ -223,7 +217,11 @@ const getGoogleCallback = async (req: Request, res: Response) => {
       authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
     );
 
-    res.redirect(`${FRONTEND_URL}/`);
+    if (userType === "CUSTOMER") {
+      res.redirect(`${FRONTEND_URL}/searchMover`);
+    } else {
+      res.redirect(`${FRONTEND_URL}/estimate/received`);
+    }
   } catch (error: any) {
     const params = new URLSearchParams({
       success: "false",
@@ -255,7 +253,11 @@ const getKakaoCallback = async (req: Request, res: Response) => {
       authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
     );
 
-    res.redirect(`${FRONTEND_URL}/`);
+    if (userType === "CUSTOMER") {
+      res.redirect(`${FRONTEND_URL}/searchMover`);
+    } else {
+      res.redirect(`${FRONTEND_URL}/estimate/received`);
+    }
   } catch (error: any) {
     const params = new URLSearchParams({
       success: "false",
@@ -287,7 +289,11 @@ const getNaverCallback = async (req: Request, res: Response) => {
       authCookieOptions(TOKEN_EXPIRES.REFRESH_TOKEN_COOKIE)
     );
 
-    res.redirect(`${FRONTEND_URL}/`);
+    if (userType === "CUSTOMER") {
+      res.redirect(`${FRONTEND_URL}/searchMover`);
+    } else {
+      res.redirect(`${FRONTEND_URL}/estimate/received`);
+    }
   } catch (error: any) {
     const params = new URLSearchParams({
       success: "false",

--- a/src/middlewares/rateLimiter.ts
+++ b/src/middlewares/rateLimiter.ts
@@ -5,32 +5,48 @@ import { TooManyRequestsError } from "../types/commonError.types";
 // 로그인 요청 제한: 1분간 최대 10회
 export const loginLimiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1분
-  max: 5,
+  limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res) => {
-    handleError(res, new TooManyRequestsError("로그인 요청이 너무 많습니다. 1분 후 다시 시도해주세요."));
+    handleError(
+      res,
+      new TooManyRequestsError(
+        "로그인 요청이 너무 많습니다. 1분 후 다시 시도해주세요."
+      )
+    );
   },
 });
 
-// 회원가입 요청 제한: 30분간 최대 5회
+// 테스트를 위해 1분으로 설정, 텍스트는 30분으로 보냄 (원래는 30분 정도)
+// 회원가입 요청 제한: 1분간 최대 5회
 export const signupLimiter = rateLimit({
-  windowMs: 30 * 60 * 1000, // 30분
-  max: 5,
+  windowMs: 1 * 60 * 1000, // 1분
+  limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res) => {
-    handleError(res, new TooManyRequestsError("회원가입 요청이 너무 많습니다. 30분 후 다시 시도해주세요."));
+    handleError(
+      res,
+      new TooManyRequestsError(
+        "회원가입 요청이 너무 많습니다. 30분 후 다시 시도해주세요."
+      )
+    );
   },
 });
 
 // 견적요청 제한: 1시간동안 최대 5회
 export const estimateRequestLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1시간
-  max: 5,
+  limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res) => {
-    handleError(res, new TooManyRequestsError("견적요청이 너무 많습니다. 1시간 후 다시 시도해주세요."));
+    handleError(
+      res,
+      new TooManyRequestsError(
+        "견적요청이 너무 많습니다. 1시간 후 다시 시도해주세요."
+      )
+    );
   },
 });

--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -22,6 +22,7 @@ export const handleError = (
   fallbackMessage: string = "예상치 못한 오류가 발생했습니다."
 ) => {
   let status = 500;
+  let success = false;
   let message = fallbackMessage;
 
   switch (error.constructor) {
@@ -67,6 +68,7 @@ export const handleError = (
 
   res.status(status).json({
     status,
+    success,
     message,
   });
 };

--- a/tests/integration/auth.int.test.ts
+++ b/tests/integration/auth.int.test.ts
@@ -1,0 +1,433 @@
+import request from "supertest";
+import app from "../../src/app";
+import prisma from "../../src/db/prisma/prisma";
+import { signupLimiter } from "../../src/middlewares/rateLimiter";
+import { loginLimiter } from "../../src/middlewares/rateLimiter";
+import authService from "../../src/services/auth.service";
+
+describe("Auth integration", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  beforeAll(() => {
+    // X-Forwarded-For를 req.ip로 인식하게 함
+    (app as any).set("trust proxy", 1);
+  });
+
+  const resetAllRateLimits = () => {
+    (loginLimiter as any).store?.resetAll?.();
+    (signupLimiter as any).store?.resetAll?.();
+  };
+
+  // 공통
+  const getCookies = (res: any) => {
+    const raw = res.headers["set-cookie"];
+    const cookies: string[] = Array.isArray(raw) ? raw : raw ? [raw] : [];
+    expect(cookies).toBeDefined();
+    expect(Array.isArray(cookies)).toBe(true);
+    return cookies;
+  };
+
+  // 1) 액세스 토큰만 검사
+  const expectAccessCookieOnly = (res: any) => {
+    const cookies = getCookies(res);
+    const access = cookies.find((c) => c.startsWith("accessToken="));
+    expect(access).toBeDefined();
+    expect(access!).not.toEqual(expect.stringContaining("HttpOnly")); // accessToken
+    expect(access!).toEqual(expect.stringContaining("SameSite=Lax"));
+    expect(access!).toEqual(expect.stringContaining("Path=/"));
+    expect(access!).toEqual(expect.stringContaining("Max-Age="));
+  };
+
+  // 2) 액세스+리프레시 둘 다 검사
+  const expectBothAuthCookies = (res: any) => {
+    const cookies = getCookies(res);
+    const access = cookies.find((c) => c.startsWith("accessToken="));
+    const refresh = cookies.find((c) => c.startsWith("refreshToken="));
+
+    // access
+    expect(access).toBeDefined();
+    expect(access!).not.toEqual(expect.stringContaining("HttpOnly"));
+    expect(access!).toEqual(expect.stringContaining("SameSite=Lax"));
+    expect(access!).toEqual(expect.stringContaining("Path=/"));
+    expect(access!).toEqual(expect.stringContaining("Max-Age="));
+
+    // refresh
+    expect(refresh).toBeDefined();
+    expect(refresh!).toEqual(expect.stringContaining("HttpOnly"));
+    expect(refresh!).toEqual(expect.stringContaining("SameSite=Lax"));
+    expect(refresh!).toEqual(expect.stringContaining("Path=/"));
+    expect(refresh!).toEqual(expect.stringContaining("Max-Age="));
+  };
+
+  // 회원가입 성공 (200)
+  it("POST /auth/sign-up - 201", async () => {
+    const res = await request(app)
+      .post("/auth/sign-up")
+      .send({
+        name: "testUser",
+        email: "test+" + Date.now() + "@naver.com",
+        password: "1rhdiddl!",
+        phoneNumber: "01012345678",
+        userType: "CUSTOMER",
+      })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("회원가입 성공");
+    // expect(res.body.user.id).toBe(1);
+    expect(res.body.user.userName).toBe("testUser");
+    expect(res.body.user.userType).toBe("CUSTOMER");
+
+    expectBothAuthCookies(res);
+  });
+
+  // 회원가입 실패 - 이메일 중복 (422)
+  it("POST /auth/sign-up - 422", async () => {
+    const res = await request(app).post("/auth/sign-up").send({
+      email: "test3334@naver.com",
+      password: "1rhdiddl!",
+      userType: "CUSTOMER",
+    });
+    expect(res.status).toBe(422);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("이미 사용 중인 이메일입니다.");
+  });
+
+  // 로그인 성공 (200)
+  it("POST /auth/sign-in - 200", async () => {
+    const res = await request(app).post("/auth/sign-in").send({
+      email: "test3334@naver.com",
+      password: "1rhdiddl!",
+      userType: "CUSTOMER",
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("로그인 성공");
+    expect(res.body.user.userName).toBe("testUser");
+    expect(res.body.user.userType).toBe("CUSTOMER");
+  });
+
+  // 로그인 실패 - 존재하지 않는 유저 (401)
+  it("POST /auth/sign-in - 401", async () => {
+    const res = await request(app).post("/auth/sign-in").send({
+      email: "wrong@naver.com",
+      password: "1rhdiddl!",
+      userType: "CUSTOMER",
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("존재하지 않는 유저입니다");
+  });
+
+  // 로그인 실패 - 소셜 로그인 유저 확인 (401)
+  it("POST /auth/sign-in - 401", async () => {
+    const res = await request(app).post("/auth/sign-in").send({
+      email: "mover1@test.com",
+      password: "1rhdiddl!",
+      userType: "MOVER",
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe(
+      "소셜 로그인 유저입니다. 소셜로그인으로 로그인 해주세요"
+    );
+  });
+
+  // 로그인 실패 - 비밀번호 불일치 (401)
+  it("POST /auth/sign-in - 401", async () => {
+    const res = await request(app).post("/auth/sign-in").send({
+      email: "test3334@naver.com",
+      password: "1wrongpassword!",
+      userType: "CUSTOMER",
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("비밀번호가 일치하지 않습니다");
+  });
+
+  // 로그아웃 성공 (200)
+  it("POST /auth/logout - 200", async () => {
+    // 로그인 전에 리미터 초기화 (이전 테스트 영향 차단)
+    for (const key of ["::ffff:127.0.0.1", "127.0.0.1", "::1"]) {
+      loginLimiter.resetKey(key);
+    }
+    // 1) 로그인
+    const signin = await request(app)
+      .post("/auth/sign-in")
+      .send({
+        email: "test3334@naver.com",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+      .expect(200);
+
+    // 2) Set-Cookie에서 accessToken 추출
+    const raw = signin.get("Set-Cookie") as string[];
+    const accessCookie = raw.find((c) => c.startsWith("accessToken="))!;
+    const accessToken = accessCookie.split(";")[0].split("=")[1];
+
+    // 3) 로그아웃 호출 (Bearer에 실어서)
+    const res = await request(app)
+      .post("/auth/logout")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("로그아웃 성공");
+
+    // 4) 쿠키 삭제 확인(선택)
+    const cleared = res.get("Set-Cookie") || [];
+    expect(cleared.join(";")).toEqual(expect.stringContaining("accessToken="));
+    expect(cleared.join(";")).toEqual(expect.stringContaining("refreshToken="));
+    expect(cleared.join(";")).toEqual(expect.stringContaining("Max-Age=0"));
+  });
+
+  // 로그아웃 실패 - 미인증 (401)
+  it("POST /auth/logout - 401 (미인증)", async () => {
+    const res = await request(app).post("/auth/logout").expect(401);
+    // 미인증 메시지는 미들웨어 구현에 맞춰 검증
+    expect(res.body.message).toBe("로그인이 필요합니다. 다시 로그인해 주세요.");
+  });
+
+  // 로그아웃 실패 - 잘못된 토큰 (401)
+  it("POST /auth/logout - 401 (잘못된 토큰)", async () => {
+    const res = await request(app)
+      .post("/auth/logout")
+      .set("Authorization", "Bearer invalid.token.here")
+      .expect(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe(
+      "유효하지 않은 로그인 정보입니다. 다시 로그인해 주세요."
+    );
+  });
+
+  // 로그인 - 요청 제한 (429)
+  it("POST /auth/sign-in - 429 after 6th try", async () => {
+    resetAllRateLimits();
+    const ip = `198.51.100.${Date.now() % 200}`; // 테스트 고유 IP
+    const body = {
+      email: "test3334@naver.com",
+      password: "1rhdiddl!",
+      userType: "CUSTOMER",
+    };
+
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post("/auth/sign-in")
+        .set("X-Forwarded-For", ip)
+        .send(body)
+        .expect(200);
+    }
+    await request(app)
+      .post("/auth/sign-in")
+      .set("X-Forwarded-For", ip)
+      .send(body)
+      .expect(429);
+  });
+
+  // 회원가입 - 요청 제한 (429)
+  it("POST /auth/sign-up - 429 after 6th try", async () => {
+    resetAllRateLimits();
+    const ip = `203.0.113.${Date.now() % 200}`;
+
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post("/auth/sign-up")
+        .set("X-Forwarded-For", ip)
+        .send({
+          name: "user",
+          email: `rate+${Date.now()}+${i}@naver.com`,
+          password: "1rhdiddl!",
+          phoneNumber: "01012345678",
+          userType: "CUSTOMER",
+        })
+        .expect((res) => expect(res.status).not.toBe(429));
+    }
+
+    await request(app)
+      .post("/auth/sign-up")
+      .set("X-Forwarded-For", ip)
+      .send({
+        name: "user",
+        email: `rate+${Date.now()}+x@naver.com`,
+        password: "1rhdiddl!",
+        phoneNumber: "01012345678",
+        userType: "CUSTOMER",
+      })
+      .expect(429);
+  });
+
+  // 토큰 갱신 성공(액세스 토큰만 반환) (200)
+  it("POST /auth/refresh-token - 200 (access만)", async () => {
+    resetAllRateLimits(); // 기존 유지
+
+    // 테스트를 위한 고유 ip 사용
+    const ip = `192.0.2.${Date.now() % 200}`;
+    loginLimiter.resetKey(ip);
+
+    const signin = await request(app)
+      .post("/auth/sign-in")
+      .set("X-Forwarded-For", ip)
+      .send({
+        email: "test3334@naver.com",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+      .expect(200);
+
+    const cookies = signin.get("Set-Cookie");
+    const res = await request(app)
+      .post("/auth/refresh-token")
+      .set("X-Forwarded-For", ip)
+      .set("Cookie", cookies as string[])
+      .expect(200);
+
+    expectAccessCookieOnly(res);
+  });
+
+  // 토큰 갱신 성공(리프레시 토큰 반환) (200)
+  it("POST /auth/refresh-token - 200 (access+refresh)", async () => {
+    resetAllRateLimits();
+
+    // 테스트를 위한 고유 ip 사용
+    const ip = `192.0.2.${(Date.now() + 1) % 200}`;
+    loginLimiter.resetKey(ip);
+
+    const signin = await request(app)
+      .post("/auth/sign-in")
+      .set("X-Forwarded-For", ip)
+      .send({
+        email: "test3334@naver.com",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+      .expect(200);
+
+    const cookies = signin.get("Set-Cookie");
+
+    const spy = jest.spyOn(authService, "refresh").mockResolvedValue({
+      accessToken: "mock-access",
+      refreshToken: "mock-refresh",
+      provider: "LOCAL" as any,
+    } as unknown as Awaited<ReturnType<typeof authService.refresh>>);
+
+    const res = await request(app)
+      .post("/auth/refresh-token")
+      .set("X-Forwarded-For", ip)
+      .set("Cookie", cookies as string[])
+      .expect(200);
+
+    expectBothAuthCookies(res);
+    spy.mockRestore();
+  });
+
+  // 토큰 갱신 실패 - 미인증 (401)
+  it("POST /auth/refresh-token - 401 (미인증)", async () => {
+    const res = await request(app).post("/auth/refresh-token").expect(401);
+    expect(res.body.message).toBe("로그인이 필요합니다.");
+  });
+
+  // 토큰 갱신 실패 - 잘못된 토큰 (401)
+  it("POST /auth/refresh-token - 401 (잘못된 토큰)", async () => {
+    const res = await request(app)
+      .post("/auth/refresh-token")
+      .set("Cookie", "invalid.token.here")
+      .expect(401);
+    expect(res.body.message).toBe("로그인이 필요합니다.");
+  });
+
+  // 역할 전환 성공 - 200
+  it("POST /auth/switch-role - 200", async () => {
+    resetAllRateLimits();
+    const ip = `198.0.2.${Date.now() % 200}`;
+    loginLimiter.resetKey(ip);
+
+    const signin = await request(app)
+      .post("/auth/sign-in")
+      .set("X-Forwarded-For", ip)
+      .send({
+        email: "test3334@naver.com",
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+      .expect(200);
+
+    // Authorization 헤더용 액세스 토큰 추출
+    const signinSetCookies = signin.get("Set-Cookie") as string[];
+    const signinAccessCookie = signinSetCookies.find((c) =>
+      c.startsWith("accessToken=")
+    )!;
+    const signinAccessToken = signinAccessCookie.split(";")[0].split("=")[1];
+
+    const res = await request(app)
+      .post("/auth/switch-role")
+      .set("X-Forwarded-For", ip)
+      .set("Authorization", `Bearer ${signinAccessToken}`)
+      .set("Cookie", signin.get("Set-Cookie") as string[])
+      .send({
+        userType: "MOVER",
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("역할 변경 성공");
+    expect(res.body.oldUserType).toBe("CUSTOMER");
+    expect(res.body.newUserType).toBe("MOVER");
+  });
+
+  // 역할 전환 실패 - 미인증 (401)
+  it("POST /auth/switch-role - 401 (미인증)", async () => {
+    const res = await request(app).post("/auth/switch-role").expect(401);
+    expect(res.body.message).toBe("로그인이 필요합니다. 다시 로그인해 주세요.");
+  });
+
+  // 역할 전환 실패 - 존재하지 않는 유저 (404)
+  it("POST /auth/switch-role - 404 (존재하지 않는 유저)", async () => {
+    resetAllRateLimits();
+    const ip = `198.0.2.${Date.now() % 200}`;
+    loginLimiter.resetKey(ip);
+
+    // 1) 테스트용 유저 생성 후 로그인
+    const email = `notfound+${Date.now()}@naver.com`;
+    await request(app)
+      .post("/auth/sign-up")
+      .set("X-Forwarded-For", ip)
+      .send({
+        name: "nf",
+        email,
+        password: "1rhdiddl!",
+        phoneNumber: "01012345678",
+        userType: "CUSTOMER",
+      })
+      .expect(201);
+
+    const signin = await request(app)
+      .post("/auth/sign-in")
+      .set("X-Forwarded-For", ip)
+      .send({
+        email,
+        password: "1rhdiddl!",
+        userType: "CUSTOMER",
+      })
+      .expect(200);
+
+    const cookies = signin.get("Set-Cookie") as string[];
+    const accessCookie = cookies.find((c) => c.startsWith("accessToken="))!;
+    const accessToken = accessCookie.split(";")[0].split("=")[1];
+
+    // 2) 유저 삭제 → 존재하지 않는 유저 상태 만들기
+    await prisma.user.delete({ where: { email } });
+
+    // 3) 역할 전환 요청 → 404 기대
+    const res = await request(app)
+      .post("/auth/switch-role")
+      .set("X-Forwarded-For", ip)
+      .set("Cookie", cookies)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({ userType: "MOVER" })
+      .expect(404);
+
+    expect(res.body.message).toBe("존재하지 않는 유저입니다");
+  });
+});


### PR DESCRIPTION
## ✨ 작업 개요
- 인증 통합 테스트 보강 및 안정화
- 쿠키 기반 토큰 정책 검증, 요청 제한(429) 시나리오 검증, 역할 전환 인증 흐름 보완

## ✅ 주요 작업 내용
- 회원가입/로그인/로그아웃/토큰 갱신/역할 전환 통합 테스트 작성 및 보강
- Set-Cookie 검증 유틸 적용: accessToken/refreshToken 존재 및 속성(HttpOnly, SameSite, Path, Max-Age)
- 로그인/회원가입 429: 5회 성공 후 6회차 429 검증(테스트별 고유 IP + 리미터 초기화)
- 토큰 갱신:
  - 쿠키 기반 갱신(바디 미사용) 시 access만/둘 다 재발급 케이스 분리
  - 서비스 mock 이용한 access+refresh 재발급 시나리오 검증
- 역할 전환:
  - Authorization Bearer 토큰 추가(쿠키만 전달 시 401 방지)
  - “존재하지 않는 유저” 404 시나리오: 로그인 후 DB에서 유저 삭제로 재현
- 테스트 안정화:
  - `app.set("trust proxy", 1)` 적용, 고유 이메일/고유 IP 사용
  - 리미터 초기화 유틸(`resetAllRateLimits`) 및 IP별 `resetKey` 병행

## 🔄 관련 이슈
Closes #311 

## 스크린샷
### 테스트 통과 이미지
<img width="761" height="469" alt="auth 통합 테스트" src="https://github.com/user-attachments/assets/99fe46c5-8368-4876-8142-512e6e8a4f5e" />



## 🧪 테스트 방법 (선택)
- [ ] 회원가입 201 응답 및 쿠키 설정 검증(access/refresh)
- [ ] 로그인 200 응답 및 `user.userName`/`userType` 필드 검증
- [ ] 로그인/회원가입 429: 5회 성공 후 6회차 429 확인(`X-Forwarded-For`로 고유 IP 지정)
- [ ] 토큰 갱신 200(access만) 및 200(access+refresh/mock) 쿠키 검증
- [ ] 로그아웃 200/401: 쿠키 삭제(`Max-Age=0`)/미인증/잘못된 토큰 검증
- [ ] 역할 전환 200: Bearer 토큰 추가 시 성공, 404: 유저 삭제 후 호출 시 확인

## 📝 비고
- Jest 실행 시 `.env.test` 강제 로드 권장: `--override` 사용
- 리미터는 IP 기준 동작 → 테스트별 고유 IP 사용으로 충돌 방지함 