### PR TITLE
fix:견적요청 내 견적 관리에서 일치된 응답으로 보내도록 수정

### DIFF
--- a/src/repositories/customerEstimateRequest.repository.ts
+++ b/src/repositories/customerEstimateRequest.repository.ts
@@ -1,14 +1,6 @@
-import {
-  EstimateRequest,
-  Estimate,
-  User,
-  EstimateStatus,
-} from "@prisma/client";
+import { EstimateRequest, Estimate, User, EstimateStatus } from "@prisma/client";
 import prisma from "../db/prisma/prisma";
-import {
-  SingleEstimateRequestWithRelations,
-  MultipleEstimateRequestWithRelations,
-} from "../types/repository.types";
+import { SingleEstimateRequestWithRelations, MultipleEstimateRequestWithRelations } from "../types/repository.types";
 import { RepositoryQueryError } from "../types/errors.types";
 
 const customerEstimateRequestRepository = {
@@ -22,6 +14,7 @@ const customerEstimateRequestRepository = {
           moveDate: {
             gte: new Date(), // 오늘 날짜 이후인 것만 조회 (미래 이사일)
           },
+          deletedAt: null,
         },
         select: {
           id: true,
@@ -31,10 +24,7 @@ const customerEstimateRequestRepository = {
       if (!EstimateRequest) return null;
       return EstimateRequest.id;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `사용자 ${userId}의 활성 견적요청 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`사용자 ${userId}의 활성 견적요청 조회 실패`, error);
     }
   },
 
@@ -57,7 +47,7 @@ const customerEstimateRequestRepository = {
   // 진행중인 이사 견적들 조회
   getPendingEstimateRequest: async (
     activeEstimateRequestId: string,
-    userId: string
+    userId: string,
   ): Promise<SingleEstimateRequestWithRelations> => {
     try {
       const pendingEstimateRequest = await prisma.estimateRequest.findFirst({
@@ -157,15 +147,13 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `진행중인 견적요청 조회 실패 - 활성ID: ${activeEstimateRequestId}, 사용자ID: ${userId}`,
-        error
+        error,
       );
     }
   },
 
   // 완료된 견적요청 목록 조회
-  getReceivedEstimateRequests: async (
-    userId: string
-  ): Promise<MultipleEstimateRequestWithRelations> => {
+  getReceivedEstimateRequests: async (userId: string): Promise<MultipleEstimateRequestWithRelations> => {
     try {
       const receivedEstimateRequests = await prisma.estimateRequest.findMany({
         where: {
@@ -263,27 +251,19 @@ const customerEstimateRequestRepository = {
       // Repository는 순수 데이터만 반환
       return receivedEstimateRequests;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `사용자 ${userId}의 완료된 견적요청 목록 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`사용자 ${userId}의 완료된 견적요청 목록 조회 실패`, error);
     }
   },
 
   // 견적요청 ID로 견적요청 조회
-  getEstimateRequestById: async (
-    estimateRequestId: string
-  ): Promise<EstimateRequest | null> => {
+  getEstimateRequestById: async (estimateRequestId: string): Promise<EstimateRequest | null> => {
     try {
       const estimateRequest = await prisma.estimateRequest.findUnique({
         where: { id: estimateRequestId },
       });
       return estimateRequest;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적요청 ID ${estimateRequestId} 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`견적요청 ID ${estimateRequestId} 조회 실패`, error);
     }
   },
 
@@ -300,10 +280,7 @@ const customerEstimateRequestRepository = {
   },
 
   // 견적 ID와 견적요청 ID로 견적 조회
-  getEstimateByIdAndRequestId: async (
-    estimateId: string,
-    estimateRequestId: string
-  ): Promise<Estimate | null> => {
+  getEstimateByIdAndRequestId: async (estimateId: string, estimateRequestId: string): Promise<Estimate | null> => {
     try {
       const estimate = await prisma.estimate.findUnique({
         where: {
@@ -320,7 +297,7 @@ const customerEstimateRequestRepository = {
   // 견적요청 상태 업데이트
   updateEstimateRequestStatus: async (
     estimateRequestId: string,
-    status: "PENDING" | "APPROVED" | "COMPLETED" | "EXPIRED"
+    status: "PENDING" | "APPROVED" | "COMPLETED" | "EXPIRED",
   ): Promise<EstimateRequest> => {
     try {
       const updatedEstimateRequest = await prisma.estimateRequest.update({
@@ -331,16 +308,13 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `견적요청 상태 업데이트 실패 - 견적요청ID: ${estimateRequestId}, 상태: ${status}`,
-        error
+        error,
       );
     }
   },
 
   // 견적 상태 업데이트
-  updateEstimateStatus: async (
-    estimateId: string,
-    status: EstimateStatus
-  ): Promise<Estimate> => {
+  updateEstimateStatus: async (estimateId: string, status: EstimateStatus): Promise<Estimate> => {
     try {
       const updatedEstimate = await prisma.estimate.update({
         where: { id: estimateId },
@@ -348,10 +322,7 @@ const customerEstimateRequestRepository = {
       });
       return updatedEstimate;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적 상태 업데이트 실패 - 견적ID: ${estimateId}, 상태: ${status}`,
-        error
-      );
+      throw new RepositoryQueryError(`견적 상태 업데이트 실패 - 견적ID: ${estimateId}, 상태: ${status}`, error);
     }
   },
 
@@ -359,7 +330,7 @@ const customerEstimateRequestRepository = {
   updateAllEstimatesStatus: async (
     estimateRequestId: string,
     status: EstimateStatus,
-    excludeEstimateId?: string
+    excludeEstimateId?: string,
   ): Promise<void> => {
     try {
       await prisma.estimate.updateMany({
@@ -372,7 +343,7 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `견적 일괄 상태 업데이트 실패 - 견적요청ID: ${estimateRequestId}, 상태: ${status}`,
-        error
+        error,
       );
     }
   },
@@ -413,18 +384,12 @@ const customerEstimateRequestRepository = {
       });
       return estimate;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적 상세 정보 조회 실패 - 견적ID: ${estimateId}`,
-        error
-      );
+      throw new RepositoryQueryError(`견적 상세 정보 조회 실패 - 견적ID: ${estimateId}`, error);
     }
   },
 
   // 다른 견적들 조회 (확정 시 반려용)
-  getOtherEstimates: async (
-    estimateRequestId: string,
-    excludeEstimateId: string
-  ) => {
+  getOtherEstimates: async (estimateRequestId: string, excludeEstimateId: string) => {
     try {
       const otherEstimates = await prisma.estimate.findMany({
         where: {
@@ -443,16 +408,13 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `다른 견적들 조회 실패 - 견적요청ID: ${estimateRequestId}, 제외견적ID: ${excludeEstimateId}`,
-        error
+        error,
       );
     }
   },
 
   // AUTO_REJECTED된 견적들 조회 (액션 생성용)
-  getAutoRejectedEstimates: async (
-    estimateRequestId: string,
-    excludeEstimateId: string
-  ) => {
+  getAutoRejectedEstimates: async (estimateRequestId: string, excludeEstimateId: string) => {
     try {
       const autoRejectedEstimates = await prisma.estimate.findMany({
         where: {
@@ -471,7 +433,7 @@ const customerEstimateRequestRepository = {
     } catch (error) {
       throw new RepositoryQueryError(
         `AUTO_REJECTED 견적들 조회 실패 - 견적요청ID: ${estimateRequestId}, 제외견적ID: ${excludeEstimateId}`,
-        error
+        error,
       );
     }
   },
@@ -487,17 +449,12 @@ const customerEstimateRequestRepository = {
       });
       return favoriteCount;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `기사님 ${moverId}의 찜 개수 조회 실패`,
-        error
-      );
+      throw new RepositoryQueryError(`기사님 ${moverId}의 찜 개수 조회 실패`, error);
     }
   },
 
   // 여러 기사님의 찜 개수 일괄 조회
-  getMoversFavoriteCounts: async (
-    moverIds: string[]
-  ): Promise<Record<string, number>> => {
+  getMoversFavoriteCounts: async (moverIds: string[]): Promise<Record<string, number>> => {
     try {
       if (moverIds.length === 0) return {};
 
@@ -541,10 +498,7 @@ const customerEstimateRequestRepository = {
       });
       return mover;
     } catch (error) {
-      throw new RepositoryQueryError(
-        `견적으로 기사 조회 실패 - 견적ID: ${estimateId}`,
-        error
-      );
+      throw new RepositoryQueryError(`견적으로 기사 조회 실패 - 견적ID: ${estimateId}`, error);
     }
   },
 };

--- a/src/repositories/estimateRequest.repository.ts
+++ b/src/repositories/estimateRequest.repository.ts
@@ -1,10 +1,4 @@
-import {
-  RequestStatus,
-  EstimateRequest,
-  UserType,
-  MoveType,
-  RegionType,
-} from "@prisma/client";
+import { RequestStatus, EstimateRequest, UserType, MoveType, RegionType } from "@prisma/client";
 import prisma from "../db/prisma/prisma";
 import { getCurrentDateString } from "../utils/dateUtils";
 import {
@@ -15,10 +9,7 @@ import {
   IUserTypeResult,
 } from "../types/estimateRequest.types";
 
-const createEstimateRequest = async (
-  data: TCreateEstimateRequestData,
-  userId: string
-): Promise<EstimateRequest> => {
+const createEstimateRequest = async (data: TCreateEstimateRequestData, userId: string): Promise<EstimateRequest> => {
   return await prisma.estimateRequest.create({
     data: {
       customerId: userId,
@@ -32,13 +23,13 @@ const createEstimateRequest = async (
   });
 };
 
-const getActiveEstimateRequestByUserId = async (
-  userId: string
-): Promise<IDatabaseEstimateRequest | null> => {
+const getActiveEstimateRequestByUserId = async (userId: string): Promise<IDatabaseEstimateRequest | null> => {
   const request = await prisma.estimateRequest.findFirst({
     where: {
       customerId: userId,
-      status: RequestStatus.PENDING,
+      // 활성 견적요청 정의 통일: 미래 이사일 + PENDING/APPROVED + 삭제 안됨
+      status: { in: [RequestStatus.PENDING, RequestStatus.APPROVED] },
+      moveDate: { gte: new Date() },
       deletedAt: null,
     },
     orderBy: { createdAt: "desc" },
@@ -89,9 +80,7 @@ const getActiveEstimateRequestByUserId = async (
   return request;
 };
 
-const getEstimateRequestById = async (
-  id: string
-): Promise<IDatabaseEstimateRequest | null> => {
+const getEstimateRequestById = async (id: string): Promise<IDatabaseEstimateRequest | null> => {
   return await prisma.estimateRequest.findUnique({
     where: {
       id,
@@ -133,10 +122,7 @@ const getEstimateRequestById = async (
   });
 };
 
-const updateEstimateRequest = async (
-  id: string,
-  updateData: TUpdateEstimateRequestData
-): Promise<EstimateRequest> => {
+const updateEstimateRequest = async (id: string, updateData: TUpdateEstimateRequestData): Promise<EstimateRequest> => {
   const prismaUpdateData: {
     moveType?: MoveType;
     moveDate?: Date;
@@ -218,7 +204,9 @@ const hasEstimateFromMover = async (userId: string): Promise<boolean> => {
   const request = await prisma.estimateRequest.findFirst({
     where: {
       customerId: userId,
-      status: RequestStatus.PENDING,
+      // 활성 견적요청 기준과 동일하게 조회
+      status: { in: [RequestStatus.PENDING, RequestStatus.APPROVED] },
+      moveDate: { gte: new Date() },
       deletedAt: null,
     },
     select: { id: true },
@@ -229,16 +217,16 @@ const hasEstimateFromMover = async (userId: string): Promise<boolean> => {
   const estimate = await prisma.estimate.findFirst({
     where: {
       estimateRequestId: request.id,
-      status: "PROPOSED", // PROPOSED 상태의 견적만 유효한 견적으로 인식
+      // 진행중 리스트와 동일 기준: 가격이 있는 제안(제안/수락/자동반려)
+      status: { in: ["PROPOSED", "ACCEPTED", "AUTO_REJECTED"] },
       deletedAt: null,
+      price: { not: null },
     },
   });
   return !!estimate;
 };
 
-const hasActiveRequestBeforeMoveDate = async (
-  userId: string
-): Promise<boolean> => {
+const hasActiveRequestBeforeMoveDate = async (userId: string): Promise<boolean> => {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -270,18 +258,14 @@ const checkCustomerProfile = async (userId: string): Promise<boolean> => {
   return user.isCustomer === true;
 };
 
-const findOrCreateAddress = async (
-  addressData: IParsedAddressData
-): Promise<{ id: string }> => {
+const findOrCreateAddress = async (addressData: IParsedAddressData): Promise<{ id: string }> => {
   const createData = {
     zoneCode: addressData.zoneCode,
     city: addressData.city,
     district: addressData.district,
     region: addressData.region as RegionType,
     detail:
-      addressData.detail === null ||
-      addressData.detail === undefined ||
-      addressData.detail === ""
+      addressData.detail === null || addressData.detail === undefined || addressData.detail === ""
         ? null
         : addressData.detail,
   };
@@ -312,10 +296,8 @@ const checkUserType = async (userId: string): Promise<IUserTypeResult> => {
     throw new Error("사용자를 찾을 수 없습니다.");
   }
 
-  const isCustomer =
-    user.userType.includes(UserType.CUSTOMER) || user.isCustomer === true;
-  const isMover =
-    user.userType.includes(UserType.MOVER) || user.isMover === true;
+  const isCustomer = user.userType.includes(UserType.CUSTOMER) || user.isCustomer === true;
+  const isMover = user.userType.includes(UserType.MOVER) || user.isMover === true;
 
   return { isCustomer, isMover };
 };
@@ -341,9 +323,7 @@ const getEstimateRequestDetailForAction = async (estimateRequestId: string) => {
 };
 
 // 이사 완료 처리를 위한 견적 요청 상세 조회
-const getEstimateRequestDetailForCompletion = async (
-  estimateRequestId: string
-) => {
+const getEstimateRequestDetailForCompletion = async (estimateRequestId: string) => {
   const estimateRequest = await prisma.estimateRequest.findUnique({
     where: { id: estimateRequestId },
     select: {
@@ -482,9 +462,7 @@ const getEstimateRequestsForReviewRequests = async () => {
 };
 
 // 이사 완료 처리 함수
-const completeEstimateRequest = async (
-  id: string
-): Promise<EstimateRequest> => {
+const completeEstimateRequest = async (id: string): Promise<EstimateRequest> => {
   return await prisma.estimateRequest.update({
     where: { id },
     data: {


### PR DESCRIPTION
## ✨ 작업 개요

- 견적요청 내 견적 관리에서 일치된 응답으로 보내도록 수정

## ✅ 주요 작업 내용

-조회 조건이 달라서 서로 다른 답변이 오는 문제 수정
`src/repositories/estimateRequest.repository.ts`
`getActiveEstimateRequestByUserId`: 활성 정의를 미래 이사일 + 상태 in `[PENDING, APPROVED] + deletedAt: null`로 통일하고 반영.
`hasEstimateFromMover`: 동일한 활성 기준 적용. 견적 존재 판정 시 상태 in ["PROPOSED","ACCEPTED","AUTO_REJECTED"]이며 price != null 조건 추가.
`src/repositories/customerEstimateRequest.repository.ts`
getActiveEstimateRequest: deletedAt: null 조건 추가.

## 🔄 관련 이슈


## 📎 참고 자료 (선택)


## 🧪 테스트 방법 (선택)

- [ ] 쿼리 파라미터 전달 시 필터링 정상 작동

## 📝 비고

- (추가 예정 기능, 보완 필요 등)
