### PR TITLE
feat: API 캐싱 적용

### DIFF
--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -9,6 +9,7 @@ import {
 } from "../controllers/user.controller";
 import { verifyAccessToken } from "../middlewares/verifyToken";
 import generatePresignedUrls from "../middlewares/presignedUrl";
+import { cache, invalidateCacheByPattern } from "../middlewares/cacheMiddleware";
 
 const userRouter = Router();
 
@@ -272,7 +273,7 @@ userRouter.get("/", verifyAccessToken, getUser);
  *               status: 500
  *               message: "서버 내부 오류가 발생했습니다"
  */
-userRouter.get("/profile", verifyAccessToken, getProfile);
+userRouter.get("/profile", verifyAccessToken, cache({ ttlSeconds: 15, varyByAuth: true }), getProfile);
 
 /**
  * @swagger
@@ -581,7 +582,23 @@ userRouter.patch("/profile/customer", verifyAccessToken, patchCustomerProfile);
  *               status: 500
  *               message: "서버 내부 오류가 발생했습니다"
  */
-userRouter.patch("/profile/mover", verifyAccessToken, patchMoverProfile);
+userRouter.patch(
+  "/profile/mover", 
+  verifyAccessToken, 
+  async (req, res, next) => {
+    try {
+      const userId = (req as any).user?.userId;
+      if (userId) {
+        await invalidateCacheByPattern(`cache:GET:/users:*:u:${userId}:*`);
+        await invalidateCacheByPattern(`cache:GET:/movers:/${userId}:*`);
+      }
+    } catch (error) {
+      console.error("Cache invalidation error:", error);
+    }
+    next();
+  },
+  patchMoverProfile
+);
 
 /**
  * @swagger
@@ -658,7 +675,23 @@ userRouter.patch("/profile/mover", verifyAccessToken, patchMoverProfile);
  *               status: 500
  *               message: "서버 내부 오류가 발생했습니다"
  */
-userRouter.patch("/profile/mover/basic", verifyAccessToken, patchMoverBasicInfo);
+userRouter.patch(
+  "/profile/mover/basic", 
+  verifyAccessToken, 
+  async (req, res, next) => {
+    try {
+      const userId = (req as any).user?.userId;
+      if (userId) {
+        await invalidateCacheByPattern(`cache:GET:/users:*:u:${userId}:*`);
+        await invalidateCacheByPattern(`cache:GET:/movers:/${userId}:*`);
+      }
+    } catch (error) {
+      console.error("Cache invalidation error:", error);
+    }
+    next();
+  },
+  patchMoverBasicInfo
+);
 
 /**
  * @swagger


### PR DESCRIPTION
## ✨ 작업 개요

- 기사님 관련 페이지들의 성능 향상을 위해 API 캐싱을 적용했습니다
- Redis를 활용한 캐싱 시스템으로 응답 속도를 개선하고, 캐시 무효화로 데이터 일관성을 보장했습니다

## ✅ 주요 작업 내용

캐싱 적용 API
- GET /users/profile API에 캐싱 적용 (TTL 15초, 사용자별 캐시 분리)
- GET /movers/:moverId API에 캐싱 적용 (TTL 60초, 사용자별 캐시 분리)

캐시 무효화 적용 API
- PATCH /users/profile/mover API에 캐시 무효화 적용
- PATCH /users/profile/mover/basic API에 캐시 무효화 적용

## 🔄 관련 이슈

Closes #이슈번호

## 📎 참고 자료 (선택)

- 캐싱 가이드: 팀원이 제공한 Redis API 캐싱 가이드
- 캐싱 미들웨어: src/middlewares/cacheMiddleware.ts


## 🧪 테스트 방법 (선택)


## 📝 비고

- (추가 예정 기능, 보완 필요 등)
