### PR TITLE
[#337] bug: 기사님 찾기 null값 0으로 처리

### DIFF
--- a/src/repositories/mover.repository.test.ts
+++ b/src/repositories/mover.repository.test.ts
@@ -88,7 +88,10 @@ describe("MoverRepository - 유닛 테스트", () => {
           currentAreas: { has: "서울" },
           serviceTypes: { has: "SMALL" },
         },
-        orderBy: [{ totalReviewCount: "desc" }, { id: "asc" }],
+        orderBy: [
+          { totalReviewCount: { sort: "desc", nulls: "last" } },
+          { id: "asc" },
+        ],
         skip: 0,
         take: 11,
         include: {
@@ -143,7 +146,10 @@ describe("MoverRepository - 유닛 테스트", () => {
           deletedAt: null,
           userType: { has: "MOVER" },
         },
-        orderBy: [{ totalReviewCount: "desc" }, { id: "asc" }],
+        orderBy: [
+          { totalReviewCount: { sort: "desc", nulls: "last" } },
+          { id: "asc" },
+        ],
         skip: 0,
         take: 11,
         include: {
@@ -174,7 +180,7 @@ describe("MoverRepository - 유닛 테스트", () => {
           deletedAt: null,
           userType: { has: "MOVER" },
         },
-        orderBy: [{ career: "desc" }, { id: "asc" }],
+        orderBy: [{ career: { sort: "desc", nulls: "last" } }, { id: "asc" }],
         skip: 0,
         take: 11,
         include: {
@@ -224,7 +230,10 @@ describe("MoverRepository - 유닛 테스트", () => {
           deletedAt: null,
           userType: { has: "MOVER" },
         },
-        orderBy: [{ workedCount: "desc" }, { id: "asc" }],
+        orderBy: [
+          { workedCount: { sort: "desc", nulls: "last" } },
+          { id: "asc" },
+        ],
         skip: 0,
         take: 11,
         include: {
@@ -254,7 +263,10 @@ describe("MoverRepository - 유닛 테스트", () => {
             { name: { contains: "이사" } },
           ],
         },
-        orderBy: [{ totalReviewCount: "desc" }, { id: "asc" }],
+        orderBy: [
+          { totalReviewCount: { sort: "desc", nulls: "last" } },
+          { id: "asc" },
+        ],
         skip: 0,
         take: 11,
         include: {

--- a/src/repositories/mover.repository.ts
+++ b/src/repositories/mover.repository.ts
@@ -57,10 +57,16 @@ export const getMoverList = async (filter: MoverListFilter) => {
   };
   const orderByField = SORT_MAP[sort] || "totalReviewCount";
 
+  // NULL 값을 0으로 처리하여 정렬
   const movers = await prisma.user.findMany({
     where,
     orderBy: [
-      { [orderByField]: "desc" },
+      {
+        [orderByField]: {
+          sort: "desc",
+          nulls: "last",
+        },
+      },
       { id: "asc" }, // 동일한 값일 때 ID로 정렬하여 일관성 보장
     ],
     skip: cursor ? 1 : 0,
@@ -71,13 +77,13 @@ export const getMoverList = async (filter: MoverListFilter) => {
     },
   });
 
-  // NULL 값 처리만 하고 정렬은 Prisma에서 처리된 결과 사용
+  // NULL 값을 0으로 변환하여 프론트엔드에서 일관된 데이터 제공
   const processedMovers = movers.map((mover) => ({
     ...mover,
-    career: mover.career || 0,
-    workedCount: mover.workedCount || 0,
-    averageRating: mover.averageRating || 0,
-    totalReviewCount: mover.totalReviewCount || 0,
+    career: mover.career ?? 0,
+    workedCount: mover.workedCount ?? 0,
+    averageRating: mover.averageRating ?? 0,
+    totalReviewCount: mover.totalReviewCount ?? 0,
   }));
 
   const hasNext = processedMovers.length > take;


### PR DESCRIPTION
## ✨ 작업 개요
- 기사님 찾기 확정 많은 순일때  null 값이 0으로 나오면서 맨 위로 정렬되는 문제

## ✅ 주요 작업 내용
- 기사님 찾기 null값 0으로 처리

## 🔄 관련 이슈
Closes #337

## 📝 비고

- (추가 예정 기능, 보완 필요 등)
