### PR TITLE
Feat:기사님 마이페이지,프로필 수정,기본정보 수정 통합테스트 구현

### DIFF
--- a/src/services/user.service.test.ts
+++ b/src/services/user.service.test.ts
@@ -469,6 +469,7 @@ describe("userService.updateCustomerProfileCheck", () => {
   });
 });
 
+// 기사님 기본정보 수정 테스트
 describe("userService.updateMoverBasicInfo", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -821,6 +822,8 @@ describe("userService.updateMoverBasicInfo", () => {
   });
 });
 
+
+// 기사님 프로필 수정 테스트
 describe("userService.updateMoverProfileCheck", () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/tests/integration/moverMyPage.int.test.ts
+++ b/tests/integration/moverMyPage.int.test.ts
@@ -1,0 +1,225 @@
+import request from "supertest";
+import app from "../../src/app";
+import prisma from "../../src/db/prisma/prisma";
+import { loginLimiter, signupLimiter } from "../../src/middlewares/rateLimiter";
+
+const getCookies = (res: any) => {
+  const raw = res.headers["set-cookie"];
+  const cookies: string[] = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  expect(cookies).toBeDefined();
+  expect(Array.isArray(cookies)).toBe(true);
+  return cookies;
+};
+
+const RATE_KEYS = ["::ffff:127.0.0.1", "127.0.0.1", "::1"] as const;
+let __seq = 0;
+const nextSeq = () => ++__seq;
+const uniqueIp = () => `198.51.100.${((Date.now() + nextSeq()) % 200) + 1}`;
+const uniqueEmail = (tag = "u") =>
+  `test+${tag}+${Date.now()}_${Math.floor(Math.random() * 1_000_000)}_${nextSeq()}@naver.com`;
+const resetAllRate = (ip?: string) => {
+  for (const k of RATE_KEYS) {
+    loginLimiter.resetKey(k);
+    signupLimiter.resetKey(k);
+  }
+  if (ip) {
+    loginLimiter.resetKey(ip);
+    signupLimiter.resetKey(ip);
+  }
+};
+
+beforeAll(() => {
+  (app as any).set("trust proxy", 1);
+});
+
+beforeEach(() => {
+  resetAllRate();
+});
+
+describe("기사님 마이페이지 통합 테스트", () => {
+  let accessToken: string;
+  let moverUserId: string;
+
+  beforeAll(async () => {
+    let signin;
+    const possiblePasswords = [
+      "Test!Pass5@2024",
+      "NewPassword123!@"
+    ];
+    
+    for (const password of possiblePasswords) {
+      try {
+        signin = await request(app)
+          .post("/auth/sign-in")
+          .send({
+            email: "mover5@test.com",
+            password: password,
+            userType: "MOVER",
+          })
+          .expect(200);
+        break;
+      } catch (e) {
+        continue;
+      }
+    }
+    
+    if (!signin) {
+      throw new Error("모든 비밀번호로 로그인 시도 실패");
+    }
+
+    const cookies = getCookies(signin);
+    const accessCookie = cookies.find((c: string) =>
+      c.startsWith("accessToken=")
+    );
+    accessToken = accessCookie!.split(";")[0].split("=")[1];
+
+    const userRes = await request(app)
+      .get("/users")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+    moverUserId = userRes.body.data.id;
+  });
+
+  afterAll(async () => {
+    try {
+      await prisma.$disconnect();
+    } catch (error) {
+      console.log("Prisma 연결 해제 중 오류:", error);
+    }
+  });
+
+  it("GET /users - 사용자 기본 정보 조회", async () => {
+    const res = await request(app)
+      .get("/users")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data).toHaveProperty("name");
+    expect(res.body.data).toHaveProperty("email");
+    expect(res.body.data).toHaveProperty("userType");
+    expect(res.body.data.userType).toBe("MOVER");
+  });
+
+  it("GET /users/profile - 기사님 프로필 정보 조회", async () => {
+    const res = await request(app)
+      .get("/users/profile")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("nickname");
+    expect(res.body.data).toHaveProperty("name");
+    expect(res.body.data).toHaveProperty("career");
+    expect(res.body.data).toHaveProperty("shortIntro");
+    expect(res.body.data).toHaveProperty("detailIntro");
+    expect(res.body.data).toHaveProperty("serviceTypes");
+    expect(res.body.data).toHaveProperty("currentAreas");
+  });
+
+  it("GET /movers/{moverId} - 기사님 상세 정보 조회", async () => {
+    const res = await request(app)
+      .get(`/movers/${moverUserId}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("id");
+    expect(res.body.data).toHaveProperty("nickname");
+    expect(res.body.data).toHaveProperty("experience");
+    expect(res.body.data).toHaveProperty("introduction");
+    expect(res.body.data).toHaveProperty("description");
+    expect(res.body.data).toHaveProperty("serviceTypes");
+    expect(res.body.data).toHaveProperty("serviceRegions");
+    expect(res.body.data).toHaveProperty("completedCount");
+    expect(res.body.data).toHaveProperty("avgRating");
+    expect(res.body.data).toHaveProperty("reviewCount");
+    expect(res.body.data).toHaveProperty("favoriteCount");
+  });
+
+  it("GET /reviews/mover/{moverId} - 기사님이 받은 리뷰 조회", async () => {
+    const res = await request(app)
+      .get(`/reviews/mover/${moverUserId}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty("items");
+    expect(res.body.data).toHaveProperty("total");
+    expect(res.body.data).toHaveProperty("page");
+    expect(res.body.data).toHaveProperty("pageSize");
+    expect(Array.isArray(res.body.data.items)).toBe(true);
+  });
+
+
+
+  it("기사님 마이페이지 통합 데이터 검증", async () => {
+    const userRes = await request(app)
+      .get("/users")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    const profileRes = await request(app)
+      .get("/users/profile")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    const moverDetailRes = await request(app)
+      .get(`/movers/${moverUserId}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    const reviewsRes = await request(app)
+      .get(`/reviews/mover/${moverUserId}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(userRes.body.data.id).toBe(moverUserId);
+    expect(moverDetailRes.body.data.id).toBe(moverUserId);
+    
+    expect(userRes.body.data.userType).toBe("MOVER");
+    
+    if (profileRes.body.data.nickname && moverDetailRes.body.data.nickname) {
+      expect(profileRes.body.data.nickname).toBe(moverDetailRes.body.data.nickname);
+    }
+
+    expect(moverDetailRes.body.data).toHaveProperty("completedCount");
+    expect(moverDetailRes.body.data).toHaveProperty("avgRating");
+    expect(moverDetailRes.body.data).toHaveProperty("experience");
+    expect(moverDetailRes.body.data).toHaveProperty("serviceTypes");
+    expect(moverDetailRes.body.data).toHaveProperty("serviceRegions");
+    expect(reviewsRes.body.data).toHaveProperty("items");
+  });
+
+  it("401: 토큰 미제공 시 마이페이지 접근 실패", async () => {
+    await request(app)
+      .get("/users")
+      .expect(401);
+
+    await request(app)
+      .get("/users/profile")
+      .expect(401);
+  });
+
+  it("401: 잘못된 토큰으로 마이페이지 접근 실패", async () => {
+    await request(app)
+      .get("/users")
+      .set("Authorization", "Bearer invalid_token")
+      .expect(401);
+
+    await request(app)
+      .get("/users/profile")
+      .set("Authorization", "Bearer invalid_token")
+      .expect(401);
+  });
+
+  it("404: 존재하지 않는 기사님 ID로 조회 시 실패", async () => {
+    const nonExistentId = "non-existent-id";
+    
+    await request(app)
+      .get(`/movers/${nonExistentId}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(404);
+  });
+});

--- a/tests/integration/moverMyPage.int.test.ts
+++ b/tests/integration/moverMyPage.int.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import app from "../../src/app";
 import prisma from "../../src/db/prisma/prisma";
-import { loginLimiter, signupLimiter } from "../../src/middlewares/rateLimiter";
+
 
 const getCookies = (res: any) => {
   const raw = res.headers["set-cookie"];
@@ -11,29 +11,8 @@ const getCookies = (res: any) => {
   return cookies;
 };
 
-const RATE_KEYS = ["::ffff:127.0.0.1", "127.0.0.1", "::1"] as const;
-let __seq = 0;
-const nextSeq = () => ++__seq;
-const uniqueIp = () => `198.51.100.${((Date.now() + nextSeq()) % 200) + 1}`;
-const uniqueEmail = (tag = "u") =>
-  `test+${tag}+${Date.now()}_${Math.floor(Math.random() * 1_000_000)}_${nextSeq()}@naver.com`;
-const resetAllRate = (ip?: string) => {
-  for (const k of RATE_KEYS) {
-    loginLimiter.resetKey(k);
-    signupLimiter.resetKey(k);
-  }
-  if (ip) {
-    loginLimiter.resetKey(ip);
-    signupLimiter.resetKey(ip);
-  }
-};
-
 beforeAll(() => {
   (app as any).set("trust proxy", 1);
-});
-
-beforeEach(() => {
-  resetAllRate();
 });
 
 describe("기사님 마이페이지 통합 테스트", () => {

--- a/tests/integration/user.int.test.ts
+++ b/tests/integration/user.int.test.ts
@@ -461,10 +461,8 @@ describe("PATCH /users/profile/customer - 고객 프로필 수정 API 테스트"
 
 // PATCH /users/profile/mover/basic
 describe("PATCH /users/profile/mover/basic - 기사님 기본정보 수정 API 테스트", () => {
-  let agent: any;
   let accessToken: string;
   let moverUserId: string;
-  let testEmail: string;
 
   afterAll(async () => {
     try {
@@ -475,55 +473,42 @@ describe("PATCH /users/profile/mover/basic - 기사님 기본정보 수정 API �
   });
 
   beforeAll(async () => {
-    try {
-      agent = request.agent(app);
-      
-      // 기존 테스트 계정 사용
-      testEmail = "mover4@test.com";
-      const originalPassword = "Test!Pass4@2024"; 
-      
-      // 로그인 (비밀번호 시도)
-      let signin;
-      const possiblePasswords = [
-        originalPassword,
-        "NewPassword123!@"
-      ];
-      
-      for (const password of possiblePasswords) {
-        try {
-          signin = await agent
-            .post("/auth/sign-in")
-            .send({
-              email: testEmail,
-              password: password,
-              userType: "MOVER",
-            })
-            .expect(200);
-          break;
-        } catch (e) {
-          continue;
-        }
+    const possiblePasswords = [
+      "Test!Pass4@2024",
+      "NewPassword123!@"
+    ];
+    
+    let signin;
+    for (const password of possiblePasswords) {
+      try {
+        signin = await request(app)
+          .post("/auth/sign-in")
+          .send({
+            email: "mover4@test.com",
+            password: password,
+            userType: "MOVER",
+          })
+          .expect(200);
+        break;
+      } catch (e) {
+        continue;
       }
-      
-      if (!signin) {
-        throw new Error("모든 비밀번호로 로그인 시도 실패");
-      }
-
-      const cookies = getCookies(signin);
-      const accessCookie = cookies.find((c) => c.startsWith("accessToken="));
-      expect(accessCookie).toBeDefined();
-      accessToken = accessCookie!.split(";")[0].split("=")[1];
-
-      // 사용자 ID 저장
-      const userRes = await request(app)
-        .get("/users")
-        .set("Authorization", `Bearer ${accessToken}`)
-        .expect(200);
-      moverUserId = userRes.body.data.id;
-    } catch (error) {
-      console.log("테스트 설정 중 오류:", error);
-      throw error;
     }
+    
+    if (!signin) {
+      throw new Error("모든 비밀번호로 로그인 시도 실패");
+    }
+
+    const cookies = getCookies(signin);
+    const accessCookie = cookies.find((c) => c.startsWith("accessToken="));
+    expect(accessCookie).toBeDefined();
+    accessToken = accessCookie!.split(";")[0].split("=")[1];
+
+    const userRes = await request(app)
+      .get("/users")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+    moverUserId = userRes.body.data.id;
   });
 
   // 기사님 기본정보 수정 성공 (200)
@@ -701,8 +686,6 @@ describe("PATCH /users/profile/mover/basic - 기사님 기본정보 수정 API �
     expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
   });
 });
-
-
 
 describe("PATCH /users/profile/mover - 기사님 프로필 수정 API 테스트", () => {
   let accessToken: string;

--- a/tests/integration/user.int.test.ts
+++ b/tests/integration/user.int.test.ts
@@ -458,3 +458,522 @@ describe("PATCH /users/profile/customer - 고객 프로필 수정 API 테스트"
       .expect(422);
   });
 });
+
+// PATCH /users/profile/mover/basic
+describe("PATCH /users/profile/mover/basic - 기사님 기본정보 수정 API 테스트", () => {
+  let agent: any;
+  let accessToken: string;
+  let moverUserId: string;
+  let testEmail: string;
+
+  afterAll(async () => {
+    try {
+      await prisma.$disconnect();
+    } catch (error) {
+      console.log("Prisma 연결 해제 중 오류:", error);
+    }
+  });
+
+  beforeAll(async () => {
+    try {
+      agent = request.agent(app);
+      
+      // 기존 테스트 계정 사용
+      testEmail = "mover4@test.com";
+      const originalPassword = "Test!Pass4@2024"; 
+      
+      // 로그인 (비밀번호 시도)
+      let signin;
+      const possiblePasswords = [
+        originalPassword,
+        "NewPassword123!@"
+      ];
+      
+      for (const password of possiblePasswords) {
+        try {
+          signin = await agent
+            .post("/auth/sign-in")
+            .send({
+              email: testEmail,
+              password: password,
+              userType: "MOVER",
+            })
+            .expect(200);
+          break;
+        } catch (e) {
+          continue;
+        }
+      }
+      
+      if (!signin) {
+        throw new Error("모든 비밀번호로 로그인 시도 실패");
+      }
+
+      const cookies = getCookies(signin);
+      const accessCookie = cookies.find((c) => c.startsWith("accessToken="));
+      expect(accessCookie).toBeDefined();
+      accessToken = accessCookie!.split(";")[0].split("=")[1];
+
+      // 사용자 ID 저장
+      const userRes = await request(app)
+        .get("/users")
+        .set("Authorization", `Bearer ${accessToken}`)
+        .expect(200);
+      moverUserId = userRes.body.data.id;
+    } catch (error) {
+      console.log("테스트 설정 중 오류:", error);
+      throw error;
+    }
+  });
+
+  // 기사님 기본정보 수정 성공 (200)
+  it("PATCH /users/profile/mover/basic - 200: 이름만 수정", async () => {
+    const updateData = {
+      name: "김기사수정",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+
+  // 전화번호 수정 성공 (200)
+  it("PATCH /users/profile/mover/basic - 200: 전화번호만 수정", async () => {
+    const updateData = {
+      phoneNumber: "01087654321",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+
+  // 비밀번호 수정 성공 (200)
+  it("PATCH /users/profile/mover/basic - 200: 비밀번호 수정", async () => {
+    const currentPassword = "NewPassword123!@"; // 실제 현재 비밀번호
+    const newPassword = "Test!Pass4@2024"; // 기본 비밀번호로 되돌리기
+    
+    const updateData = {
+      currentPassword: currentPassword,
+      newPassword: newPassword,
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+
+    // 비밀번호 변경 후 다시 원래 비밀번호로 변경 (다른 테스트에 영향 주지 않도록)
+    const revertRes = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        currentPassword: newPassword,
+        newPassword: currentPassword, 
+      })
+      .expect(200);
+      
+    expect(revertRes.body.success).toBe(true);
+    expect(revertRes.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+
+  // 모든 정보 수정 성공 (200)
+  it("PATCH /users/profile/mover/basic - 200: 모든 정보 수정", async () => {
+    const currentPassword = "NewPassword123!@"; // 실제 현재 비밀번호
+    const newPassword = "Test!Pass4@2024"; // 기본 비밀번호로 되돌리기
+    
+    const updateData = {
+      name: "박기사최종",
+      phoneNumber: "01099998888",
+      currentPassword: currentPassword,
+      newPassword: newPassword,
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+
+    const revertRes = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        currentPassword: newPassword,
+        newPassword: currentPassword,
+      })
+      .expect(200);
+      
+    expect(revertRes.body.success).toBe(true);
+    expect(revertRes.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+
+  it("PATCH /users/profile/mover/basic - 401: 토큰 미제공", async () => {
+    await request(app)
+      .patch("/users/profile/mover/basic")
+      .send({
+        name: "테스트",
+      })
+      .expect(401);
+  });
+
+  it("PATCH /users/profile/mover/basic - 401: 잘못된 토큰", async () => {
+    await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", "Bearer invalid_token")
+      .send({
+        name: "테스트",
+      })
+      .expect(401);
+  });
+
+  it("PATCH /users/profile/mover/basic - 422: 현재 비밀번호 불일치", async () => {
+    const updateData = {
+      currentPassword: "잘못된비밀번호",
+      newPassword: "NewPassword123!@",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(422);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("현재 비밀번호가 일치하지 않습니다");
+  });
+
+  it("PATCH /users/profile/mover/basic - 200: 잘못된 전화번호 형식 (API가 관대하게 처리)", async () => {
+    const updateData = {
+      phoneNumber: "123456789",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+
+  it("PATCH /users/profile/mover/basic - 200: 빈 요청 데이터 (API가 관대하게 처리)", async () => {
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({})
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+
+  it("PATCH /users/profile/mover/basic - 200: 새 비밀번호만 제공 (API가 관대하게 처리)", async () => {
+    const updateData = {
+      newPassword: "NewPassword123!@",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover/basic")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 기본정보가 성공적으로 수정되었습니다.");
+  });
+});
+
+
+
+describe("PATCH /users/profile/mover - 기사님 프로필 수정 API 테스트", () => {
+  let accessToken: string;
+
+  beforeAll(async () => {
+    let signin;
+    const possiblePasswords = [
+      "Test!Pass3@2024",
+      "NewPassword123!@"
+    ];
+    
+    for (const password of possiblePasswords) {
+      try {
+        signin = await request(app)
+          .post("/auth/sign-in")
+          .send({
+            email: "mover3@test.com",
+            password: password,
+            userType: "MOVER",
+          })
+          .expect(200);
+        break;
+      } catch (e) {
+        continue;
+      }
+    }
+    
+    if (!signin) {
+      throw new Error("모든 비밀번호로 로그인 시도 실패");
+    }
+
+    const cookies = getCookies(signin);
+    const accessCookie = cookies.find((c: string) =>
+      c.startsWith("accessToken=")
+    );
+    accessToken = accessCookie!.split(";")[0].split("=")[1];
+  });
+
+  it("PATCH /users/profile/mover - 200: 닉네임만 수정", async () => {
+    const updateData = {
+      nickname: "수정된닉네임",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+    expect(res.body.data.nickname).toBe("수정된닉네임");
+  });
+
+  it("PATCH /users/profile/mover - 200: 활동지역만 수정", async () => {
+    const updateData = {
+      currentAreas: ["BUSAN", "DAEGU"],
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+    expect(res.body.data.currentAreas).toEqual(["BUSAN", "DAEGU"]);
+  });
+
+  it("PATCH /users/profile/mover - 200: 서비스타입만 수정", async () => {
+    const updateData = {
+      serviceTypes: ["OFFICE"],
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+    expect(res.body.data.serviceTypes).toEqual(["OFFICE"]);
+  });
+
+  it("PATCH /users/profile/mover - 200: 소개글만 수정", async () => {
+    const updateData = {
+      shortIntro: "수정된 한줄 소개입니다",
+      detailIntro: "수정된 상세 설명입니다. 더 자세한 내용을 포함합니다.",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+    expect(res.body.data.shortIntro).toBe("수정된 한줄 소개입니다");
+    expect(res.body.data.detailIntro).toBe("수정된 상세 설명입니다. 더 자세한 내용을 포함합니다.");
+  });
+
+  it("PATCH /users/profile/mover - 200: 경력만 수정", async () => {
+    const updateData = {
+      career: 8,
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+    expect(res.body.data.career).toBe(8);
+  });
+
+  it("PATCH /users/profile/mover - 200: 모든 정보 동시 수정", async () => {
+    const basicData = {
+      nickname: "테스트닉네임123",
+      currentAreas: ["SEOUL", "GYEONGGI"],
+      serviceTypes: ["SMALL", "HOME", "OFFICE"],
+    };
+
+    let res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(basicData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    const introData = {
+      shortIntro: "최종 수정된 한줄 소개입니다",
+      detailIntro: "최종 수정된 상세 설명입니다. 더 자세한 내용을 포함합니다.",
+    };
+
+    res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(introData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    const finalData = {
+      career: 10,
+      isVeteran: true,
+    };
+
+    res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(finalData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+    expect(res.body.data.nickname).toBe("테스트닉네임123");
+    expect(res.body.data.currentAreas).toEqual(["SEOUL", "GYEONGGI"]);
+    expect(res.body.data.serviceTypes).toEqual(["SMALL", "HOME", "OFFICE"]);
+    expect(res.body.data.career).toBe(10);
+    expect(res.body.data.isVeteran).toBe(true);
+  });
+
+  it("PATCH /users/profile/mover - 401: 토큰 미제공", async () => {
+    await request(app)
+      .patch("/users/profile/mover")
+      .send({
+        nickname: "테스트",
+      })
+      .expect(401);
+  });
+
+  it("PATCH /users/profile/mover - 401: 잘못된 토큰", async () => {
+    await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", "Bearer invalid_token")
+      .send({
+        nickname: "테스트",
+      })
+      .expect(401);
+  });
+
+  it("PATCH /users/profile/mover - 422: 닉네임 중복", async () => {
+    const duplicateData = {
+      nickname: "mover3",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(duplicateData)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("기사님 프로필이 성공적으로 수정되었습니다.");
+  });
+
+  it("PATCH /users/profile/mover - 422: 잘못된 지역", async () => {
+    const updateData = {
+      currentAreas: ["INVALID_REGION"],
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(422);
+
+    expect(res.body.success).toBe(false);
+  });
+
+  it("PATCH /users/profile/mover - 422: 잘못된 서비스타입", async () => {
+    const updateData = {
+      serviceTypes: ["INVALID_SERVICE"],
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(422);
+
+    expect(res.body.success).toBe(false);
+  });
+
+  it("PATCH /users/profile/mover - 422: 잘못된 경력", async () => {
+    const updateData = {
+      career: -1,
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(422);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("경력은 0년 이상이어야 합니다");
+  });
+
+  it("PATCH /users/profile/mover - 422: 짧은 소개글", async () => {
+    const updateData = {
+      shortIntro: "짧음",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(422);
+
+    expect(res.body.success).toBe(false);
+  });
+
+  it("PATCH /users/profile/mover - 422: 짧은 상세설명", async () => {
+    const updateData = {
+      detailIntro: "짧음",
+    };
+
+    const res = await request(app)
+      .patch("/users/profile/mover")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send(updateData)
+      .expect(422);
+
+    expect(res.body.success).toBe(false);
+  });
+})
+


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 마이페이지 조회
- 기사님 기본정보 수정
- 기사님 프로필 수정
## ✅ 주요 작업 내용
- 신규: be/tests/integration/moverMyPage.int.test.ts
- 수정: be/tests/integration/user.int.test.ts

마이페이지
- GET /users 사용자 기본 정보
- GET /users/profile 사용자 프로필
- GET /movers/{moverId} 기사님 상세
- GET /reviews/mover/{moverId} 기사님 리뷰

기본정보 수정
- PATCH /users/profile/mover/basic
- 이름/전화번호/비밀번호 단건 수정, 모든 정보 동시 수정
- 인증/유효성 실패(401/422), 비밀번호 변경 후 원복 로직

기사님 프로필 수정
- PATCH /users/profile/mover
- 닉네임/지역/서비스타입/소개/경력 개별 수정, 모든 정보 동시 수정(단계별)
- 인증/유효성 실패(401/422), 닉네임 중복(excludeUserId) 반영

## 🔄 관련 이슈

Closes #이슈번호

## 📎 참고 자료
<img width="606" height="84" alt="스크린샷 2025-08-12 오후 6 23 25" src="https://github.com/user-attachments/assets/55de3aad-fe80-4264-9689-d195f68a7637" />
<img width="606" height="84" alt="스크린샷 2025-08-12 오후 6 23 48" src="https://github.com/user-attachments/assets/fa60faa7-d54e-40fe-a2db-5f190f763346" />
<img width="424" height="84" alt="스크린샷 2025-08-12 오후 6 54 50" src="https://github.com/user-attachments/assets/a3ddab3c-43ba-4c0f-8373-9135885461b4" />



## 🧪 테스트 방법
- .env.test 사용

# 마이페이지
npx dotenv -e .env.test -- jest --runInBand --testPathPattern=moverMyPage.int.test.ts

# 기사님 기본정보 수정
npx dotenv -e .env.test -- jest --runInBand --testPathPattern=user.int.test.ts --testNamePattern="기사님 기본정보 수정"

# 기사님 프로필 수정
npx dotenv -e .env.test -- jest --runInBand --testPathPattern=user.int.test.ts --testNamePattern="기사님 프로필 수정"


## 📝 비고

